### PR TITLE
chore: sync release v0.1.1 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-02-23
+
 ### Added
 - Provider-level fallback on failure — optional `fallback` field in provider config triggers a backup provider when the primary fails for any reason (exception, error response, or timeout). Fallback providers can be `enabled: false` to only activate as backups. ([#2](https://github.com/jkudish/librarium/issues/2) — thanks @taocoding99)
+
 
 ## [0.1.0] - 2026-02-21
 
@@ -38,5 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API keys use environment variable references, never stored in plaintext
 - Response size guard (10MB) on HTTP client
 
-[Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.1...HEAD
 [0.1.0]: https://github.com/jkudish/librarium/releases/tag/v0.1.0
+[0.1.1]: https://github.com/jkudish/librarium/releases/tag/v0.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Sync the `Release v0.1.1` commit (created by the release workflow) back onto `main` via PR so branch-protection rules are respected.

## Changes

- Bump package version metadata to `0.1.1` in `package.json` and `package-lock.json`
- Update `CHANGELOG.md` release links/version entry for `v0.1.1`

## Context

The release workflow successfully published/tagged `v0.1.1`, but direct push to `main` from Actions is blocked by repo rules requiring pull requests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Syncs release v0.1.1 metadata back to main branch via PR to comply with branch protection rules.

- Bumps version to `0.1.1` in `package.json` and `package-lock.json`
- Adds v0.1.1 release entry to `CHANGELOG.md` with proper date and links
- Updates `[Unreleased]` comparison link to point from v0.1.1 to HEAD

All version metadata is consistent across files. No code changes, purely administrative release metadata sync.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is completely safe to merge with zero risk
- This is a routine release metadata sync with no code changes. All version numbers are consistent across files (0.1.1), changelog follows Keep a Changelog format correctly, and the changes match the stated purpose of syncing automated release commits back to main.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 0.1.0 to 0.1.1 |
| package-lock.json | Lockfile version updated to match package.json (0.1.1) |
| CHANGELOG.md | Added v0.1.1 release entry with proper links and changelog formatting |

</details>


</details>


<sub>Last reviewed commit: 7999d37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->