### PR TITLE
docs: move sponsor link to bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 
 Fan out research queries to multiple search and deep-research APIs in parallel.
 
-<p align="center">
-  <a href="https://github.com/sponsors/jkudish">
-    <img src="https://img.shields.io/badge/Sponsor-❤-ea4aaa?style=flat-square&logo=github-sponsors" alt="Sponsor librarium" />
-  </a>
-</p>
-
 Inspired by Aaron Francis' [counselors](https://github.com/aarondfrancis/counselors), librarium applies the same fan-out pattern to search APIs. Where counselors fans out prompts to multiple LLM CLIs, librarium fans out research queries to search engines, AI-grounded search, and deep-research APIs -- collecting, normalizing, and deduplicating results into structured output.
 
 ## Installation
@@ -505,6 +499,10 @@ The skill guides agents through:
 ## Publishing
 
 The release workflow at `.github/workflows/release.yml` handles npm publishing. It requires a `NPM_TOKEN` repository secret configured in GitHub Settings > Secrets.
+
+## Sponsoring
+
+If librarium saves you time, consider [sponsoring development](https://github.com/sponsors/jkudish). ❤️
 
 ## License
 


### PR DESCRIPTION
Removes the awkward centered badge from the top and adds a clean '## Sponsoring' section at the bottom, just before License. Less intrusive, more natural placement.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reorganizes the README by moving the GitHub Sponsors link from a centered badge at the top to a dedicated "## Sponsoring" section at the bottom, just before the License section. The new placement is more conventional and less visually intrusive while maintaining discoverability.

- Removed centered sponsor badge from top of README (after project description)
- Added new "Sponsoring" section with link and heart emoji at bottom
- Better structural organization with dedicated section heading
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk
- Documentation-only change that improves README structure by relocating sponsor link to a more conventional position. No code changes, no functional impact.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Moved sponsor link from centered badge at top to dedicated section at bottom before License |

</details>


</details>


<sub>Last reviewed commit: 07f3f98</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->