### PR TITLE
Add Synthetic Search provider (raw-search tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ librarium status --wait
 
 ## Providers
 
-Librarium ships with 10 provider adapters organized into three tiers:
+Librarium ships with 11 provider adapters organized into three tiers:
 
 | Provider | ID | Tier | API Key Env Var |
 |---|---|---|---|
@@ -85,6 +85,7 @@ Librarium ships with 10 provider adapters organized into three tiers:
 | Brave Web Search | `brave-search` | raw-search | `BRAVE_API_KEY` |
 | SearchAPI | `searchapi` | raw-search | `SEARCHAPI_API_KEY` |
 | SerpAPI | `serpapi` | raw-search | `SERPAPI_API_KEY` |
+| Synthetic Search | `synthetic` | raw-search | `SYNTHETIC_API_KEY` |
 | Tavily Search | `tavily` | raw-search | `TAVILY_API_KEY` |
 
 ## Provider Tiers
@@ -236,10 +237,10 @@ Groups are named collections of provider IDs. Librarium ships with six default g
 |---|---|---|
 | `deep` | perplexity-deep, openai-deep, gemini-deep | Thorough async research |
 | `quick` | perplexity-sonar, brave-answers, exa | Fast AI-grounded answers |
-| `raw` | brave-search, searchapi, serpapi, tavily | Traditional search results |
+| `raw` | brave-search, searchapi, serpapi, synthetic, tavily | Traditional search results |
 | `fast` | perplexity-sonar, brave-answers, exa, brave-search, tavily | Quick results from multiple tiers |
 | `comprehensive` | All deep-research + all ai-grounded | Deep + AI-grounded combined |
-| `all` | All 10 providers | Maximum coverage |
+| `all` | All 11 providers | Maximum coverage |
 
 ### Custom Groups
 
@@ -418,7 +419,7 @@ Groups:
   deep           — Thorough async research (minutes)
   fast           — Quick results from multiple tiers
   comprehensive  — Deep + AI-grounded combined
-  all            — All 10 providers
+  all            — All 11 providers
 
 Output lands in ./agents/librarium/<timestamp>-<slug>/:
   summary.md     — Synthesized overview with stats

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,6 +10,7 @@ import { PerplexityDeepProvider } from './perplexity-deep.js';
 import { PerplexitySonarProvider } from './perplexity-sonar.js';
 import { SearchApiProvider } from './searchapi.js';
 import { SerpApiProvider } from './serpapi.js';
+import { SyntheticProvider } from './synthetic.js';
 import { TavilyProvider } from './tavily.js';
 
 const providers = new Map<string, Provider>();
@@ -82,5 +83,6 @@ export async function initializeProviders(): Promise<void> {
   registerProvider(new BraveSearchProvider());
   registerProvider(new SearchApiProvider());
   registerProvider(new SerpApiProvider());
+  registerProvider(new SyntheticProvider());
   registerProvider(new TavilyProvider());
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -66,7 +66,7 @@ export function getProviderMeta(
 
 /**
  * Initialize all providers — called at startup.
- * Instantiates and registers all 10 provider adapters.
+ * Instantiates and registers all 11 provider adapters.
  */
 export async function initializeProviders(): Promise<void> {
   // Deep Research (async capable)

--- a/src/adapters/synthetic.ts
+++ b/src/adapters/synthetic.ts
@@ -1,0 +1,152 @@
+import type {
+  Citation,
+  ProviderOptions,
+  ProviderResult,
+  ProviderTier,
+} from '../types.js';
+import { BaseProvider } from './base.js';
+
+interface SyntheticResult {
+  url: string;
+  title?: string;
+  text?: string;
+  published?: string;
+}
+
+interface SyntheticResponse {
+  results?: SyntheticResult[];
+  error?: string;
+}
+
+/**
+ * Synthetic Search provider.
+ * Zero-data-retention web search API from synthetic.new.
+ * Tier: raw-search (sync)
+ */
+export class SyntheticProvider extends BaseProvider {
+  readonly id = 'synthetic';
+  readonly tier: ProviderTier = 'raw-search';
+
+  async execute(
+    query: string,
+    options: ProviderOptions,
+  ): Promise<ProviderResult> {
+    const start = performance.now();
+    const apiKey = this.getApiKey();
+
+    try {
+      const response = await this.request<SyntheticResponse>(
+        'https://api.synthetic.new/v2/search',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: { query },
+          timeout: options.timeout * 1000,
+          signal: options.signal,
+        },
+      );
+
+      const durationMs = Math.round(performance.now() - start);
+
+      if (response.status !== 200) {
+        return {
+          provider: this.id,
+          tier: this.tier,
+          content: '',
+          citations: [],
+          durationMs,
+          error: this.formatError(response.status, response.data),
+        };
+      }
+
+      const data = response.data;
+
+      if (data.error) {
+        return {
+          provider: this.id,
+          tier: this.tier,
+          content: '',
+          citations: [],
+          durationMs,
+          error: `Synthetic error: ${data.error}`,
+        };
+      }
+
+      const results = data.results ?? [];
+      const citations = this.extractCitations(results);
+      const content = this.buildContent(results);
+
+      return {
+        provider: this.id,
+        tier: this.tier,
+        content,
+        citations,
+        durationMs,
+      };
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start);
+      return {
+        provider: this.id,
+        tier: this.tier,
+        content: '',
+        citations: [],
+        durationMs,
+        error: this.formatCatchError(err),
+      };
+    }
+  }
+
+  async test(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const apiKey = this.getApiKey();
+      const response = await this.request<SyntheticResponse>(
+        'https://api.synthetic.new/v2/search',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: { query: 'test' },
+          timeout: 10000,
+        },
+      );
+
+      if (response.status === 200) return { ok: true };
+      return { ok: false, error: `HTTP ${response.status}` };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private buildContent(results: SyntheticResult[]): string {
+    if (results.length === 0) return 'No results found.';
+
+    const parts: string[] = [];
+    parts.push('## Search Results\n');
+
+    for (const result of results) {
+      const title = result.title ?? 'Untitled';
+      parts.push(`### [${title}](${result.url})`);
+      if (result.text) {
+        parts.push(result.text);
+      }
+      parts.push('');
+    }
+
+    return parts.join('\n');
+  }
+
+  private extractCitations(results: SyntheticResult[]): Citation[] {
+    return results.map((result) => ({
+      url: result.url,
+      title: result.title,
+      snippet: result.text?.slice(0, 200),
+      provider: this.id,
+    }));
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,7 @@ export const PROVIDER_ENV_VARS: Record<string, string> = {
   exa: 'EXA_API_KEY',
   searchapi: 'SEARCHAPI_API_KEY',
   serpapi: 'SERPAPI_API_KEY',
+  synthetic: 'SYNTHETIC_API_KEY',
   tavily: 'TAVILY_API_KEY',
 };
 
@@ -54,6 +55,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   exa: 'Exa Search',
   searchapi: 'SearchAPI',
   serpapi: 'SerpAPI',
+  synthetic: 'Synthetic Search',
   tavily: 'Tavily Search',
 };
 
@@ -61,8 +63,15 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 export const DEFAULT_GROUPS: Record<string, string[]> = {
   deep: ['perplexity-deep', 'openai-deep', 'gemini-deep'],
   quick: ['perplexity-sonar', 'brave-answers', 'exa'],
-  raw: ['brave-search', 'searchapi', 'serpapi', 'tavily'],
-  fast: ['perplexity-sonar', 'brave-answers', 'exa', 'brave-search', 'tavily'],
+  raw: ['brave-search', 'searchapi', 'serpapi', 'synthetic', 'tavily'],
+  fast: [
+    'perplexity-sonar',
+    'brave-answers',
+    'exa',
+    'brave-search',
+    'synthetic',
+    'tavily',
+  ],
   comprehensive: [
     'perplexity-deep',
     'openai-deep',
@@ -81,6 +90,7 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'brave-search',
     'searchapi',
     'serpapi',
+    'synthetic',
     'tavily',
   ],
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,7 +69,6 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'brave-answers',
     'exa',
     'brave-search',
-    'synthetic',
     'tavily',
   ],
   comprehensive: [

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -119,10 +119,10 @@ describe('registry', () => {
     expect(meta[0].hasApiKey).toBe(true);
   });
 
-  it('initializeProviders registers all 10 providers', async () => {
+  it('initializeProviders registers all 11 providers', async () => {
     await initializeProviders();
     const all = getAllProviders();
-    expect(all).toHaveLength(10);
+    expect(all).toHaveLength(11);
 
     const ids = all.map((p) => p.id);
     expect(ids).toContain('perplexity-deep');
@@ -134,6 +134,7 @@ describe('registry', () => {
     expect(ids).toContain('brave-search');
     expect(ids).toContain('searchapi');
     expect(ids).toContain('serpapi');
+    expect(ids).toContain('synthetic');
     expect(ids).toContain('tavily');
   });
 });


### PR DESCRIPTION
## Summary

Adds [Synthetic](https://synthetic.new) as the 11th search provider (`raw-search` tier).

Synthetic is a **zero-data-retention** web search API designed for coding agents. It complements existing raw-search providers (Brave, Tavily, SearchAPI, SerpAPI) with a privacy-first approach — no query data is stored.

## Changes

- `src/adapters/synthetic.ts` — New provider implementation (modeled on Tavily)
- `src/adapters/index.ts` — Register provider
- `src/constants.ts` — Env var (`SYNTHETIC_API_KEY`), display name, added to `raw`, `fast`, and `all` groups
- `tests/registry.test.ts` — Updated provider count from 10 → 11

## API Details

- **Endpoint:** `POST https://api.synthetic.new/v2/search`
- **Auth:** Bearer token in header
- **Request:** `{ "query": "..." }`
- **Response:** `{ "results": [{ "url", "title", "text", "published?" }] }`
- **Docs:** https://dev.synthetic.new/docs/synthetic/search

## Notes

- The Synthetic API is marked as "still under development" per their docs, but the search endpoint works reliably in testing
- No `max_results` parameter available — returns a variable number of results (typically 5)
- Returns full page text (not snippets), so results tend to be larger than other raw-search providers

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — 79/79 pass
- `npm run build` — success
- Integration tested with live API key: `librarium doctor` passes, `librarium run` returns results with citations

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Synthetic Search as the 11th provider in the `raw-search` tier. The implementation closely follows the established pattern from Tavily, with proper error handling, HTTP authentication via Bearer token, and citation extraction. The new provider is integrated into the `raw` and `all` groups but intentionally excluded from `fast` due to current API access limitations (subscription waitlisted per commit 55b5923).

**Key changes:**
- New `SyntheticProvider` class in `src/adapters/synthetic.ts` with POST-based search API
- Registration in provider index and constants with `SYNTHETIC_API_KEY` env var
- Documentation and test updates reflecting 10→11 provider count
- All existing tests pass, type checks clean

The implementation is clean, consistent with existing patterns, and well-tested.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns exactly, all tests pass, type checks are clean, and the code has been integration tested with a live API key. The new provider is properly isolated and won't affect existing functionality.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/adapters/synthetic.ts | New provider adapter following established patterns from Tavily, includes proper error handling, HTTP client usage, and citation extraction |
| src/adapters/index.ts | Adds Synthetic provider import and registration, updates comment from 10 to 11 providers |
| src/constants.ts | Adds Synthetic configuration: env var, display name, and inclusion in `raw` and `all` groups (intentionally excluded from `fast` due to API access limitations) |
| tests/registry.test.ts | Updates test expectations from 10 to 11 providers, adds Synthetic to provider ID checks |
| README.md | Documentation updates: provider count 10→11, adds Synthetic to provider table, updates group definitions |

</details>


</details>


<sub>Last reviewed commit: 55b5923</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->