### PR TITLE
add pluggable custom provider system

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ Some providers support optional model overrides. For example, to override Gemini
 
 Librarium supports external providers without changing core code. Add definitions to config and trust them explicitly.
 
+For provider-author implementation details (module contract, script runtime semantics, timeouts, and troubleshooting), see [`docs/provider-development.md`](docs/provider-development.md).
+
 ### Trust Model
 
 - Custom providers load only when their ID appears in `trustedProviderIds`

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -1,0 +1,218 @@
+# Provider Development Guide
+
+This guide documents the implementation-level contract for custom providers in librarium.
+
+Use this when you are authoring a provider package or script, not just configuring one.
+
+## Scope
+
+Custom providers support two source types:
+
+- `npm`: load a module from the project or runtime install context
+- `script`: spawn a command per operation and exchange JSON over stdin/stdout
+
+## Config Model
+
+Custom providers are configured in `~/.config/librarium/config.json` and/or `.librarium.json`.
+
+```json
+{
+  "customProviders": {
+    "my-provider": {
+      "type": "script",
+      "command": "node",
+      "args": ["./scripts/provider.mjs"]
+    }
+  },
+  "trustedProviderIds": ["my-provider"],
+  "providers": {
+    "my-provider": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Load rules:
+
+- Provider ID must be present in `trustedProviderIds`
+- Built-in IDs are reserved and cannot be overridden
+- Project and global configs merge; project `customProviders` override same IDs from global
+
+## Provider Interface Contract
+
+Your provider must match librarium's `Provider` shape:
+
+- Required fields:
+  - `id` (must equal the config key)
+  - `displayName`
+  - `tier` (`deep-research`, `ai-grounded`, `raw-search`)
+  - `envVar` (string, may be empty only when `requiresApiKey` is `false`)
+  - `execute(query, options)`
+- Optional methods:
+  - `submit(query, options)`
+  - `poll(handle)`
+  - `retrieve(handle)`
+  - `test()`
+- Optional metadata:
+  - `requiresApiKey` (defaults to `true`)
+
+Notes:
+
+- If `requiresApiKey` is `true`, empty `envVar` is rejected.
+- `source` is set by librarium (`npm` or `script`).
+
+## NPM Providers
+
+### Resolution Order
+
+`module` is resolved in this order:
+
+1. Current project (`process.cwd()` context)
+2. Librarium runtime install context
+
+In standalone/Homebrew install modes, npm custom providers are skipped with a warning.
+
+### Export Patterns
+
+You can export either:
+
+- A provider object
+- A factory function returning a provider object
+
+Factory function receives:
+
+```ts
+{
+  id: string;
+  config?: ProviderConfig;
+  sourceOptions: Record<string, unknown>;
+}
+```
+
+`sourceOptions` is `customProviders.<id>.options`.
+
+## Script Providers
+
+### Execution Model
+
+Librarium spawns one process per operation:
+
+- `describe`
+- `execute`
+- `submit`
+- `poll`
+- `retrieve`
+- `test`
+
+Process settings:
+
+- stdin: one JSON request envelope
+- stdout: one JSON response envelope
+- stderr: optional debug/error text
+- env: `process.env` merged with `customProviders.<id>.env`
+- cwd:
+  - if `cwd` is set, it is resolved relative to current working directory
+  - otherwise uses current working directory
+
+### Request Envelope
+
+```json
+{
+  "protocolVersion": 1,
+  "operation": "execute",
+  "providerId": "my-provider",
+  "query": "topic",
+  "options": { "timeout": 30 },
+  "providerConfig": { "enabled": true },
+  "sourceOptions": {}
+}
+```
+
+### Response Envelope
+
+Success:
+
+```json
+{
+  "ok": true,
+  "data": {}
+}
+```
+
+Failure:
+
+```json
+{
+  "ok": false,
+  "error": "message"
+}
+```
+
+### `describe` Response
+
+`describe` must return provider metadata and capabilities.
+
+```json
+{
+  "ok": true,
+  "data": {
+    "id": "my-provider",
+    "displayName": "My Provider",
+    "tier": "raw-search",
+    "envVar": "MY_PROVIDER_API_KEY",
+    "requiresApiKey": true,
+    "capabilities": {
+      "execute": true,
+      "submit": false,
+      "poll": false,
+      "retrieve": false,
+      "test": true
+    }
+  }
+}
+```
+
+Rules:
+
+- `displayName` and `tier` are required
+- `execute` is expected; if `capabilities.execute` is explicitly `false`, load fails
+- If `id` is returned, it must match the configured provider ID
+
+### Operation Data Shapes
+
+- `execute` and `retrieve`: `ProviderResult`
+  - includes `provider`, `tier`, `content`, `citations`, `durationMs`
+- `submit`: `AsyncTaskHandle`
+- `poll`: `AsyncPollResult`
+- `test`: `{ ok: boolean; error?: string }`
+
+All responses are validated. Invalid payloads fail the operation.
+
+### Timeouts
+
+- `execute`: uses `options.timeout` seconds (minimum 1s)
+- `submit`: uses `options.timeout` seconds (minimum 1s)
+- `describe`, `poll`, `test`: 30s default
+- `retrieve`: 120s default
+
+## Error Handling and Loading Behavior
+
+- Untrusted provider ID: skipped with warning
+- Built-in ID collision: skipped with warning
+- Module resolution failure: skipped with warning
+- Script startup / JSON parse / schema validation failure: skipped with warning or operation failure
+- Script `ok: false`: surfaced as operation error
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `not trusted` warning | ID missing from `trustedProviderIds` | Add provider ID to trust list |
+| `conflicts with a built-in` warning | Custom ID matches built-in ID | Rename custom provider ID |
+| `Cannot resolve npm module` | Module not installed in project/runtime | Install package or fix `module` name |
+| `describe id ... does not match` | Script reported different ID | Return matching ID or omit `id` |
+| `returned invalid JSON` | Script wrote non-JSON to stdout | Write only one JSON envelope to stdout |
+| `returned invalid ... payload` | Shape mismatch for operation data | Return correct schema for that operation |
+| `timed out` | Operation exceeded timeout | Optimize provider or raise timeout for execute/submit |
+

--- a/scripts/custom-providers/wikipedia-provider.mjs
+++ b/scripts/custom-providers/wikipedia-provider.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const PROTOCOL_VERSION = 1;
+
+function printError(message) {
+  process.stdout.write(JSON.stringify({ ok: false, error: message }));
+}
+
+function printData(data) {
+  process.stdout.write(JSON.stringify({ ok: true, data }));
+}
+
+function buildMarkdown(query, items) {
+  const lines = [`# Wikipedia Results`, '', `Query: ${query}`, ''];
+  if (items.length === 0) {
+    lines.push('No matching Wikipedia entries found.');
+    return lines.join('\n');
+  }
+
+  lines.push('## Top Matches', '');
+  for (const item of items) {
+    lines.push(`- [${item.title}](${item.url})`);
+    if (item.snippet) {
+      lines.push(`  - ${item.snippet}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function execute(providerId, query) {
+  const started = Date.now();
+  const url =
+    'https://en.wikipedia.org/w/api.php?action=opensearch&limit=5&namespace=0&format=json&search=' +
+    encodeURIComponent(query);
+  const response = await fetch(url, {
+    headers: { 'user-agent': 'librarium-wikipedia-provider/1.0' },
+  });
+  if (!response.ok) {
+    throw new Error(`Wikipedia API returned ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const titles = Array.isArray(payload?.[1]) ? payload[1] : [];
+  const snippets = Array.isArray(payload?.[2]) ? payload[2] : [];
+  const links = Array.isArray(payload?.[3]) ? payload[3] : [];
+  const rows = [];
+  for (let i = 0; i < Math.min(titles.length, links.length); i++) {
+    rows.push({
+      title: String(titles[i]),
+      snippet: snippets[i] ? String(snippets[i]) : undefined,
+      url: String(links[i]),
+    });
+  }
+
+  return {
+    provider: providerId,
+    tier: 'raw-search',
+    content: buildMarkdown(query, rows),
+    citations: rows.map((row) => ({
+      url: row.url,
+      title: row.title,
+      snippet: row.snippet,
+      provider: providerId,
+    })),
+    durationMs: Date.now() - started,
+    model: 'wikipedia-opensearch',
+  };
+}
+
+async function main() {
+  const raw = readFileSync(0, 'utf-8');
+  const request = JSON.parse(raw || '{}');
+
+  if (request.protocolVersion !== PROTOCOL_VERSION) {
+    printError(`Unsupported protocolVersion: ${request.protocolVersion}`);
+    return;
+  }
+
+  const providerId = String(request.providerId || 'wikipedia-script');
+  const operation = request.operation;
+
+  if (operation === 'describe') {
+    printData({
+      id: providerId,
+      displayName: 'Wikipedia Script Provider',
+      tier: 'raw-search',
+      envVar: '',
+      requiresApiKey: false,
+      capabilities: {
+        execute: true,
+        test: true,
+      },
+    });
+    return;
+  }
+
+  if (operation === 'test') {
+    try {
+      await execute(providerId, 'OpenAI');
+      printData({ ok: true });
+    } catch (error) {
+      printData({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return;
+  }
+
+  if (operation === 'execute') {
+    const query = String(request.query || '').trim();
+    if (!query) {
+      printError('Missing query');
+      return;
+    }
+    const result = await execute(providerId, query);
+    printData(result);
+    return;
+  }
+
+  printError(`Unsupported operation: ${operation}`);
+}
+
+main().catch((error) => {
+  printError(error instanceof Error ? error.message : String(error));
+});

--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -1,0 +1,580 @@
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { z } from 'zod';
+import { detectInstallMethod } from '../core/install-method.js';
+import type {
+  AsyncTaskHandle,
+  Config,
+  NpmProviderSource,
+  Provider,
+  ProviderConfig,
+  ProviderOptions,
+  ProviderTier,
+  ScriptProviderSource,
+} from '../types.js';
+
+const PROVIDER_TIER_SCHEMA = z.enum([
+  'deep-research',
+  'ai-grounded',
+  'raw-search',
+]);
+
+const CITATION_SCHEMA = z.object({
+  url: z.string(),
+  title: z.string().optional(),
+  snippet: z.string().optional(),
+  provider: z.string(),
+});
+
+const PROVIDER_RESULT_SCHEMA = z.object({
+  provider: z.string(),
+  tier: PROVIDER_TIER_SCHEMA,
+  content: z.string(),
+  citations: z.array(CITATION_SCHEMA),
+  durationMs: z.number().nonnegative(),
+  model: z.string().optional(),
+  tokenUsage: z
+    .object({
+      input: z.number().optional(),
+      output: z.number().optional(),
+    })
+    .optional(),
+  error: z.string().optional(),
+});
+
+const ASYNC_TASK_HANDLE_SCHEMA = z.object({
+  provider: z.string(),
+  taskId: z.string(),
+  query: z.string(),
+  submittedAt: z.number(),
+  status: z.enum(['pending', 'running', 'completed', 'failed', 'cancelled']),
+  lastPolledAt: z.number().optional(),
+  completedAt: z.number().optional(),
+  outputDir: z.string().optional(),
+});
+
+const ASYNC_POLL_RESULT_SCHEMA = z.object({
+  status: z.enum(['pending', 'running', 'completed', 'failed', 'cancelled']),
+  progress: z.number().optional(),
+  message: z.string().optional(),
+});
+
+const SCRIPT_OPERATION_SCHEMA = z.enum([
+  'describe',
+  'execute',
+  'submit',
+  'poll',
+  'retrieve',
+  'test',
+]);
+type ScriptOperation = z.infer<typeof SCRIPT_OPERATION_SCHEMA>;
+
+const SCRIPT_RESPONSE_SCHEMA = z.union([
+  z.object({ ok: z.literal(true), data: z.unknown() }),
+  z.object({ ok: z.literal(false), error: z.string().min(1) }),
+]);
+
+const SCRIPT_DESCRIBE_SCHEMA = z.object({
+  id: z.string().optional(),
+  displayName: z.string().min(1),
+  tier: PROVIDER_TIER_SCHEMA,
+  envVar: z.string().optional(),
+  requiresApiKey: z.boolean().optional(),
+  capabilities: z
+    .object({
+      execute: z.boolean().optional(),
+      submit: z.boolean().optional(),
+      poll: z.boolean().optional(),
+      retrieve: z.boolean().optional(),
+      test: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+const SCRIPT_TEST_SCHEMA = z.object({
+  ok: z.boolean(),
+  error: z.string().optional(),
+});
+
+const SCRIPT_PROTOCOL_VERSION = 1;
+const DEFAULT_SCRIPT_OPERATION_TIMEOUT_SECONDS = 30;
+const DEFAULT_SCRIPT_RETRIEVE_TIMEOUT_SECONDS = 120;
+
+interface ScriptRequestEnvelope {
+  protocolVersion: number;
+  operation: ScriptOperation;
+  providerId: string;
+  query?: string;
+  handle?: AsyncTaskHandle;
+  options?: ProviderOptions;
+  providerConfig?: ProviderConfig;
+  sourceOptions?: Record<string, unknown>;
+}
+
+interface CustomProviderLoadOptions {
+  customProviders: Config['customProviders'];
+  trustedProviderIds: Config['trustedProviderIds'];
+  providerConfigs: Config['providers'];
+  reservedProviderIds: ReadonlySet<string>;
+}
+
+export interface CustomProviderLoadResult {
+  providers: Provider[];
+  loadedIds: string[];
+  skippedIds: string[];
+  warnings: string[];
+}
+
+export async function loadCustomProviders(
+  options: CustomProviderLoadOptions,
+): Promise<CustomProviderLoadResult> {
+  const providers: Provider[] = [];
+  const loadedIds: string[] = [];
+  const skippedIds: string[] = [];
+  const warnings: string[] = [];
+  const trusted = new Set(options.trustedProviderIds);
+  const installMethod = getInstallMethod();
+  const npmLoadingBlocked =
+    installMethod === 'homebrew' || installMethod === 'sea-standalone';
+
+  for (const [providerId, source] of Object.entries(options.customProviders)) {
+    if (options.reservedProviderIds.has(providerId)) {
+      warnings.push(
+        `Custom provider "${providerId}" conflicts with a built-in provider ID and was skipped`,
+      );
+      skippedIds.push(providerId);
+      continue;
+    }
+
+    if (!trusted.has(providerId)) {
+      warnings.push(
+        `Custom provider "${providerId}" is not trusted (add it to trustedProviderIds to enable loading)`,
+      );
+      skippedIds.push(providerId);
+      continue;
+    }
+
+    try {
+      if (source.type === 'npm') {
+        if (npmLoadingBlocked) {
+          warnings.push(
+            `Custom npm provider "${providerId}" was skipped because npm plugin loading is not supported for install method "${installMethod}"`,
+          );
+          skippedIds.push(providerId);
+          continue;
+        }
+        const provider = await loadNpmProvider(
+          providerId,
+          source,
+          options.providerConfigs[providerId],
+        );
+        providers.push(provider);
+        loadedIds.push(providerId);
+        continue;
+      }
+
+      const provider = await loadScriptProvider(
+        providerId,
+        source,
+        options.providerConfigs[providerId],
+      );
+      providers.push(provider);
+      loadedIds.push(providerId);
+    } catch (error) {
+      warnings.push(
+        `Failed to load custom provider "${providerId}": ${error instanceof Error ? error.message : String(error)}`,
+      );
+      skippedIds.push(providerId);
+    }
+  }
+
+  return { providers, loadedIds, skippedIds, warnings };
+}
+
+function getInstallMethod():
+  | 'homebrew'
+  | 'sea-standalone'
+  | 'pnpm'
+  | 'yarn'
+  | 'npm' {
+  try {
+    return detectInstallMethod();
+  } catch {
+    return 'npm';
+  }
+}
+
+async function loadNpmProvider(
+  providerId: string,
+  source: NpmProviderSource,
+  providerConfig?: ProviderConfig,
+): Promise<Provider> {
+  const resolvedModule = resolveNpmModule(source.module);
+  const imported = await import(pathToFileURL(resolvedModule).href);
+  const exported = pickNpmExport(imported, source);
+  const maybeProvider =
+    typeof exported === 'function'
+      ? await Promise.resolve(
+          exported({
+            id: providerId,
+            config: providerConfig,
+            sourceOptions: source.options ?? {},
+          }),
+        )
+      : exported;
+  return normalizeAndValidateProvider(maybeProvider, providerId, 'npm');
+}
+
+function resolveNpmModule(moduleSpecifier: string): string {
+  const resolutionErrors: string[] = [];
+
+  const projectRequire = createRequire(
+    resolvePath(process.cwd(), 'package.json'),
+  );
+  try {
+    return projectRequire.resolve(moduleSpecifier);
+  } catch (error) {
+    resolutionErrors.push(
+      `project: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const runtimeRequire = createRequire(import.meta.url);
+  try {
+    return runtimeRequire.resolve(moduleSpecifier);
+  } catch (error) {
+    resolutionErrors.push(
+      `runtime: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  throw new Error(
+    `Cannot resolve npm module "${moduleSpecifier}". ${resolutionErrors.join(' | ')}`,
+  );
+}
+
+function pickNpmExport(
+  imported: Record<string, unknown>,
+  source: NpmProviderSource,
+): unknown {
+  if (source.export) {
+    if (source.export === 'default') {
+      return imported.default;
+    }
+    return imported[source.export];
+  }
+  return imported.default ?? imported;
+}
+
+async function loadScriptProvider(
+  providerId: string,
+  source: ScriptProviderSource,
+  providerConfig?: ProviderConfig,
+): Promise<Provider> {
+  const describe = await callScriptOperation({
+    providerId,
+    source,
+    providerConfig,
+    operation: 'describe',
+    timeoutSeconds: DEFAULT_SCRIPT_OPERATION_TIMEOUT_SECONDS,
+    schema: SCRIPT_DESCRIBE_SCHEMA,
+  });
+
+  if (describe.id && describe.id !== providerId) {
+    throw new Error(
+      `Script describe id "${describe.id}" does not match config key "${providerId}"`,
+    );
+  }
+
+  const capabilities = describe.capabilities ?? {};
+  if (capabilities.execute === false) {
+    throw new Error(
+      'Script provider describe.capabilities.execute must be true',
+    );
+  }
+
+  const provider: Provider = {
+    id: providerId,
+    displayName: describe.displayName,
+    tier: describe.tier,
+    envVar: describe.envVar ?? '',
+    source: 'script',
+    requiresApiKey: describe.requiresApiKey ?? true,
+    execute: async (query, options) =>
+      callScriptOperation({
+        providerId,
+        source,
+        providerConfig,
+        operation: 'execute',
+        query,
+        options,
+        timeoutSeconds: getOperationTimeoutSeconds('execute', options),
+        schema: PROVIDER_RESULT_SCHEMA,
+      }),
+  };
+
+  if (capabilities.submit) {
+    provider.submit = async (query, options) =>
+      callScriptOperation({
+        providerId,
+        source,
+        providerConfig,
+        operation: 'submit',
+        query,
+        options,
+        timeoutSeconds: getOperationTimeoutSeconds('submit', options),
+        schema: ASYNC_TASK_HANDLE_SCHEMA,
+      });
+  }
+
+  if (capabilities.poll) {
+    provider.poll = async (handle) =>
+      callScriptOperation({
+        providerId,
+        source,
+        providerConfig,
+        operation: 'poll',
+        handle,
+        timeoutSeconds: getOperationTimeoutSeconds('poll'),
+        schema: ASYNC_POLL_RESULT_SCHEMA,
+      });
+  }
+
+  if (capabilities.retrieve) {
+    provider.retrieve = async (handle) =>
+      callScriptOperation({
+        providerId,
+        source,
+        providerConfig,
+        operation: 'retrieve',
+        handle,
+        timeoutSeconds: getOperationTimeoutSeconds('retrieve'),
+        schema: PROVIDER_RESULT_SCHEMA,
+      });
+  }
+
+  if (capabilities.test) {
+    provider.test = async () =>
+      callScriptOperation({
+        providerId,
+        source,
+        providerConfig,
+        operation: 'test',
+        timeoutSeconds: getOperationTimeoutSeconds('test'),
+        schema: SCRIPT_TEST_SCHEMA,
+      });
+  }
+
+  return provider;
+}
+
+function getOperationTimeoutSeconds(
+  operation: ScriptOperation,
+  options?: ProviderOptions,
+): number {
+  if (operation === 'execute' || operation === 'submit') {
+    return Math.max(1, Math.floor(options?.timeout ?? 1));
+  }
+  if (operation === 'retrieve') {
+    return DEFAULT_SCRIPT_RETRIEVE_TIMEOUT_SECONDS;
+  }
+  return DEFAULT_SCRIPT_OPERATION_TIMEOUT_SECONDS;
+}
+
+async function callScriptOperation<T>({
+  providerId,
+  source,
+  providerConfig,
+  operation,
+  query,
+  handle,
+  options,
+  timeoutSeconds,
+  schema,
+}: {
+  providerId: string;
+  source: ScriptProviderSource;
+  providerConfig?: ProviderConfig;
+  operation: ScriptOperation;
+  query?: string;
+  handle?: AsyncTaskHandle;
+  options?: ProviderOptions;
+  timeoutSeconds: number;
+  schema: z.ZodSchema<T>;
+}): Promise<T> {
+  const envelope: ScriptRequestEnvelope = {
+    protocolVersion: SCRIPT_PROTOCOL_VERSION,
+    operation,
+    providerId,
+    query,
+    handle,
+    options,
+    providerConfig,
+    sourceOptions: source.options ?? {},
+  };
+
+  const raw = await runScriptOperation(source, envelope, timeoutSeconds);
+  const response = SCRIPT_RESPONSE_SCHEMA.parse(raw);
+
+  if (!response.ok) {
+    throw new Error(
+      `Script provider operation "${operation}" failed: ${response.error}`,
+    );
+  }
+
+  try {
+    return schema.parse(response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const issue = error.issues[0];
+      throw new Error(
+        `Script provider returned invalid "${operation}" payload: ${issue?.message ?? error.message}`,
+      );
+    }
+    throw error;
+  }
+}
+
+function runScriptOperation(
+  source: ScriptProviderSource,
+  envelope: ScriptRequestEnvelope,
+  timeoutSeconds: number,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(source.command, source.args ?? [], {
+      cwd: source.cwd ? resolvePath(process.cwd(), source.cwd) : process.cwd(),
+      env: { ...process.env, ...(source.env ?? {}) },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const finish = (error?: Error, value?: unknown): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(value);
+      }
+    };
+
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      finish(
+        new Error(
+          `Failed to start script provider command "${source.command}": ${error.message}`,
+        ),
+      );
+    });
+
+    child.on('close', (code, signal) => {
+      const trimmed = stdout.trim();
+      if (!trimmed) {
+        const detail = [
+          code !== null ? `exit code ${code}` : null,
+          signal ? `signal ${signal}` : null,
+          stderr.trim() ? `stderr: ${stderr.trim().slice(0, 300)}` : null,
+        ]
+          .filter(Boolean)
+          .join(', ');
+        finish(
+          new Error(
+            `Script provider returned no JSON response for operation "${envelope.operation}"${detail ? ` (${detail})` : ''}`,
+          ),
+        );
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        finish(undefined, parsed);
+      } catch (error) {
+        const detail = stderr.trim()
+          ? ` stderr: ${stderr.trim().slice(0, 300)}`
+          : '';
+        finish(
+          new Error(
+            `Script provider returned invalid JSON for operation "${envelope.operation}": ${error instanceof Error ? error.message : String(error)}.${detail}`,
+          ),
+        );
+      }
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(
+        new Error(
+          `Script provider operation "${envelope.operation}" timed out after ${timeoutSeconds}s`,
+        ),
+      );
+    }, Math.max(1, timeoutSeconds) * 1000);
+
+    child.stdin.write(JSON.stringify(envelope));
+    child.stdin.end();
+  });
+}
+
+function normalizeAndValidateProvider(
+  candidate: unknown,
+  providerId: string,
+  source: 'npm' | 'script',
+): Provider {
+  if (!candidate || typeof candidate !== 'object') {
+    throw new Error('Provider module did not return a provider object');
+  }
+
+  const provider = candidate as Partial<Provider>;
+
+  if (provider.id !== providerId) {
+    throw new Error(
+      `Provider id mismatch: expected "${providerId}", got "${provider.id ?? 'undefined'}"`,
+    );
+  }
+  if (!provider.displayName || typeof provider.displayName !== 'string') {
+    throw new Error('Provider must define a non-empty displayName');
+  }
+  if (!provider.tier || !isProviderTier(provider.tier)) {
+    throw new Error(`Provider must define a valid tier`);
+  }
+  if (typeof provider.envVar !== 'string') {
+    throw new Error('Provider must define envVar as a string');
+  }
+  if (typeof provider.execute !== 'function') {
+    throw new Error('Provider must define an execute(query, options) function');
+  }
+  for (const method of ['submit', 'poll', 'retrieve', 'test'] as const) {
+    const value = provider[method];
+    if (value !== undefined && typeof value !== 'function') {
+      throw new Error(`Provider method "${method}" must be a function`);
+    }
+  }
+
+  provider.source = source;
+  provider.requiresApiKey ??= true;
+  if (provider.requiresApiKey && provider.envVar.trim().length === 0) {
+    throw new Error(
+      'Provider requires an API key but envVar is empty; set requiresApiKey=false for keyless providers',
+    );
+  }
+
+  return provider as Provider;
+}
+
+function isProviderTier(value: unknown): value is ProviderTier {
+  return (
+    value === 'deep-research' ||
+    value === 'ai-grounded' ||
+    value === 'raw-search'
+  );
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -61,6 +61,29 @@ function printConfig(config: Record<string, unknown>, title: string): void {
     }
   }
 
+  const customProviders = config.customProviders as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const customProviderIds = Object.keys(customProviders);
+  console.log(`\n  Custom Providers (${customProviderIds.length}):`);
+  if (customProviderIds.length === 0) {
+    console.log('    (none configured)');
+  } else {
+    for (const [id, source] of Object.entries(customProviders)) {
+      const type = String(source.type ?? 'unknown');
+      console.log(`    ${id}: ${type}`);
+    }
+  }
+
+  const trustedProviderIds = (config.trustedProviderIds as string[]) ?? [];
+  console.log(`\n  Trusted Provider IDs (${trustedProviderIds.length}):`);
+  if (trustedProviderIds.length === 0) {
+    console.log('    (none)');
+  } else {
+    console.log(`    ${trustedProviderIds.join(', ')}`);
+  }
+
   const groups = config.groups as Record<string, string[]>;
   const groupNames = Object.keys(groups);
   console.log(`\n  Groups (${groupNames.length}):`);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -88,8 +88,8 @@ export function registerInitCommand(program: Command): void {
         }
 
         // Disable unselected providers that were previously enabled
-        for (const id of Object.keys(existingConfig.providers)) {
-          if (!selectedProviders.includes(id)) {
+        for (const id of Object.keys(PROVIDER_ENV_VARS)) {
+          if (existingConfig.providers[id] && !selectedProviders.includes(id)) {
             existingConfig.providers[id].enabled = false;
           }
         }

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -12,7 +12,10 @@ export function registerLsCommand(program: Command): void {
         const globalConfig = loadConfig();
         const projectConfig = loadProjectConfig(process.cwd());
         const config = mergeConfigs(globalConfig, projectConfig);
-        await initializeProviders(config.providers);
+        const initResult = await initializeProviders(config);
+        for (const warning of initResult.warnings) {
+          console.error(`[librarium] warning: ${warning}`);
+        }
 
         const meta = getProviderMeta(config.providers);
 
@@ -37,6 +40,10 @@ export function registerLsCommand(program: Command): void {
           'Tier'.length,
           ...meta.map((p) => p.tier.length),
         );
+        const sourceWidth = Math.max(
+          'Source'.length,
+          ...meta.map((p) => p.source.length),
+        );
         const enabledWidth = Math.max('Enabled'.length, 'Yes'.length);
         const apiKeyWidth = Math.max('API Key'.length, 'Missing'.length);
 
@@ -45,6 +52,7 @@ export function registerLsCommand(program: Command): void {
           'ID'.padEnd(idWidth),
           'Name'.padEnd(nameWidth),
           'Tier'.padEnd(tierWidth),
+          'Source'.padEnd(sourceWidth),
           'Enabled'.padEnd(enabledWidth),
           'API Key'.padEnd(apiKeyWidth),
         ].join('  ');
@@ -59,6 +67,7 @@ export function registerLsCommand(program: Command): void {
             p.id.padEnd(idWidth),
             p.displayName.padEnd(nameWidth),
             p.tier.padEnd(tierWidth),
+            p.source.padEnd(sourceWidth),
             enabled.padEnd(enabledWidth),
             apiKey.padEnd(apiKeyWidth),
           ].join('  ');

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -93,7 +93,10 @@ export function registerStatusCommand(program: Command): void {
         const globalConfig = loadConfig();
         const projectConfig = loadProjectConfig(process.cwd());
         const config = mergeConfigs(globalConfig, projectConfig);
-        await initializeProviders(config.providers);
+        const initResult = await initializeProviders(config);
+        for (const warning of initResult.warnings) {
+          console.error(`[librarium] warning: ${warning}`);
+        }
         const baseDir = resolve(config.defaults.outputDir);
 
         // Gather all async tasks (pending + completed unretrieved)

--- a/tests/custom-providers.test.ts
+++ b/tests/custom-providers.test.ts
@@ -1,0 +1,333 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('custom providers', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let initializeProviders: typeof import('../src/adapters/index.js').initializeProviders;
+  let getProvider: typeof import('../src/adapters/index.js').getProvider;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `librarium-custom-${randomUUID().slice(0, 8)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    vi.resetModules();
+    const adapters = await import('../src/adapters/index.js');
+    initializeProviders = adapters.initializeProviders;
+    getProvider = adapters.getProvider;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('skips untrusted custom providers', async () => {
+    const modulePath = join(tmpDir, 'untrusted-provider.mjs');
+    writeFileSync(
+      modulePath,
+      [
+        'export default {',
+        "  id: 'untrusted-provider',",
+        "  displayName: 'Untrusted Provider',",
+        "  tier: 'raw-search',",
+        "  envVar: '',",
+        '  requiresApiKey: false,',
+        '  async execute(query) {',
+        "    return { provider: 'untrusted-provider', tier: 'raw-search', content: query, citations: [], durationMs: 1 };",
+        '  },',
+        '};',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: {
+        'untrusted-provider': {
+          enabled: true,
+        },
+      },
+      customProviders: {
+        'untrusted-provider': {
+          type: 'npm',
+          module: modulePath,
+        },
+      },
+      trustedProviderIds: [],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.skippedCustomProviders).toContain('untrusted-provider');
+    expect(result.warnings.join('\n')).toContain('not trusted');
+    expect(getProvider('untrusted-provider')).toBeUndefined();
+  });
+
+  it('loads trusted npm provider from project node_modules', async () => {
+    const pkgDir = join(tmpDir, 'node_modules', 'my-provider');
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'tmp-project', private: true }, null, 2),
+      'utf-8',
+    );
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'my-provider',
+          version: '1.0.0',
+          type: 'module',
+          exports: './index.mjs',
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+    writeFileSync(
+      join(pkgDir, 'index.mjs'),
+      [
+        'export async function factory(context) {',
+        '  return {',
+        '    id: context.id,',
+        "    displayName: 'My NPM Provider',",
+        "    tier: 'ai-grounded',",
+        "    envVar: '',",
+        '    requiresApiKey: false,',
+        '    async execute(query) {',
+        '      return {',
+        '        provider: context.id,',
+        "        tier: 'ai-grounded',",
+        '        content: `${query}:${context.sourceOptions.suffix}`,',
+        '        citations: [],',
+        '        durationMs: 5,',
+        '      };',
+        '    },',
+        '  };',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: {
+        'my-provider': {
+          enabled: true,
+        },
+      },
+      customProviders: {
+        'my-provider': {
+          type: 'npm',
+          module: 'my-provider',
+          export: 'factory',
+          options: { suffix: 'ok' },
+        },
+      },
+      trustedProviderIds: ['my-provider'],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.loadedCustomProviders).toContain('my-provider');
+
+    const provider = getProvider('my-provider');
+    expect(provider).toBeDefined();
+    expect(provider!.source).toBe('npm');
+    expect(provider!.requiresApiKey).toBe(false);
+
+    const executed = await provider!.execute('hello', { timeout: 10 });
+    expect(executed.content).toBe('hello:ok');
+  });
+
+  it('loads script provider with async lifecycle hooks', async () => {
+    const scriptPath = join(tmpDir, 'script-provider.mjs');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { readFileSync } from 'node:fs';",
+        'const input = JSON.parse(readFileSync(0, "utf-8"));',
+        'const op = input.operation;',
+        'const providerId = input.providerId;',
+        'const sourceTag = input.sourceOptions?.tag ?? "none";',
+        'if (op === "describe") {',
+        '  process.stdout.write(JSON.stringify({',
+        '    ok: true,',
+        '    data: {',
+        "      displayName: 'Script Provider',",
+        "      tier: 'deep-research',",
+        "      envVar: '',",
+        '      requiresApiKey: false,',
+        '      capabilities: { submit: true, poll: true, retrieve: true, test: true }',
+        '    }',
+        '  }));',
+        '} else if (op === "execute") {',
+        '  process.stdout.write(JSON.stringify({',
+        '    ok: true,',
+        '    data: {',
+        '      provider: providerId,',
+        "      tier: 'deep-research',",
+        '      content: `exec:${input.query}:${sourceTag}`,',
+        '      citations: [],',
+        '      durationMs: 2',
+        '    }',
+        '  }));',
+        '} else if (op === "submit") {',
+        '  process.stdout.write(JSON.stringify({',
+        '    ok: true,',
+        '    data: {',
+        '      provider: providerId,',
+        "      taskId: 'task-123',",
+        '      query: input.query,',
+        '      submittedAt: Date.now(),',
+        "      status: 'pending'",
+        '    }',
+        '  }));',
+        '} else if (op === "poll") {',
+        '  process.stdout.write(JSON.stringify({',
+        '    ok: true,',
+        '    data: {',
+        "      status: 'completed',",
+        '      progress: 100',
+        '    }',
+        '  }));',
+        '} else if (op === "retrieve") {',
+        '  process.stdout.write(JSON.stringify({',
+        '    ok: true,',
+        '    data: {',
+        '      provider: providerId,',
+        "      tier: 'deep-research',",
+        '      content: `retrieved:${input.handle.taskId}`,',
+        '      citations: [],',
+        '      durationMs: 3',
+        '    }',
+        '  }));',
+        '} else if (op === "test") {',
+        '  process.stdout.write(JSON.stringify({',
+        '    ok: true,',
+        '    data: { ok: true }',
+        '  }));',
+        '} else {',
+        '  process.stdout.write(JSON.stringify({ ok: false, error: `unsupported:${op}` }));',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const initResult = await initializeProviders({
+      providers: {
+        'script-provider': {
+          enabled: true,
+          apiKey: '$SCRIPT_PROVIDER_KEY',
+        },
+      },
+      customProviders: {
+        'script-provider': {
+          type: 'script',
+          command: 'node',
+          args: [scriptPath],
+          options: { tag: 'tagged' },
+        },
+      },
+      trustedProviderIds: ['script-provider'],
+    });
+
+    expect(initResult.warnings).toEqual([]);
+    const provider = getProvider('script-provider');
+    expect(provider).toBeDefined();
+    expect(provider!.source).toBe('script');
+    expect(provider!.submit).toBeDefined();
+    expect(provider!.poll).toBeDefined();
+    expect(provider!.retrieve).toBeDefined();
+    expect(provider!.test).toBeDefined();
+
+    const executed = await provider!.execute('question', { timeout: 5 });
+    expect(executed.provider).toBe('script-provider');
+    expect(executed.tier).toBe('deep-research');
+    expect(executed.content).toBe('exec:question:tagged');
+
+    const handle = await provider!.submit!('question', { timeout: 5 });
+    expect(handle.provider).toBe('script-provider');
+    const pollResult = await provider!.poll!(handle);
+    expect(pollResult.status).toBe('completed');
+    const retrieved = await provider!.retrieve!(handle);
+    expect(retrieved.content).toBe('retrieved:task-123');
+    const health = await provider!.test!();
+    expect(health.ok).toBe(true);
+  });
+
+  it('skips malformed script providers', async () => {
+    const scriptPath = join(tmpDir, 'bad-script-provider.mjs');
+    writeFileSync(scriptPath, 'process.stdout.write("not-json");\n', 'utf-8');
+
+    const initResult = await initializeProviders({
+      providers: {
+        'bad-script': {
+          enabled: true,
+        },
+      },
+      customProviders: {
+        'bad-script': {
+          type: 'script',
+          command: 'node',
+          args: [scriptPath],
+        },
+      },
+      trustedProviderIds: ['bad-script'],
+    });
+
+    expect(initResult.loadedCustomProviders).toEqual([]);
+    expect(initResult.skippedCustomProviders).toContain('bad-script');
+    expect(initResult.warnings.join('\n')).toContain('invalid JSON');
+  });
+
+  it('rejects custom providers that collide with built-in IDs', async () => {
+    const modulePath = join(tmpDir, 'exa-override.mjs');
+    writeFileSync(
+      modulePath,
+      [
+        'export default {',
+        "  id: 'exa',",
+        "  displayName: 'Exa Override',",
+        "  tier: 'ai-grounded',",
+        "  envVar: '',",
+        '  requiresApiKey: false,',
+        '  async execute(query, _options) {',
+        "    return { provider: 'exa', tier: 'ai-grounded', content: query, citations: [], durationMs: 1 };",
+        '  },',
+        '};',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const initResult = await initializeProviders({
+      providers: {
+        exa: {
+          enabled: true,
+        },
+      },
+      customProviders: {
+        exa: {
+          type: 'npm',
+          module: modulePath,
+        },
+      },
+      trustedProviderIds: ['exa'],
+    });
+
+    const exa = getProvider('exa');
+    expect(exa).toBeDefined();
+    expect(exa!.source).toBe('builtin');
+    expect(initResult.loadedCustomProviders).toEqual([]);
+    expect(initResult.warnings.join('\n')).toContain(
+      'conflicts with a built-in',
+    );
+  });
+});

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -1,10 +1,17 @@
 import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 // Integration tests run against the built CLI.
 // Run `npm run build` before executing these tests.
 const CLI = resolve(import.meta.dirname, '../../dist/cli.js');
+const TEST_HOME = mkdtempSync(resolve(tmpdir(), 'librarium-integration-'));
+
+afterAll(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
 
 function run(args: string): string {
   try {
@@ -12,6 +19,10 @@ function run(args: string): string {
       encoding: 'utf-8',
       timeout: 15_000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        HOME: TEST_HOME,
+      },
     });
   } catch (err: unknown) {
     const e = err as { stdout?: string; stderr?: string };

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -115,6 +115,7 @@ describe('registry', () => {
     expect(meta).toHaveLength(1);
     expect(meta[0].id).toBe('test-meta');
     expect(meta[0].tier).toBe('ai-grounded');
+    expect(meta[0].source).toBe('builtin');
     expect(meta[0].enabled).toBe(true);
     expect(meta[0].hasApiKey).toBe(true);
   });
@@ -142,8 +143,10 @@ describe('registry', () => {
 
   it('initializeProviders applies gemini model config override', async () => {
     await initializeProviders({
-      'gemini-deep': {
-        model: 'gemini-2.5-pro',
+      providers: {
+        'gemini-deep': {
+          model: 'gemini-2.5-pro',
+        },
       },
     });
 


### PR DESCRIPTION
## Summary

Add first-class pluggable providers so users can add custom providers via config (npm modules or local scripts) without modifying librarium core code.

## Changes

- added external provider loading pipeline with trust gating and two source types (`npm`, `script`)
- added script-provider protocol v1 with strict request/response validation and support for `execute`, `submit`, `poll`, `retrieve`, and `test`
- refactored provider initialization into built-in registration + custom provider loading
- extended config/types with `customProviders`, `trustedProviderIds`, and project-level provider/custom/group overrides
- updated merge semantics (`providers` deep merge, `customProviders` project override, `trustedProviderIds` union+dedupe)
- updated CLI behavior:
  - `run` validates selected providers against loaded registry and warns on unavailable IDs
  - `ls` includes provider `source`
  - `doctor` respects `requiresApiKey: false`
  - `status` surfaces loader warnings
  - `init` no longer disables non-built-in custom providers
  - `config` prints custom providers and trust list
- added docs for custom providers, trust model, npm/script examples, and protocol contract
- added a concrete custom script provider example at `scripts/custom-providers/wikipedia-provider.mjs`
- added/updated tests for config merge behavior, custom provider loading, protocol validation, and CLI integration isolation

## Testing

- [x] Added / updated unit tests (`npm test`)
- [x] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

Manual real query smoke:
- ran mixed-provider query with built-in `brave-search` + custom `wikipedia-script`
- query: `lithium ion battery recycling`
- result: 2 succeeded, 0 failed, exit code 0, outputs written for both providers

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] New providers include an adapter in `src/adapters/` and are registered in `src/adapters/index.ts`
- [x] Config changes are reflected in `src/core/config.ts` and `src/types.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR successfully implements a pluggable custom provider system allowing users to extend librarium with npm modules or local scripts without modifying core code.

## Key Changes

- **Custom Provider Loading Pipeline**: Implemented trust-gated loading with two source types (`npm` and `script`), including proper conflict detection with built-in providers and install method compatibility checks
- **Script Provider Protocol v1**: Defined a clean JSON-based stdio protocol with strict Zod validation for `describe`, `execute`, `submit`, `poll`, `retrieve`, and `test` operations
- **Config System Extensions**: Added `customProviders`, `trustedProviderIds`, and project-level provider overrides with proper merge semantics (providers deep merge, customProviders override, trustedProviderIds union+dedupe)
- **CLI Integration**: Updated all commands to handle custom providers - `run` validates provider availability, `ls` shows source column, `doctor` respects `requiresApiKey: false`, `status` surfaces warnings, `init` preserves custom providers, `config` displays custom provider configuration
- **Security Model**: Trust gating requires explicit opt-in via `trustedProviderIds`, reserved ID protection prevents conflicts with built-ins, npm loading blocked for Homebrew/standalone installs
- **Complete Example**: Wikipedia script provider demonstrates the protocol implementation with proper error handling and no API key requirement

## Implementation Quality

The implementation is well-architected with proper separation of concerns, comprehensive error handling, and thorough test coverage. The trust model is sound and clearly documented. Config merge semantics are correctly implemented and tested. The script protocol uses proper timeout handling with cleanup, structured validation with Zod schemas, and clear error messages.

## Testing

Excellent test coverage including trust model verification, npm/script loading paths, protocol validation, ID conflicts, error cases, and CLI integration. Manual testing verified mixed built-in + custom provider queries work correctly.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk - well-tested feature addition with strong security boundaries
- Clean architecture with proper separation of concerns, comprehensive test coverage (420+ lines of new tests), sound trust model with explicit opt-in, no breaking changes to existing functionality, thorough validation and error handling throughout, manual testing verified, and complete documentation
- No files require special attention - all changes are well-implemented with proper validation and testing
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/types.ts | added well-structured types for custom provider sources (npm/script), provider metadata, and config schemas with proper Zod validation |
| src/core/config.ts | implemented proper config merge semantics for custom providers, trust list union+dedupe, and deep merge for provider configs with validation |
| src/adapters/custom.ts | implemented comprehensive custom provider loading with trust gating, npm module resolution, script protocol v1 with validation, proper timeout handling and error reporting |
| src/adapters/index.ts | refactored initialization to separate built-in and custom provider registration, proper source tracking, returns load results with warnings |
| src/commands/run.ts | added provider availability validation before execution, warns on unavailable providers, prevents running with no valid providers |
| src/commands/init.ts | fixed to only disable built-in providers during init, prevents accidentally disabling custom providers |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start[User Config] --> LoadGlobal[Load Global Config]
    LoadGlobal --> LoadProject[Load Project Config]
    LoadProject --> MergeConfig[Merge Configs]
    
    MergeConfig --> InitProviders[Initialize Providers]
    InitProviders --> RegisterBuiltin[Register 13 Built-in Providers]
    RegisterBuiltin --> LoadCustom[Load Custom Providers]
    
    LoadCustom --> CheckReserved{ID conflicts with<br/>built-in?}
    CheckReserved -->|Yes| Skip1[Skip + Warning]
    CheckReserved -->|No| CheckTrust{Provider in<br/>trustedProviderIds?}
    
    CheckTrust -->|No| Skip2[Skip + Warning]
    CheckTrust -->|Yes| CheckType{Provider Type?}
    
    CheckType -->|npm| CheckInstall{Install method<br/>supports npm?}
    CheckInstall -->|No| Skip3[Skip + Warning]
    CheckInstall -->|Yes| LoadNPM[Resolve & Import NPM Module]
    
    CheckType -->|script| LoadScript[Load Script Provider]
    
    LoadNPM --> Validate[Validate Provider Interface]
    LoadScript --> ScriptDescribe[Call describe operation]
    ScriptDescribe --> Validate
    
    Validate --> Register[Register Provider]
    Register --> Ready[Ready for Execution]
    
    Skip1 --> Complete[Return Load Results]
    Skip2 --> Complete
    Skip3 --> Complete
    Ready --> Complete
```
</details>


<sub>Last reviewed commit: aa75ff6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->