### PR TITLE
add Firecrawl Search provider adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Firecrawl Search provider adapter: `firecrawl-search` — web search via Firecrawl v2 Search API (raw-search tier)
 - OpenAI Deep Research (o3) provider adapter: `openai-deep-o3` — higher-quality deep research using the o3-deep-research model
 - You.com Research provider adapter: `you-research` — AI-powered research with cited answers (ai-grounded tier)
 - Jina AI Search provider adapter: `jina-search` — search-to-markdown API for LLM-native content (raw-search tier)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Librarium ships with 17 built-in provider adapters organized into three tiers:
 | SearchAPI | `searchapi` | raw-search | `SEARCHAPI_API_KEY` |
 | SerpAPI | `serpapi` | raw-search | `SERPAPI_API_KEY` |
 | Tavily Search | `tavily` | raw-search | `TAVILY_API_KEY` |
+| Firecrawl Search | `firecrawl-search` | raw-search | `FIRECRAWL_API_KEY` |
 
 ### Provider ID Migration (Legacy Aliases)
 
@@ -261,10 +262,10 @@ Groups are named collections of provider IDs. Librarium ships with six default g
 |---|---|---|
 | `deep` | perplexity-sonar-deep, perplexity-deep-research, perplexity-advanced-deep, openai-deep, openai-deep-o3, gemini-deep | Thorough async research |
 | `quick` | perplexity-sonar-pro, brave-answers, exa, kagi-fastgpt | Fast AI-grounded answers |
-| `raw` | perplexity-search, brave-search, jina-search, searchapi, serpapi, tavily | Traditional search results |
-| `fast` | perplexity-sonar-pro, perplexity-search, brave-answers, exa, kagi-fastgpt, jina-search, brave-search, tavily | Quick results from multiple tiers |
+| `raw` | perplexity-search, brave-search, jina-search, firecrawl-search, searchapi, serpapi, tavily | Traditional search results |
+| `fast` | perplexity-sonar-pro, perplexity-search, brave-answers, exa, kagi-fastgpt, jina-search, brave-search, firecrawl-search, tavily | Quick results from multiple tiers |
 | `comprehensive` | All deep-research + all ai-grounded | Deep + AI-grounded combined |
-| `all` | All 17 providers | Maximum coverage |
+| `all` | All 18 providers | Maximum coverage |
 
 ### Custom Groups
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ librarium status --wait
 
 ## Providers
 
-Librarium ships with 17 built-in provider adapters organized into three tiers:
+Librarium ships with 18 built-in provider adapters organized into three tiers:
 
 | Provider | ID | Tier | API Key Env Var |
 |---|---|---|---|

--- a/src/adapters/firecrawl-search.ts
+++ b/src/adapters/firecrawl-search.ts
@@ -10,7 +10,6 @@ interface FirecrawlWebResult {
   url: string;
   title?: string;
   description?: string;
-  markdown?: string;
 }
 
 interface FirecrawlSearchResponse {
@@ -150,7 +149,7 @@ export class FirecrawlSearchProvider extends BaseProvider {
     return results.map((result) => ({
       url: result.url,
       title: result.title,
-      snippet: result.description,
+      snippet: result.description?.slice(0, 200),
       provider: this.id,
     }));
   }

--- a/src/adapters/firecrawl-search.ts
+++ b/src/adapters/firecrawl-search.ts
@@ -1,0 +1,157 @@
+import type {
+  Citation,
+  ProviderOptions,
+  ProviderResult,
+  ProviderTier,
+} from '../types.js';
+import { BaseProvider } from './base.js';
+
+interface FirecrawlWebResult {
+  url: string;
+  title?: string;
+  description?: string;
+  markdown?: string;
+}
+
+interface FirecrawlSearchResponse {
+  success?: boolean;
+  data?: {
+    web?: FirecrawlWebResult[];
+  };
+  error?: string;
+}
+
+/**
+ * Firecrawl Search provider.
+ * Uses Firecrawl v2 Search API for raw web search results.
+ * Tier: raw-search (sync)
+ */
+export class FirecrawlSearchProvider extends BaseProvider {
+  readonly id = 'firecrawl-search';
+  readonly tier: ProviderTier = 'raw-search';
+
+  async execute(
+    query: string,
+    options: ProviderOptions,
+  ): Promise<ProviderResult> {
+    const start = performance.now();
+    const apiKey = this.getApiKey();
+
+    try {
+      const url = 'https://api.firecrawl.dev/v2/search';
+
+      const response = await this.request<FirecrawlSearchResponse>(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          query,
+          limit: 10,
+          sources: ['web'],
+        },
+        timeout: options.timeout * 1000,
+        signal: options.signal,
+      });
+
+      const durationMs = Math.round(performance.now() - start);
+
+      if (response.status !== 200) {
+        return {
+          provider: this.id,
+          tier: this.tier,
+          content: '',
+          citations: [],
+          durationMs,
+          error: this.formatError(response.status, response.data),
+        };
+      }
+
+      const data = response.data;
+      if (data.error) {
+        return {
+          provider: this.id,
+          tier: this.tier,
+          content: '',
+          citations: [],
+          durationMs,
+          error: data.error,
+        };
+      }
+
+      const results = data.data?.web ?? [];
+      const citations = this.extractCitations(results);
+      const content = this.buildContent(results);
+
+      return {
+        provider: this.id,
+        tier: this.tier,
+        content,
+        citations,
+        durationMs,
+      };
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start);
+      return {
+        provider: this.id,
+        tier: this.tier,
+        content: '',
+        citations: [],
+        durationMs,
+        error: this.formatCatchError(err),
+      };
+    }
+  }
+
+  async test(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const apiKey = this.getApiKey();
+      const response = await this.request<FirecrawlSearchResponse>(
+        'https://api.firecrawl.dev/v2/search',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: { query: 'test', limit: 1, sources: ['web'] },
+          timeout: 10000,
+        },
+      );
+
+      if (response.status === 200) return { ok: true };
+      return { ok: false, error: `HTTP ${response.status}` };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private buildContent(results: FirecrawlWebResult[]): string {
+    if (results.length === 0) return 'No results found.';
+
+    const parts: string[] = [];
+
+    for (const result of results) {
+      const title = result.title ?? 'Untitled';
+      parts.push(`- **[${title}](${result.url})**`);
+      if (result.description) {
+        parts.push(`  ${result.description}`);
+      }
+    }
+
+    return parts.join('\n');
+  }
+
+  private extractCitations(results: FirecrawlWebResult[]): Citation[] {
+    return results.map((result) => ({
+      url: result.url,
+      title: result.title,
+      snippet: result.description,
+      provider: this.id,
+    }));
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -90,7 +90,7 @@ export function getProviderMeta(
 
 /**
  * Initialize all providers — called at startup.
- * Instantiates and registers all 17 provider adapters.
+ * Instantiates and registers all 18 provider adapters.
  */
 export async function initializeProviders(
   config: ProviderInitConfig = {},

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -5,6 +5,7 @@ import { BraveAnswersProvider } from './brave-answers.js';
 import { BraveSearchProvider } from './brave-search.js';
 import { loadCustomProviders } from './custom.js';
 import { ExaProvider } from './exa.js';
+import { FirecrawlSearchProvider } from './firecrawl-search.js';
 import { GeminiDeepProvider } from './gemini-deep.js';
 import { JinaSearchProvider } from './jina-search.js';
 import { KagiFastGPTProvider } from './kagi-fastgpt.js';
@@ -117,6 +118,7 @@ export async function initializeProviders(
     new PerplexitySearchProvider(),
     new BraveSearchProvider(),
     new JinaSearchProvider(),
+    new FirecrawlSearchProvider(),
     new SearchApiProvider(),
     new SerpApiProvider(),
     new TavilyProvider(),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,7 @@ export const PROVIDER_ENV_VARS: Record<string, string> = {
   searchapi: 'SEARCHAPI_API_KEY',
   serpapi: 'SERPAPI_API_KEY',
   tavily: 'TAVILY_API_KEY',
+  'firecrawl-search': 'FIRECRAWL_API_KEY',
 };
 
 // Provider display names
@@ -69,6 +70,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   searchapi: 'SearchAPI',
   serpapi: 'SerpAPI',
   tavily: 'Tavily Search',
+  'firecrawl-search': 'Firecrawl Search',
 };
 
 // Backward-compatible provider ID aliases (legacy -> canonical)
@@ -117,6 +119,7 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'perplexity-search',
     'brave-search',
     'jina-search',
+    'firecrawl-search',
     'searchapi',
     'serpapi',
     'tavily',
@@ -129,6 +132,7 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'kagi-fastgpt',
     'jina-search',
     'brave-search',
+    'firecrawl-search',
     'tavily',
   ],
   comprehensive: [
@@ -157,6 +161,7 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'you-research',
     'kagi-fastgpt',
     'jina-search',
+    'firecrawl-search',
     'perplexity-search',
     'brave-search',
     'searchapi',

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -120,10 +120,10 @@ describe('registry', () => {
     expect(meta[0].hasApiKey).toBe(true);
   });
 
-  it('initializeProviders registers all 17 providers', async () => {
+  it('initializeProviders registers all 18 providers', async () => {
     await initializeProviders();
     const all = getAllProviders();
-    expect(all).toHaveLength(17);
+    expect(all).toHaveLength(18);
 
     const ids = all.map((p) => p.id);
     expect(ids).toContain('perplexity-sonar-deep');
@@ -140,6 +140,7 @@ describe('registry', () => {
     expect(ids).toContain('perplexity-search');
     expect(ids).toContain('brave-search');
     expect(ids).toContain('jina-search');
+    expect(ids).toContain('firecrawl-search');
     expect(ids).toContain('searchapi');
     expect(ids).toContain('serpapi');
     expect(ids).toContain('tavily');


### PR DESCRIPTION
## Summary

- Add `firecrawl-search` provider adapter using the Firecrawl v2 Search API (`POST https://api.firecrawl.dev/v2/search`)
- Tier: `raw-search` (sync) — returns web search results with URL, title, and description
- Added to `raw`, `fast`, and `all` default groups
- Env var: `FIRECRAWL_API_KEY`

## Changes

| File | Change |
|------|--------|
| `src/adapters/firecrawl-search.ts` | New provider adapter |
| `src/adapters/index.ts` | Register provider + update count comment |
| `src/constants.ts` | Add env var, display name, and default groups |
| `tests/registry.test.ts` | Bump count 17→18, assert new ID |
| `README.md` | Provider table + group table + count |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] All 100 existing tests pass
- [x] `librarium ls` shows firecrawl-search in raw-search tier
- [x] Live test: `librarium run "what is librarium" --providers firecrawl-search` returns 10 citations with content
- [x] Deep review: fixed 2 stale provider count references (17→18)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `firecrawl-search` provider adapter integrating the Firecrawl v2 Search API (`POST /v2/search`), registers it in the `raw`, `fast`, and `all` default groups, and updates all count references from 17→18. The implementation correctly maps the nested `{ success, data: { web: [] }, error }` response shape and follows the same patterns as the existing `jina-search` and `tavily` adapters. Both concerns raised in the previous review (untruncated citation snippet, unused `markdown` field) have been resolved in this version.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — the adapter is correctly implemented with no P0 or P1 issues.

Both concerns from the previous review cycle (untruncated citation snippet, unused `markdown` interface field) were resolved. The response shape mapping matches the Firecrawl v2 API docs, error handling and fallbacks are consistent with sibling adapters, and all count/group references are updated correctly. No blocking issues remain.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/adapters/firecrawl-search.ts | New adapter correctly models the Firecrawl v2 `{ data: { web: [] } }` response shape, truncates citation snippets to 200 chars, and implements execute/test following established patterns. |
| src/adapters/index.ts | Imports and registers `FirecrawlSearchProvider` in the correct position; comment updated to 18 providers. |
| src/constants.ts | Env var, display name, and default group memberships (`raw`, `fast`, `all`) correctly added for `firecrawl-search`. |
| tests/registry.test.ts | Provider count bumped to 18 and `firecrawl-search` ID assertion added; no issues. |
| README.md | Provider table, group table, and count all updated consistently. |
| CHANGELOG.md | Unreleased entry added for the new provider; no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant FirecrawlSearchProvider
    participant FirecrawlAPI as Firecrawl v2 API

    Caller->>FirecrawlSearchProvider: execute(query, options)
    FirecrawlSearchProvider->>FirecrawlSearchProvider: getApiKey()
    FirecrawlSearchProvider->>FirecrawlAPI: POST /v2/search {query, limit:10, sources:['web']}
    alt HTTP error (non-200)
        FirecrawlAPI-->>FirecrawlSearchProvider: 4xx/5xx
        FirecrawlSearchProvider-->>Caller: ProviderResult { error }
    else API-level error
        FirecrawlAPI-->>FirecrawlSearchProvider: 200 { error: ... }
        FirecrawlSearchProvider-->>Caller: ProviderResult { error }
    else Success
        FirecrawlAPI-->>FirecrawlSearchProvider: 200 { success:true, data:{ web:[...] } }
        FirecrawlSearchProvider->>FirecrawlSearchProvider: extractCitations(results) + buildContent(results)
        FirecrawlSearchProvider-->>Caller: ProviderResult { content, citations }
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: truncate snippet and remove unused ..."](https://github.com/jkudish/librarium/commit/91ccd888e4406ffd29f38f42ba89c432083cf36c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28113869)</sub>

<!-- /greptile_comment -->