### PR TITLE
release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,5 +75,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.3...HEAD
 [0.1.3]: https://github.com/jkudish/librarium/compare/v0.1.2...v0.1.3
 [0.1.0]: https://github.com/jkudish/librarium/releases/tag/v0.1.0
-[0.1.1]: https://github.com/jkudish/librarium/releases/tag/v0.1.1
-[0.1.2]: https://github.com/jkudish/librarium/releases/tag/v0.1.2
+[0.1.1]: https://github.com/jkudish/librarium/compare/v0.1.0...v0.1.1
+[0.1.2]: https://github.com/jkudish/librarium/compare/v0.1.1...v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-04-11
+
 ### Added
 - Firecrawl Search provider adapter: `firecrawl-search` — web search via Firecrawl v2 Search API (raw-search tier)
 - OpenAI Deep Research (o3) provider adapter: `openai-deep-o3` — higher-quality deep research using the o3-deep-research model
@@ -70,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API keys use environment variable references, never stored in plaintext
 - Response size guard (10MB) on HTTP client
 
-[Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/jkudish/librarium/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/jkudish/librarium/compare/v0.1.2...v0.1.3
 [0.1.0]: https://github.com/jkudish/librarium/releases/tag/v0.1.0
 [0.1.1]: https://github.com/jkudish/librarium/releases/tag/v0.1.1
 [0.1.2]: https://github.com/jkudish/librarium/releases/tag/v0.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to 0.1.3
- Update CHANGELOG with release date and comparison links

### What's new in v0.1.3

- **Firecrawl Search** provider adapter (`firecrawl-search`) — web search via Firecrawl v2 Search API (raw-search tier)
- Added to `raw`, `fast`, and `all` default groups
- Env var: `FIRECRAWL_API_KEY`

## Test plan

- [x] All 100 tests pass
- [x] Build succeeds

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR releases v0.1.3 by bumping the version in `package.json` and `package-lock.json`, adding a dated CHANGELOG entry for v0.1.3, and fixing the comparison links for prior versions (`0.1.1`, `0.1.2`) to use the `compare/` URL format for consistency. All version strings are in sync and the link structure is correct.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a clean version bump with no code changes, only versioning and CHANGELOG updates.

All three changed files are in sync at v0.1.3, the CHANGELOG links are now consistent, and there are no logic, security, or dependency changes introduced.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | v0.1.3 entry added with correct date; comparison links for 0.1.1 and 0.1.2 updated to `compare/` format; 0.1.0 correctly retains `releases/tag` as the initial version |
| package.json | Version bumped to 0.1.3, consistent with CHANGELOG and package-lock.json; no dependency changes |
| package-lock.json | Lockfile version updated to 0.1.3 to match package.json; no dependency tree changes |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #16 merged: firecrawl-search feature] --> B[Bump version to 0.1.3]
    B --> C[Update package.json]
    B --> D[Update package-lock.json]
    B --> E[Update CHANGELOG.md]
    E --> E1[Add dated v0.1.3 entry]
    E --> E2[Add Unreleased compare link]
    E --> E3[Fix 0.1.1 & 0.1.2 links to compare/ format]
    C & D & E --> F[Release v0.1.3]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: use consistent compare links in CHA..."](https://github.com/jkudish/librarium/commit/4748e88293704e92ea0f565c72cede7728ebd7f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28114687)</sub>

<!-- /greptile_comment -->