### PR TITLE
docs: add GitHub Sponsors link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Fan out research queries to multiple search and deep-research APIs in parallel.
 
+<p align="center">
+  <a href="https://github.com/sponsors/jkudish">
+    <img src="https://img.shields.io/badge/Sponsor-❤-ea4aaa?style=flat-square&logo=github-sponsors" alt="Sponsor librarium" />
+  </a>
+</p>
+
 Inspired by Aaron Francis' [counselors](https://github.com/aarondfrancis/counselors), librarium applies the same fan-out pattern to search APIs. Where counselors fans out prompts to multiple LLM CLIs, librarium fans out research queries to search engines, AI-grounded search, and deep-research APIs -- collecting, normalizing, and deduplicating results into structured output.
 
 ## Installation


### PR DESCRIPTION
Adds a sponsor badge/link below the intro line in the README, pointing to https://github.com/sponsors/jkudish.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub Sponsors badge to the README, positioned between the intro and main description.

- Badge links to https://github.com/sponsors/jkudish
- Uses shields.io format with appropriate styling
- Centered alignment matches existing README structure
- No issues found
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk
- Documentation-only change adding a sponsor badge with correct URL, proper formatting, and appropriate placement
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Added GitHub Sponsors badge with proper formatting and placement |

</details>


</details>


<sub>Last reviewed commit: ce097b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->