### PR TITLE
chore: sync release v0.1.2 commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-02-23
+
 ### Added
 - Perplexity Agent API provider adapters: `perplexity-deep-research` and `perplexity-advanced-deep`
 - Perplexity Search API provider adapter: `perplexity-search` (raw-search tier)
@@ -20,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added backward-compatible legacy ID support for `perplexity-sonar` and `perplexity-deep` across CLI provider selection, config provider keys, group members, and fallback targets
 - `librarium ls` output table now uses dynamic column widths for long provider IDs
+
 
 ## [0.1.1] - 2026-02-23
 
@@ -55,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API keys use environment variable references, never stored in plaintext
 - Response size guard (10MB) on HTTP client
 
-[Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.2...HEAD
 [0.1.0]: https://github.com/jkudish/librarium/releases/tag/v0.1.0
 [0.1.1]: https://github.com/jkudish/librarium/releases/tag/v0.1.1
+[0.1.2]: https://github.com/jkudish/librarium/releases/tag/v0.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Sync the release workflow version-bump commit (`Release v0.1.2`) back into `main`.

## Why
The release workflow successfully published `v0.1.2`, but direct push to `main` was blocked by repository rules requiring pull requests.

## Changes
- Bump `package.json` / `package-lock.json` to `0.1.2`
- Move changelog unreleased entries into `0.1.2`

## Notes
- Tag and GitHub release `v0.1.2` are already published.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR syncs the release workflow's version bump commit back into `main` after the v0.1.2 release was successfully published. The version has been consistently updated across `package.json` and `package-lock.json`, and the changelog has been properly formatted with the release date and updated version links.

- Version bumped from 0.1.1 to 0.1.2 across all package files
- Changelog unreleased entries correctly moved to [0.1.2] section with date 2026-02-23
- Version comparison links updated at bottom of changelog
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk
- Standard automated release commit syncing version metadata only - no code changes, all version numbers consistent, changelog properly formatted
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 0.1.1 to 0.1.2 |
| package-lock.json | Lock file version updated to match package.json |
| CHANGELOG.md | Unreleased entries moved to 0.1.2 section with release date and links updated |

</details>


</details>


<sub>Last reviewed commit: 18e914a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->