### PR TITLE
Live per-provider results table for librarium run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Live per-provider results table for `librarium run`: each provider prints an aligned status line as it finishes (✓ success / ✗ error with reason / ◷ async-submitted), with tier, duration, and source/result counts, plus an indented `↳ falling back to …` notice when a fallback fires
+- Resolve-in-place rendering in interactive terminals: all provider rows print at fan-out with an animated spinner glyph and ticking elapsed time, then update in place as results arrive (non-TTY and NO_COLOR environments keep append-on-completion output)
 - End-of-run summary with `▸` unique-source and output-directory lines, and a `librarium status --wait` hint when async tasks are pending
+- Wall-clock total on the tallies line (`4 succeeded, 0 failed, 0 async pending in 13.3s`) and a yellow highlight on provider durations of 10s or more
+- `librarium run --open`: opens the output directory when the run completes (`open` on macOS, `xdg-open` on Linux)
+- `librarium status --wait` / `--retrieve` now render retrieved results with the same table line format as `run`, with the output file and word count as a dim suffix
 - Dispatcher progress events now include the provider report on `error` and `async-submitted` events (additive — `ProgressEvent.report` was already optional)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Live per-provider results table for `librarium run`: each provider prints an aligned status line as it finishes (✓ success / ✗ error with reason / ◷ async-submitted), with tier, duration, and source/result counts, plus an indented `↳ falling back to …` notice when a fallback fires
+- End-of-run summary with `▸` unique-source and output-directory lines, and a `librarium status --wait` hint when async tasks are pending
+- Dispatcher progress events now include the provider report on `error` and `async-submitted` events (additive — `ProgressEvent.report` was already optional)
+
+### Changed
+- `librarium run --json` now keeps stdout pure JSON: all pretty/table output is routed to stderr in that mode
+
 ## [0.2.0] - 2026-06-11
 
 ### Added

--- a/src/commands/live-table.ts
+++ b/src/commands/live-table.ts
@@ -1,0 +1,207 @@
+import type { ProviderReport, ProviderTier } from '../types.js';
+import {
+  formatFallbackNotice,
+  formatPendingLine,
+  formatProviderLine,
+  type LineWidths,
+  truncateAnsi,
+} from './run-format.js';
+
+/**
+ * In-place (resolve-as-they-finish) renderer for the `librarium run` table.
+ *
+ * All provider rows are printed up front with an animated spinner glyph,
+ * then each row is rewritten in place as its provider resolves. The whole
+ * block is re-rendered on every update (cursor up N, clear line, rewrite),
+ * which keeps fallback-row insertion trivial. Rows are truncated to the
+ * terminal width so wrapped lines never break the cursor math.
+ *
+ * Only used when the pretty stream is a TTY and color is enabled; non-TTY
+ * and NO_COLOR environments keep the append-on-completion output.
+ */
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const FRAME_INTERVAL_MS = 80;
+const HIDE_CURSOR = '\u001b[?25l';
+const SHOW_CURSOR = '\u001b[?25h';
+
+interface ProviderRow {
+  kind: 'provider';
+  id: string;
+  tier: ProviderTier;
+  fallbackFor?: string;
+  startedAt?: number;
+  resolvedLine?: string;
+}
+
+interface NoticeRow {
+  kind: 'notice';
+  text: string;
+}
+
+type Row = ProviderRow | NoticeRow;
+
+interface LiveStream {
+  write(chunk: string): unknown;
+  columns?: number;
+}
+
+export class LiveRunTable {
+  private rows: Row[] = [];
+  private renderedLines = 0;
+  private timer: NodeJS.Timeout | undefined;
+  private frameIndex = 0;
+  private active = false;
+  private readonly restoreCursorOnExit = (): void => {
+    if (this.active) this.stream.write(SHOW_CURSOR);
+  };
+
+  constructor(
+    private readonly stream: LiveStream,
+    private readonly widths: LineWidths,
+    private readonly color: boolean,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /** Register a provider row (call once per primary before start()). */
+  addProvider(id: string, tier: ProviderTier): void {
+    this.rows.push({ kind: 'provider', id, tier });
+  }
+
+  /** Print the initial block and start the spinner animation. */
+  start(): void {
+    this.active = true;
+    this.stream.write(HIDE_CURSOR);
+    process.once('exit', this.restoreCursorOnExit);
+    this.render();
+    this.timer = setInterval(() => {
+      this.frameIndex = (this.frameIndex + 1) % SPINNER_FRAMES.length;
+      this.render();
+    }, FRAME_INTERVAL_MS);
+  }
+
+  /** Mark a provider as actually running (starts its elapsed ticker). */
+  markStarted(id: string): void {
+    const row = this.findPending(id);
+    if (row) row.startedAt = this.now();
+    this.render();
+  }
+
+  /** Insert the fallback notice and a pending fallback row under the failed primary. */
+  addFallback(primaryId: string, fallbackId: string, tier: ProviderTier): void {
+    const index = this.rows.findIndex(
+      (row) =>
+        row.kind === 'provider' && row.id === primaryId && !row.fallbackFor,
+    );
+    const notice: NoticeRow = {
+      kind: 'notice',
+      text: formatFallbackNotice(fallbackId, this.color),
+    };
+    const fallbackRow: ProviderRow = {
+      kind: 'provider',
+      id: fallbackId,
+      tier,
+      fallbackFor: primaryId,
+      startedAt: this.now(),
+    };
+    if (index === -1) {
+      this.rows.push(notice, fallbackRow);
+    } else {
+      this.rows.splice(index + 1, 0, notice, fallbackRow);
+    }
+    this.render();
+  }
+
+  /** Resolve a provider row with its final report line. */
+  resolve(report: ProviderReport): void {
+    const row = this.rows.find(
+      (candidate): candidate is ProviderRow =>
+        candidate.kind === 'provider' &&
+        candidate.id === report.id &&
+        (candidate.fallbackFor ?? null) === (report.fallbackFor ?? null) &&
+        candidate.resolvedLine === undefined,
+    );
+    const line = formatProviderLine(report, this.widths, this.color);
+    if (row) {
+      row.resolvedLine = line;
+    } else {
+      this.rows.push({
+        kind: 'provider',
+        id: report.id,
+        tier: report.tier,
+        fallbackFor: report.fallbackFor,
+        resolvedLine: line,
+      });
+    }
+    this.render();
+  }
+
+  /**
+   * Resolve any rows that never received a progress event (e.g. skipped
+   * providers) from the final reports. Call before stop().
+   */
+  resolveRemaining(reports: ProviderReport[]): void {
+    for (const row of this.rows) {
+      if (row.kind !== 'provider' || row.resolvedLine !== undefined) continue;
+      const report = reports.find(
+        (candidate) =>
+          candidate.id === row.id &&
+          (candidate.fallbackFor ?? null) === (row.fallbackFor ?? null),
+      );
+      if (report) {
+        row.resolvedLine = formatProviderLine(report, this.widths, this.color);
+      }
+    }
+    this.render();
+  }
+
+  /** Stop the animation and leave the final block printed. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.render();
+    this.stream.write(SHOW_CURSOR);
+    this.active = false;
+    process.removeListener('exit', this.restoreCursorOnExit);
+  }
+
+  private findPending(id: string): ProviderRow | undefined {
+    return this.rows.find(
+      (row): row is ProviderRow =>
+        row.kind === 'provider' &&
+        row.id === id &&
+        row.resolvedLine === undefined,
+    );
+  }
+
+  private lineFor(row: Row): string {
+    if (row.kind === 'notice') return row.text;
+    if (row.resolvedLine !== undefined) return row.resolvedLine;
+    const frame = SPINNER_FRAMES[this.frameIndex] as string;
+    const elapsed =
+      row.startedAt === undefined ? undefined : this.now() - row.startedAt;
+    return formatPendingLine(
+      row.id,
+      row.tier,
+      this.widths,
+      this.color,
+      frame,
+      elapsed,
+    );
+  }
+
+  private render(): void {
+    const maxWidth = Math.max(20, (this.stream.columns ?? 80) - 1);
+    let out = '';
+    if (this.renderedLines > 0) {
+      out += `\u001b[${this.renderedLines}A`;
+    }
+    for (const row of this.rows) {
+      out += `\u001b[2K${truncateAnsi(this.lineFor(row), maxWidth)}\n`;
+    }
+    this.stream.write(out);
+    this.renderedLines = this.rows.length;
+  }
+}

--- a/src/commands/run-format.ts
+++ b/src/commands/run-format.ts
@@ -151,7 +151,7 @@ export function formatRunSummary(input: RunSummaryInput): string[] {
     lines.push('');
     lines.push(
       paint(
-        '  ◷ async tasks pending — run `librarium status --wait` to poll and retrieve',
+        '  ◷ async tasks pending: run `librarium status --wait` to poll and retrieve',
         ANSI.yellow,
         input.color,
       ),

--- a/src/commands/run-format.ts
+++ b/src/commands/run-format.ts
@@ -10,8 +10,12 @@ const ANSI = {
   red: '\u001b[31m',
   green: '\u001b[32m',
   yellow: '\u001b[33m',
+  cyan: '\u001b[36m',
   dim: '\u001b[2m',
 } as const;
+
+/** Durations at or above this threshold are highlighted in color mode. */
+export const SLOW_DURATION_MS = 10_000;
 
 /**
  * Decide whether to emit ANSI colors for a given stream.
@@ -78,7 +82,11 @@ export function formatProviderLine(
     ANSI.dim,
     color,
   );
-  const duration = formatDuration(report.durationMs).padStart(7);
+  // Highlight slow providers so they pop in the table.
+  const duration =
+    report.durationMs >= SLOW_DURATION_MS
+      ? paint(formatDuration(report.durationMs).padStart(7), ANSI.yellow, color)
+      : formatDuration(report.durationMs).padStart(7);
   const fallbackSuffix = report.fallbackFor
     ? `   ${paint(`(fallback for ${report.fallbackFor})`, ANSI.dim, color)}`
     : '';
@@ -103,6 +111,81 @@ export function formatProviderLine(
       return `  ${glyph} ${id}   ${tier}   ${duration}   ${reason}${fallbackSuffix}`;
     }
   }
+}
+
+/** Dim a piece of text (no-op when color is disabled). */
+export function dimText(text: string, color: boolean): string {
+  return paint(text, ANSI.dim, color);
+}
+
+/**
+ * Format an unresolved provider row for the live (in-place) table.
+ * The glyph slot shows a spinner frame; the duration column ticks while
+ * the provider runs, or shows "queued" before it starts.
+ */
+export function formatPendingLine(
+  id: string,
+  tier: ProviderTier,
+  widths: LineWidths,
+  color: boolean,
+  frame: string,
+  elapsedMs?: number,
+): string {
+  const paddedId = id.padEnd(Math.max(widths.id, id.length));
+  const paddedTier = paint(
+    tier.padEnd(Math.max(widths.tier, tier.length)),
+    ANSI.dim,
+    color,
+  );
+  const glyph = paint(frame, ANSI.cyan, color);
+  const status =
+    elapsedMs === undefined
+      ? paint('queued', ANSI.dim, color)
+      : paint(formatDuration(elapsedMs).padStart(7), ANSI.dim, color);
+  return `  ${glyph} ${paddedId}   ${paddedTier}   ${status}`;
+}
+
+/**
+ * Truncate a line to a maximum visible width, preserving ANSI escape
+ * sequences (they don't count toward the width). Appends a reset when the
+ * line is cut so styling never bleeds into the next line.
+ */
+export function truncateAnsi(line: string, maxWidth: number): string {
+  if (maxWidth <= 0) return '';
+  let visible = 0;
+  let out = '';
+  let i = 0;
+  let sawAnsi = false;
+  let truncated = false;
+  while (i < line.length) {
+    const char = line[i];
+    if (char === '\u001b') {
+      // Copy the full escape sequence (ESC [ ... final byte) without counting.
+      let j = i + 1;
+      if (line[j] === '[') {
+        j++;
+        while (j < line.length && !/[a-zA-Z]/.test(line[j] as string)) j++;
+        j++; // include the final byte
+      }
+      out += line.slice(i, j);
+      sawAnsi = true;
+      i = j;
+      continue;
+    }
+    if (visible >= maxWidth) {
+      // Drop remaining visible chars but keep scanning for ANSI resets.
+      truncated = true;
+      i++;
+      continue;
+    }
+    out += char;
+    visible++;
+    i++;
+  }
+  if (truncated && sawAnsi && !out.endsWith(ANSI.reset)) {
+    out += ANSI.reset;
+  }
+  return out;
 }
 
 /** Indented notice printed when a failed primary triggers its fallback. */
@@ -131,14 +214,20 @@ export interface RunSummaryInput {
   outputDir: string;
   color: boolean;
   home?: string;
+  /** Wall-clock duration of the whole dispatch, in milliseconds. */
+  totalDurationMs?: number;
 }
 
 /** End-of-run summary block (returned as individual lines). */
 export function formatRunSummary(input: RunSummaryInput): string[] {
   const lines: string[] = [''];
+  const total =
+    input.totalDurationMs === undefined
+      ? ''
+      : ` in ${formatDuration(input.totalDurationMs)}`;
   lines.push(
     paint(
-      `  ${input.succeeded} succeeded, ${input.failed} failed, ${input.pending} async pending`,
+      `  ${input.succeeded} succeeded, ${input.failed} failed, ${input.pending} async pending${total}`,
       ANSI.dim,
       input.color,
     ),

--- a/src/commands/run-format.ts
+++ b/src/commands/run-format.ts
@@ -1,0 +1,161 @@
+import type { ProviderReport, ProviderTier } from '../types.js';
+
+/**
+ * Pure formatting helpers for the `librarium run` live results table.
+ * No I/O here — everything returns strings so it stays trivially testable.
+ */
+
+const ANSI = {
+  reset: '\u001b[0m',
+  red: '\u001b[31m',
+  green: '\u001b[32m',
+  yellow: '\u001b[33m',
+  dim: '\u001b[2m',
+} as const;
+
+/**
+ * Decide whether to emit ANSI colors for a given stream.
+ * Honors NO_COLOR / FORCE_COLOR and falls back to TTY detection.
+ */
+export function isColorEnabled(
+  stream: { isTTY?: boolean },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.NO_COLOR) return false;
+  if (env.FORCE_COLOR && env.FORCE_COLOR !== '0') return true;
+  return Boolean(stream.isTTY);
+}
+
+function paint(text: string, code: string, color: boolean): string {
+  return color ? `${code}${text}${ANSI.reset}` : text;
+}
+
+/** Column widths so provider lines align across the whole run. */
+export interface LineWidths {
+  id: number;
+  tier: number;
+}
+
+export function computeLineWidths(
+  ids: string[],
+  tiers: ProviderTier[],
+): LineWidths {
+  return {
+    id: Math.max(0, ...ids.map((id) => id.length)),
+    tier: Math.max(0, ...tiers.map((tier) => tier.length)),
+  };
+}
+
+export function formatDuration(durationMs: number): string {
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function citationLabel(report: ProviderReport): string {
+  const noun = report.tier === 'raw-search' ? 'results' : 'sources';
+  return `${String(report.citationCount).padStart(3)} ${noun}`;
+}
+
+function compactError(error: string | undefined, maxLength = 80): string {
+  const flat = (error ?? 'unknown error').replace(/\s+/g, ' ').trim();
+  return flat.length > maxLength ? `${flat.slice(0, maxLength - 1)}…` : flat;
+}
+
+/**
+ * Format one provider's result as a table line:
+ *
+ *   ✓ perplexity-sonar-pro   ai-grounded      2.1s    12 sources
+ *   ✗ brave-search           raw-search       0.3s   HTTP 401 Unauthorized
+ *   ◷ openai-deep            deep-research   submitted
+ */
+export function formatProviderLine(
+  report: ProviderReport,
+  widths: LineWidths,
+  color: boolean,
+): string {
+  const id = report.id.padEnd(Math.max(widths.id, report.id.length));
+  const tier = paint(
+    report.tier.padEnd(Math.max(widths.tier, report.tier.length)),
+    ANSI.dim,
+    color,
+  );
+  const duration = formatDuration(report.durationMs).padStart(7);
+  const fallbackSuffix = report.fallbackFor
+    ? `   ${paint(`(fallback for ${report.fallbackFor})`, ANSI.dim, color)}`
+    : '';
+
+  switch (report.status) {
+    case 'success': {
+      const glyph = paint('✓', ANSI.green, color);
+      return `  ${glyph} ${id}   ${tier}   ${duration}   ${citationLabel(report)}${fallbackSuffix}`;
+    }
+    case 'async-pending': {
+      const glyph = paint('◷', ANSI.yellow, color);
+      return `  ${glyph} ${id}   ${tier}   ${paint('submitted', ANSI.yellow, color)}`;
+    }
+    case 'skipped': {
+      const glyph = paint('-', ANSI.dim, color);
+      return `  ${glyph} ${id}   ${tier}   ${paint('skipped', ANSI.dim, color)}`;
+    }
+    default: {
+      // error / timeout
+      const glyph = paint('✗', ANSI.red, color);
+      const reason = paint(compactError(report.error), ANSI.red, color);
+      return `  ${glyph} ${id}   ${tier}   ${duration}   ${reason}${fallbackSuffix}`;
+    }
+  }
+}
+
+/** Indented notice printed when a failed primary triggers its fallback. */
+export function formatFallbackNotice(
+  fallbackId: string,
+  color: boolean,
+): string {
+  return `    ${paint(`↳ falling back to ${fallbackId}`, ANSI.yellow, color)}`;
+}
+
+/** Replace the home directory prefix with ~ for display. */
+export function shortenHomePath(
+  path: string,
+  home: string | undefined = process.env.HOME,
+): string {
+  if (home && path.startsWith(home)) return `~${path.slice(home.length)}`;
+  return path;
+}
+
+export interface RunSummaryInput {
+  succeeded: number;
+  failed: number;
+  pending: number;
+  uniqueSources: number;
+  totalCitations: number;
+  outputDir: string;
+  color: boolean;
+  home?: string;
+}
+
+/** End-of-run summary block (returned as individual lines). */
+export function formatRunSummary(input: RunSummaryInput): string[] {
+  const lines: string[] = [''];
+  lines.push(
+    paint(
+      `  ${input.succeeded} succeeded, ${input.failed} failed, ${input.pending} async pending`,
+      ANSI.dim,
+      input.color,
+    ),
+  );
+  lines.push(
+    `  ▸ ${input.uniqueSources} unique sources after dedupe (${input.totalCitations} total citations)`,
+  );
+  lines.push(`  ▸ ${shortenHomePath(input.outputDir, input.home)}/`);
+  if (input.pending > 0) {
+    lines.push('');
+    lines.push(
+      paint(
+        '  ◷ async tasks pending — run `librarium status --wait` to poll and retrieve',
+        ANSI.yellow,
+        input.color,
+      ),
+    );
+  }
+  return lines;
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { Command } from 'commander';
@@ -26,6 +27,7 @@ import type {
   ProviderTier,
   RunManifest,
 } from '../types.js';
+import { LiveRunTable } from './live-table.js';
 import {
   computeLineWidths,
   formatFallbackNotice,
@@ -50,6 +52,7 @@ export function registerRunCommand(program: Command): void {
     .option('--parallel <n>', 'Max parallel requests', Number.parseInt)
     .option('--timeout <n>', 'Timeout per provider in seconds', Number.parseInt)
     .option('--json', 'Output run.json to stdout')
+    .option('--open', 'Open the output directory when the run completes')
     .action(async (query: string, opts) => {
       // In --json mode stdout must stay pure JSON (the run manifest), so all
       // pretty output is routed to stderr. The ora spinner already writes to
@@ -158,6 +161,13 @@ export function registerRunCommand(program: Command): void {
           tableIds.map((id) => tierById.get(id) ?? 'raw-search'),
         );
 
+        // Live (resolve-in-place) rendering needs a real TTY for the cursor
+        // math; NO_COLOR and non-TTY environments keep append-on-completion.
+        const liveMode = color && Boolean(prettyStream.isTTY);
+        const live = liveMode
+          ? new LiveRunTable(prettyStream, widths, color)
+          : null;
+
         const running = new Set<string>();
         const spinnerText = (): string => {
           if (running.size === 0) return 'Waiting for providers...';
@@ -169,8 +179,16 @@ export function registerRunCommand(program: Command): void {
         printLine('');
         printLine(`  fanning out to ${providerIds.length} providers`);
         printLine('');
-        spinner.start(spinnerText());
+        if (live) {
+          for (const id of providerIds) {
+            live.addProvider(id, tierById.get(id) ?? 'raw-search');
+          }
+          live.start();
+        } else {
+          spinner.start(spinnerText());
+        }
 
+        const dispatchStartedAt = Date.now();
         const { reports, results, asyncTasks } = await dispatch({
           config,
           providerIds,
@@ -178,6 +196,26 @@ export function registerRunCommand(program: Command): void {
           mode: config.defaults.mode,
           credentials,
           onProgress: (event) => {
+            if (live) {
+              switch (event.event) {
+                case 'started':
+                  live.markStarted(event.providerId);
+                  break;
+                case 'fallback-started':
+                  live.addFallback(
+                    event.report?.id ?? event.providerId,
+                    event.providerId,
+                    tierById.get(event.providerId) ?? 'raw-search',
+                  );
+                  break;
+                case 'completed':
+                case 'error':
+                case 'async-submitted':
+                  if (event.report) live.resolve(event.report);
+                  break;
+              }
+              return;
+            }
             switch (event.event) {
               case 'started':
                 running.add(event.providerId);
@@ -198,13 +236,21 @@ export function registerRunCommand(program: Command): void {
             spinner.text = spinnerText();
           },
         });
+        const totalDurationMs = Date.now() - dispatchStartedAt;
 
         spinner.stop();
 
-        // Skipped providers never emit progress events — show them too.
-        for (const report of reports) {
-          if (report.status === 'skipped') {
-            printLine(formatProviderLine(report, widths, color));
+        if (live) {
+          // Rows that never emitted events (e.g. skipped providers) resolve
+          // from the final reports before the block is finalized.
+          live.resolveRemaining(reports);
+          live.stop();
+        } else {
+          // Skipped providers never emit progress events — show them too.
+          for (const report of reports) {
+            if (report.status === 'skipped') {
+              printLine(formatProviderLine(report, widths, color));
+            }
           }
         }
 
@@ -301,6 +347,7 @@ export function registerRunCommand(program: Command): void {
           totalCitations: allCitations.length,
           outputDir,
           color,
+          totalDurationMs,
         })) {
           printLine(line);
         }
@@ -309,12 +356,37 @@ export function registerRunCommand(program: Command): void {
           console.log(JSON.stringify(manifest, null, 2));
         }
 
+        if (opts.open && exitCode !== 2) {
+          openPath(outputDir);
+        }
+
         process.exitCode = exitCode;
       } catch (e) {
         spinner.fail(e instanceof Error ? e.message : String(e));
         process.exitCode = 2;
       }
     });
+}
+
+/** Open a file or directory with the platform opener. Failures are silent. */
+function openPath(target: string): void {
+  const command =
+    process.platform === 'darwin'
+      ? 'open'
+      : process.platform === 'linux'
+        ? 'xdg-open'
+        : null;
+  if (!command) return;
+  try {
+    const child = spawn(command, [target], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // Best-effort only.
+  }
 }
 
 function writeProviderOutputs(

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -23,8 +23,16 @@ import type {
   Defaults,
   ProviderDispatchResult,
   ProviderReport,
+  ProviderTier,
   RunManifest,
 } from '../types.js';
+import {
+  computeLineWidths,
+  formatFallbackNotice,
+  formatProviderLine,
+  formatRunSummary,
+  isColorEnabled,
+} from './run-format.js';
 
 export function registerRunCommand(program: Command): void {
   program
@@ -43,7 +51,18 @@ export function registerRunCommand(program: Command): void {
     .option('--timeout <n>', 'Timeout per provider in seconds', Number.parseInt)
     .option('--json', 'Output run.json to stdout')
     .action(async (query: string, opts) => {
+      // In --json mode stdout must stay pure JSON (the run manifest), so all
+      // pretty output is routed to stderr. The ora spinner already writes to
+      // stderr and no-ops in non-TTY environments.
+      const prettyStream = opts.json ? process.stderr : process.stdout;
+      const color = isColorEnabled(prettyStream);
       const spinner = ora('Initializing providers...').start();
+      const printLine = (line: string): void => {
+        const wasSpinning = spinner.isSpinning;
+        if (wasSpinning) spinner.stop();
+        prettyStream.write(`${line}\n`);
+        if (wasSpinning) spinner.start();
+      };
 
       try {
         const globalConfig = loadConfig();
@@ -125,7 +144,32 @@ export function registerRunCommand(program: Command): void {
         // Write prompt
         safeWriteFile(join(outputDir, 'prompt.md'), buildPrompt(query));
 
-        spinner.text = `Dispatching to ${providerIds.length} providers...`;
+        // Column widths cover both primaries and any configured fallbacks so
+        // lines stay aligned if a fallback fires mid-run.
+        const tierById = new Map<string, ProviderTier>(
+          getAllProviders().map((provider) => [provider.id, provider.tier]),
+        );
+        const fallbackIds = providerIds
+          .map((id) => config.providers[id]?.fallback)
+          .filter((id): id is string => Boolean(id && tierById.has(id)));
+        const tableIds = [...new Set([...providerIds, ...fallbackIds])];
+        const widths = computeLineWidths(
+          tableIds,
+          tableIds.map((id) => tierById.get(id) ?? 'raw-search'),
+        );
+
+        const running = new Set<string>();
+        const spinnerText = (): string => {
+          if (running.size === 0) return 'Waiting for providers...';
+          const names = [...running].join(', ');
+          return `running: ${names.length > 60 ? `${names.slice(0, 59)}…` : names}`;
+        };
+
+        spinner.stop();
+        printLine('');
+        printLine(`  fanning out to ${providerIds.length} providers`);
+        printLine('');
+        spinner.start(spinnerText());
 
         const { reports, results, asyncTasks } = await dispatch({
           config,
@@ -134,15 +178,35 @@ export function registerRunCommand(program: Command): void {
           mode: config.defaults.mode,
           credentials,
           onProgress: (event) => {
-            if (event.event === 'started') {
-              spinner.text = `Running: ${event.providerId}...`;
-            } else if (event.event === 'completed') {
-              spinner.text = `Completed: ${event.providerId}`;
-            } else if (event.event === 'fallback-started') {
-              spinner.text = `Falling back: ${event.report?.id} → ${event.providerId}...`;
+            switch (event.event) {
+              case 'started':
+                running.add(event.providerId);
+                break;
+              case 'fallback-started':
+                printLine(formatFallbackNotice(event.providerId, color));
+                running.add(event.providerId);
+                break;
+              case 'completed':
+              case 'error':
+              case 'async-submitted':
+                running.delete(event.providerId);
+                if (event.report) {
+                  printLine(formatProviderLine(event.report, widths, color));
+                }
+                break;
             }
+            spinner.text = spinnerText();
           },
         });
+
+        spinner.stop();
+
+        // Skipped providers never emit progress events — show them too.
+        for (const report of reports) {
+          if (report.status === 'skipped') {
+            printLine(formatProviderLine(report, widths, color));
+          }
+        }
 
         writeProviderOutputs(outputDir, reports, results);
 
@@ -221,8 +285,6 @@ export function registerRunCommand(program: Command): void {
         });
         safeWriteFile(join(outputDir, 'summary.md'), summary);
 
-        spinner.succeed(`Research complete: ${outputDir}`);
-
         // Print summary (exclude recovered primaries so they don't show as failures)
         const successful = effectiveReports.filter(
           (r) => r.status === 'success',
@@ -231,12 +293,17 @@ export function registerRunCommand(program: Command): void {
         const pending = effectiveReports.filter(
           (r) => r.status === 'async-pending',
         );
-        console.log(
-          `  ${successful.length} succeeded, ${failed.length} failed, ${pending.length} async pending`,
-        );
-        console.log(
-          `  ${sources.length} unique sources from ${allCitations.length} total citations`,
-        );
+        for (const line of formatRunSummary({
+          succeeded: successful.length,
+          failed: failed.length,
+          pending: pending.length,
+          uniqueSources: sources.length,
+          totalCitations: allCitations.length,
+          outputDir,
+          color,
+        })) {
+          printLine(line);
+        }
 
         if (opts.json) {
           console.log(JSON.stringify(manifest, null, 2));

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -12,7 +12,14 @@ import {
 } from '../core/async-manager.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import { safeWriteFile } from '../core/fs-utils.js';
-import type { AsyncTaskHandle } from '../types.js';
+import type { AsyncTaskHandle, ProviderReport } from '../types.js';
+import {
+  computeLineWidths,
+  dimText,
+  formatProviderLine,
+  isColorEnabled,
+  type LineWidths,
+} from './run-format.js';
 
 function formatTaskAge(submittedAt: number): string {
   // submittedAt is in milliseconds
@@ -27,10 +34,20 @@ function formatTaskStatus(task: AsyncTaskHandle): string {
   return `  ${task.provider} | Task: ${task.taskId.slice(0, 20)}... | Status: ${task.status} | Submitted: ${formatTaskAge(task.submittedAt)}`;
 }
 
+/** Column widths across a set of async tasks so result lines align. */
+function widthsForTasks(tasks: AsyncTaskHandle[]): LineWidths {
+  return computeLineWidths(
+    tasks.map((task) => task.provider),
+    tasks.map((task) => getProvider(task.provider)?.tier ?? 'deep-research'),
+  );
+}
+
 async function retrieveTask(
   task: AsyncTaskHandle,
   dir: string,
   spinner: ReturnType<typeof ora>,
+  widths: LineWidths,
+  color: boolean,
 ): Promise<boolean> {
   const provider = getProvider(task.provider);
   if (!provider?.retrieve) {
@@ -70,10 +87,30 @@ async function retrieveTask(
 
     const words = result.content.split(/\s+/).filter(Boolean).length;
     const cites = result.citations.length;
-    spinner.text = `Retrieved ${task.provider} -> ${outputFile} (${words} words, ${cites} citations)`;
+    spinner.text = `Retrieved ${task.provider} -> ${outputFile}`;
+
+    // Render the retrieved result with the same table line as `librarium run`,
+    // with the retrieval details as a dim suffix.
+    const report: ProviderReport = {
+      id: task.provider,
+      tier: result.tier,
+      status: result.error ? 'error' : 'success',
+      durationMs: result.durationMs,
+      wordCount: words,
+      citationCount: cites,
+      outputFile,
+      metaFile,
+      error: result.error,
+    };
+    const wasSpinning = spinner.isSpinning;
+    if (wasSpinning) spinner.stop();
     console.log(
-      `  Retrieved ${task.provider} -> ${outputFile} (${words} words, ${cites} citations)`,
+      `${formatProviderLine(report, widths, color)}   ${dimText(
+        `${outputFile}, ${words} words`,
+        color,
+      )}`,
     );
+    if (wasSpinning) spinner.start();
     return true;
   } catch (e) {
     spinner.text = `Error retrieving ${task.provider}: ${e instanceof Error ? e.message : String(e)}`;
@@ -101,6 +138,7 @@ export function registerStatusCommand(program: Command): void {
           console.error(`[librarium] warning: ${warning}`);
         }
         const baseDir = resolve(config.defaults.outputDir);
+        const color = isColorEnabled(process.stdout);
 
         // Gather all async tasks (pending + completed unretrieved)
         const pendingTasks = getPendingTasks(baseDir);
@@ -181,7 +219,29 @@ export function registerStatusCommand(program: Command): void {
                   if (result.status === 'completed' && task.outputDir) {
                     justCompleted.push({ task, dir: task.outputDir });
                   }
-                  spinner.text = `${task.provider}: ${result.status}${result.message ? ` — ${result.message}` : ''}`;
+                  if (result.status === 'failed') {
+                    const failureReport: ProviderReport = {
+                      id: task.provider,
+                      tier: getProvider(task.provider)?.tier ?? 'deep-research',
+                      status: 'error',
+                      durationMs: 0,
+                      wordCount: 0,
+                      citationCount: 0,
+                      outputFile: '',
+                      metaFile: '',
+                      error: result.message ?? 'task failed',
+                    };
+                    spinner.stop();
+                    console.log(
+                      formatProviderLine(
+                        failureReport,
+                        widthsForTasks(pendingTasks),
+                        color,
+                      ),
+                    );
+                    spinner.start();
+                  }
+                  spinner.text = `${task.provider}: ${result.status}${result.message ? `: ${result.message}` : ''}`;
                 } else {
                   const progress = result.progress
                     ? ` (${result.progress}%)`
@@ -215,9 +275,16 @@ export function registerStatusCommand(program: Command): void {
             const retrieveSpinner = ora(
               `Retrieving ${justCompleted.length} results...`,
             ).start();
+            const widths = widthsForTasks(justCompleted.map((c) => c.task));
             let retrieved = 0;
             for (const { task, dir } of justCompleted) {
-              const ok = await retrieveTask(task, dir, retrieveSpinner);
+              const ok = await retrieveTask(
+                task,
+                dir,
+                retrieveSpinner,
+                widths,
+                color,
+              );
               if (ok) retrieved++;
             }
             retrieveSpinner.succeed(
@@ -232,6 +299,8 @@ export function registerStatusCommand(program: Command): void {
           const entries = readdirSync(baseDir);
           let retrieved = 0;
 
+          // Collect all completed tasks first so table columns align.
+          const toRetrieve: Array<{ task: AsyncTaskHandle; dir: string }> = [];
           for (const entry of entries) {
             const dir = join(baseDir, entry);
             try {
@@ -241,12 +310,15 @@ export function registerStatusCommand(program: Command): void {
             }
 
             const tasks = loadAsyncTasks(dir);
-            const completed = tasks.filter((t) => t.status === 'completed');
-
-            for (const task of completed) {
-              const ok = await retrieveTask(task, dir, spinner);
-              if (ok) retrieved++;
+            for (const task of tasks) {
+              if (task.status === 'completed') toRetrieve.push({ task, dir });
             }
+          }
+
+          const widths = widthsForTasks(toRetrieve.map((c) => c.task));
+          for (const { task, dir } of toRetrieve) {
+            const ok = await retrieveTask(task, dir, spinner, widths, color);
+            if (ok) retrieved++;
           }
 
           if (retrieved > 0) {

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -206,7 +206,7 @@ export async function dispatch(
             reports.push(report);
 
             if (result.error) {
-              onProgress?.({ providerId: id, event: 'error' });
+              onProgress?.({ providerId: id, event: 'error', report });
               const fallbackReport = await tryFallback(id, report);
               if (fallbackReport) {
                 reports.push(fallbackReport);
@@ -220,6 +220,7 @@ export async function dispatch(
                   onProgress?.({
                     providerId: fallbackReport.id,
                     event: 'error',
+                    report: fallbackReport,
                   });
                 }
               }
@@ -243,7 +244,7 @@ export async function dispatch(
             citations: [],
             durationMs: 0,
           });
-          reports.push({
+          const pendingReport: ProviderReport = {
             id,
             tier: provider.tier,
             status: 'async-pending',
@@ -252,8 +253,13 @@ export async function dispatch(
             citationCount: 0,
             outputFile: '',
             metaFile: '',
+          };
+          reports.push(pendingReport);
+          onProgress?.({
+            providerId: id,
+            event: 'async-submitted',
+            report: pendingReport,
           });
-          onProgress?.({ providerId: id, event: 'async-submitted' });
           return;
         } catch {
           // Fall through to sync execution
@@ -273,7 +279,7 @@ export async function dispatch(
 
         // If provider returned an error result (e.g. 401/403), attempt fallback
         if (result.error) {
-          onProgress?.({ providerId: id, event: 'error' });
+          onProgress?.({ providerId: id, event: 'error', report });
           const fallbackReport = await tryFallback(id, report);
           if (fallbackReport) {
             reports.push(fallbackReport);
@@ -287,6 +293,7 @@ export async function dispatch(
               onProgress?.({
                 providerId: fallbackReport.id,
                 event: 'error',
+                report: fallbackReport,
               });
             }
           }
@@ -317,7 +324,7 @@ export async function dispatch(
           error,
         };
         reports.push(errorReport);
-        onProgress?.({ providerId: id, event: 'error' });
+        onProgress?.({ providerId: id, event: 'error', report: errorReport });
 
         // Attempt fallback
         const fallbackReport = await tryFallback(id, errorReport);
@@ -330,7 +337,11 @@ export async function dispatch(
               report: fallbackReport,
             });
           } else {
-            onProgress?.({ providerId: fallbackReport.id, event: 'error' });
+            onProgress?.({
+              providerId: fallbackReport.id,
+              event: 'error',
+              report: fallbackReport,
+            });
           }
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,5 +234,7 @@ export interface ProgressEvent {
     | 'error'
     | 'async-submitted'
     | 'fallback-started';
+  // Populated on 'completed', 'error', and 'async-submitted' (the report for
+  // providerId) and on 'fallback-started' (the failed primary's error report).
   report?: ProviderReport;
 }

--- a/tests/live-table.test.ts
+++ b/tests/live-table.test.ts
@@ -47,6 +47,7 @@ describe('LiveRunTable', () => {
     table.markStarted('exa'); // triggers first render (2 rows, no cursor-up)
     const first = stream.chunks.at(-1) as string;
     expect(first.startsWith(CLEAR_LINE)).toBe(true);
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI clear-line escapes
     expect(first.match(/\u001b\[2K/g)).toHaveLength(2);
     expect(first).toContain('exa');
     expect(first).toContain('queued'); // brave-search not started yet
@@ -121,6 +122,7 @@ describe('LiveRunTable', () => {
       }),
     );
     const render = stream.chunks.at(-1) as string;
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escapes
     const visible = render.replace(/\u001b\[[0-9;?]*[a-zA-Z]/g, '');
     for (const line of visible.split('\n')) {
       expect(line.length).toBeLessThanOrEqual(29);

--- a/tests/live-table.test.ts
+++ b/tests/live-table.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { LiveRunTable } from '../src/commands/live-table.js';
+import { computeLineWidths } from '../src/commands/run-format.js';
+import type { ProviderReport } from '../src/types.js';
+
+const CURSOR_UP = (n: number) => `\u001b[${n}A`;
+const CLEAR_LINE = '\u001b[2K';
+
+function makeStream(columns = 120) {
+  const chunks: string[] = [];
+  return {
+    chunks,
+    write(chunk: string) {
+      chunks.push(chunk);
+      return true;
+    },
+    columns,
+  };
+}
+
+function makeReport(overrides: Partial<ProviderReport> = {}): ProviderReport {
+  return {
+    id: 'exa',
+    tier: 'ai-grounded',
+    status: 'success',
+    durationMs: 1800,
+    wordCount: 100,
+    citationCount: 25,
+    outputFile: 'exa.md',
+    metaFile: 'exa.meta.json',
+    ...overrides,
+  };
+}
+
+const widths = computeLineWidths(
+  ['exa', 'brave-search'],
+  ['ai-grounded', 'raw-search'],
+);
+
+describe('LiveRunTable', () => {
+  it('renders one cleared line per row and moves the cursor up on re-render', () => {
+    const stream = makeStream();
+    const table = new LiveRunTable(stream, widths, false);
+    table.addProvider('exa', 'ai-grounded');
+    table.addProvider('brave-search', 'raw-search');
+
+    table.markStarted('exa'); // triggers first render (2 rows, no cursor-up)
+    const first = stream.chunks.at(-1) as string;
+    expect(first.startsWith(CLEAR_LINE)).toBe(true);
+    expect(first.match(/\u001b\[2K/g)).toHaveLength(2);
+    expect(first).toContain('exa');
+    expect(first).toContain('queued'); // brave-search not started yet
+
+    table.resolve(makeReport());
+    const second = stream.chunks.at(-1) as string;
+    expect(second.startsWith(CURSOR_UP(2))).toBe(true);
+    expect(second).toContain('25 sources');
+  });
+
+  it('inserts fallback notice and row under the failed primary', () => {
+    const stream = makeStream();
+    const table = new LiveRunTable(stream, widths, false);
+    table.addProvider('exa', 'ai-grounded');
+    table.addProvider('brave-search', 'raw-search');
+    table.markStarted('exa');
+
+    table.addFallback('exa', 'tavily', 'raw-search');
+    const render = stream.chunks.at(-1) as string;
+    const lines = render.split('\n');
+    expect(lines[0]).toContain('exa');
+    expect(lines[1]).toContain('falling back to tavily');
+    expect(lines[2]).toContain('tavily');
+    expect(lines[3]).toContain('brave-search');
+  });
+
+  it('resolves the fallback row, not the primary, for fallback reports', () => {
+    const stream = makeStream();
+    const table = new LiveRunTable(stream, widths, false);
+    table.addProvider('exa', 'ai-grounded');
+    table.addFallback('exa', 'tavily', 'raw-search');
+
+    table.resolve(
+      makeReport({ id: 'tavily', tier: 'raw-search', fallbackFor: 'exa' }),
+    );
+    const render = stream.chunks.at(-1) as string;
+    const lines = render.split('\n');
+    // Primary row still pending (spinner frame), fallback row resolved.
+    expect(lines[0]).not.toContain('✓');
+    expect(lines[2]).toContain('✓');
+    expect(lines[2]).toContain('(fallback for exa)');
+  });
+
+  it('resolveRemaining fills rows that never got events', () => {
+    const stream = makeStream();
+    const table = new LiveRunTable(stream, widths, false);
+    table.addProvider('exa', 'ai-grounded');
+    table.addProvider('brave-search', 'raw-search');
+    table.resolve(makeReport());
+
+    table.resolveRemaining([
+      makeReport(),
+      makeReport({
+        id: 'brave-search',
+        tier: 'raw-search',
+        status: 'skipped',
+        error: 'Provider not enabled',
+      }),
+    ]);
+    const render = stream.chunks.at(-1) as string;
+    expect(render).toContain('skipped');
+  });
+
+  it('truncates rows to the stream width', () => {
+    const stream = makeStream(30);
+    const table = new LiveRunTable(stream, widths, false);
+    table.addProvider('exa', 'ai-grounded');
+    table.resolve(
+      makeReport({
+        status: 'error',
+        error: 'a very long error message that would normally wrap the line',
+      }),
+    );
+    const render = stream.chunks.at(-1) as string;
+    const visible = render.replace(/\u001b\[[0-9;?]*[a-zA-Z]/g, '');
+    for (const line of visible.split('\n')) {
+      expect(line.length).toBeLessThanOrEqual(29);
+    }
+  });
+});

--- a/tests/run-format.test.ts
+++ b/tests/run-format.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
   computeLineWidths,
+  dimText,
   formatDuration,
   formatFallbackNotice,
+  formatPendingLine,
   formatProviderLine,
   formatRunSummary,
   isColorEnabled,
   shortenHomePath,
+  truncateAnsi,
 } from '../src/commands/run-format.js';
 import type { ProviderReport } from '../src/types.js';
 
@@ -229,5 +232,110 @@ describe('isColorEnabled', () => {
     expect(isColorEnabled({ isTTY: true }, {})).toBe(true);
     expect(isColorEnabled({ isTTY: false }, {})).toBe(false);
     expect(isColorEnabled({}, {})).toBe(false);
+  });
+});
+
+describe('slow duration highlight', () => {
+  it('paints durations at or above 10s yellow in color mode', () => {
+    const line = formatProviderLine(
+      makeReport({ durationMs: 12_345 }),
+      widths,
+      true,
+    );
+    expect(line).toContain('\u001b[33m  12.3s\u001b[0m');
+  });
+
+  it('leaves fast durations unpainted in color mode', () => {
+    const line = formatProviderLine(
+      makeReport({ durationMs: 2_100 }),
+      widths,
+      true,
+    );
+    expect(line).not.toContain('\u001b[33m');
+  });
+
+  it('emits no ANSI for slow durations when color is off', () => {
+    const line = formatProviderLine(
+      makeReport({ durationMs: 12_345 }),
+      widths,
+      false,
+    );
+    expect(line).toContain('  12.3s');
+    expect(line).not.toContain('\u001b');
+  });
+});
+
+describe('formatPendingLine', () => {
+  it('shows queued before the provider starts', () => {
+    const line = formatPendingLine(
+      'exa',
+      'ai-grounded',
+      widths,
+      false,
+      '\u280b',
+    );
+    expect(line).toBe('  \u280b exa                    ai-grounded     queued');
+  });
+
+  it('ticks elapsed time once started', () => {
+    const line = formatPendingLine(
+      'exa',
+      'ai-grounded',
+      widths,
+      false,
+      '\u280b',
+      2_300,
+    );
+    expect(line).toContain('2.3s');
+  });
+});
+
+describe('truncateAnsi', () => {
+  it('returns short lines unchanged', () => {
+    expect(truncateAnsi('hello', 10)).toBe('hello');
+  });
+
+  it('truncates visible characters to the max width', () => {
+    expect(truncateAnsi('hello world', 5)).toBe('hello');
+  });
+
+  it('does not count ANSI sequences toward the width', () => {
+    const line = '\u001b[32mhello\u001b[0m world';
+    expect(truncateAnsi(line, 11)).toBe(line);
+  });
+
+  it('appends a reset when cutting a styled line', () => {
+    const line = '\u001b[32mhello world\u001b[0m';
+    const cut = truncateAnsi(line, 5);
+    expect(cut).toBe('\u001b[32mhello\u001b[0m');
+  });
+
+  it('handles zero width', () => {
+    expect(truncateAnsi('hello', 0)).toBe('');
+  });
+});
+
+describe('dimText', () => {
+  it('wraps in dim ANSI when color is on and is a no-op otherwise', () => {
+    expect(dimText('x', true)).toBe('\u001b[2mx\u001b[0m');
+    expect(dimText('x', false)).toBe('x');
+  });
+});
+
+describe('wall-clock total', () => {
+  it('appends the total duration to the tallies line', () => {
+    const lines = formatRunSummary({
+      succeeded: 4,
+      failed: 0,
+      pending: 0,
+      uniqueSources: 10,
+      totalCitations: 12,
+      outputDir: '/srv/out',
+      color: false,
+      totalDurationMs: 13_300,
+    });
+    expect(lines).toContain(
+      '  4 succeeded, 0 failed, 0 async pending in 13.3s',
+    );
   });
 });

--- a/tests/run-format.test.ts
+++ b/tests/run-format.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeLineWidths,
+  formatDuration,
+  formatFallbackNotice,
+  formatProviderLine,
+  formatRunSummary,
+  isColorEnabled,
+  shortenHomePath,
+} from '../src/commands/run-format.js';
+import type { ProviderReport } from '../src/types.js';
+
+function makeReport(overrides: Partial<ProviderReport> = {}): ProviderReport {
+  return {
+    id: 'perplexity-sonar-pro',
+    tier: 'ai-grounded',
+    status: 'success',
+    durationMs: 2100,
+    wordCount: 500,
+    citationCount: 12,
+    outputFile: 'perplexity-sonar-pro.md',
+    metaFile: 'perplexity-sonar-pro.meta.json',
+    ...overrides,
+  };
+}
+
+const widths = computeLineWidths(
+  ['perplexity-sonar-pro', 'exa', 'brave-search', 'openai-deep'],
+  ['ai-grounded', 'ai-grounded', 'raw-search', 'deep-research'],
+);
+
+describe('computeLineWidths', () => {
+  it('returns the longest id and tier lengths', () => {
+    expect(widths).toEqual({
+      id: 'perplexity-sonar-pro'.length,
+      tier: 'deep-research'.length,
+    });
+  });
+
+  it('handles empty input', () => {
+    expect(computeLineWidths([], [])).toEqual({ id: 0, tier: 0 });
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats milliseconds as seconds with one decimal', () => {
+    expect(formatDuration(2100)).toBe('2.1s');
+    expect(formatDuration(900)).toBe('0.9s');
+    expect(formatDuration(0)).toBe('0.0s');
+  });
+});
+
+describe('formatProviderLine', () => {
+  it('formats a successful ai-grounded provider with "sources"', () => {
+    const line = formatProviderLine(makeReport(), widths, false);
+    expect(line).toBe(
+      '  ✓ perplexity-sonar-pro   ai-grounded        2.1s    12 sources',
+    );
+  });
+
+  it('uses "results" for raw-search providers', () => {
+    const line = formatProviderLine(
+      makeReport({
+        id: 'brave-search',
+        tier: 'raw-search',
+        durationMs: 900,
+        citationCount: 20,
+      }),
+      widths,
+      false,
+    );
+    expect(line).toBe(
+      '  ✓ brave-search           raw-search         0.9s    20 results',
+    );
+  });
+
+  it('aligns lines across providers of different lengths', () => {
+    const a = formatProviderLine(makeReport(), widths, false);
+    const b = formatProviderLine(
+      makeReport({ id: 'exa', citationCount: 9 }),
+      widths,
+      false,
+    );
+    expect(a.indexOf('ai-grounded')).toBe(b.indexOf('ai-grounded'));
+    expect(a.indexOf('sources')).toBe(b.indexOf('sources'));
+  });
+
+  it('formats async-pending as submitted without duration', () => {
+    const line = formatProviderLine(
+      makeReport({
+        id: 'openai-deep',
+        tier: 'deep-research',
+        status: 'async-pending',
+        durationMs: 0,
+        citationCount: 0,
+      }),
+      widths,
+      false,
+    );
+    expect(line).toBe('  ◷ openai-deep            deep-research   submitted');
+  });
+
+  it('formats errors with the failure reason', () => {
+    const line = formatProviderLine(
+      makeReport({
+        id: 'exa',
+        status: 'error',
+        durationMs: 300,
+        citationCount: 0,
+        error: 'HTTP 401 Unauthorized',
+      }),
+      widths,
+      false,
+    );
+    expect(line).toBe(
+      '  ✗ exa                    ai-grounded        0.3s   HTTP 401 Unauthorized',
+    );
+  });
+
+  it('flattens and truncates long error messages', () => {
+    const line = formatProviderLine(
+      makeReport({ status: 'error', error: `boom\n${'x'.repeat(200)}` }),
+      widths,
+      false,
+    );
+    expect(line).not.toContain('\n');
+    expect(line).toContain('boom x');
+    expect(line.length).toBeLessThan(140);
+    expect(line).toContain('…');
+  });
+
+  it('marks fallback results with the primary they recovered', () => {
+    const line = formatProviderLine(
+      makeReport({ id: 'exa', fallbackFor: 'openai-deep' }),
+      widths,
+      false,
+    );
+    expect(line).toContain('(fallback for openai-deep)');
+  });
+
+  it('formats skipped providers', () => {
+    const line = formatProviderLine(
+      makeReport({ status: 'skipped', error: 'Provider not enabled' }),
+      widths,
+      false,
+    );
+    expect(line).toContain('skipped');
+    expect(line.trimStart().startsWith('-')).toBe(true);
+  });
+
+  it('wraps glyphs in ANSI colors when color is enabled', () => {
+    const ok = formatProviderLine(makeReport(), widths, true);
+    expect(ok).toContain('\u001b[32m✓\u001b[0m');
+    const err = formatProviderLine(
+      makeReport({ status: 'error', error: 'nope' }),
+      widths,
+      true,
+    );
+    expect(err).toContain('\u001b[31m✗\u001b[0m');
+  });
+});
+
+describe('formatFallbackNotice', () => {
+  it('renders an indented arrow line', () => {
+    expect(formatFallbackNotice('openai-deep', false)).toBe(
+      '    ↳ falling back to openai-deep',
+    );
+  });
+});
+
+describe('shortenHomePath', () => {
+  it('replaces the home prefix with ~', () => {
+    expect(shortenHomePath('/home/joey/research/run-1', '/home/joey')).toBe(
+      '~/research/run-1',
+    );
+  });
+
+  it('leaves non-home paths untouched', () => {
+    expect(shortenHomePath('/srv/research', '/home/joey')).toBe(
+      '/srv/research',
+    );
+  });
+});
+
+describe('formatRunSummary', () => {
+  it('includes counts, dedupe line, and output dir', () => {
+    const lines = formatRunSummary({
+      succeeded: 5,
+      failed: 0,
+      pending: 0,
+      uniqueSources: 74,
+      totalCitations: 96,
+      outputDir: '/home/joey/research/run-1',
+      color: false,
+      home: '/home/joey',
+    });
+    expect(lines).toContain('  5 succeeded, 0 failed, 0 async pending');
+    expect(lines).toContain(
+      '  ▸ 74 unique sources after dedupe (96 total citations)',
+    );
+    expect(lines).toContain('  ▸ ~/research/run-1/');
+    expect(lines.join('\n')).not.toContain('librarium status');
+  });
+
+  it('adds the librarium status hint when async tasks are pending', () => {
+    const lines = formatRunSummary({
+      succeeded: 4,
+      failed: 1,
+      pending: 1,
+      uniqueSources: 10,
+      totalCitations: 12,
+      outputDir: '/srv/out',
+      color: false,
+    });
+    expect(lines.join('\n')).toContain('librarium status --wait');
+  });
+});
+
+describe('isColorEnabled', () => {
+  it('disables color when NO_COLOR is set', () => {
+    expect(isColorEnabled({ isTTY: true }, { NO_COLOR: '1' })).toBe(false);
+  });
+
+  it('enables color when FORCE_COLOR is set even without a TTY', () => {
+    expect(isColorEnabled({ isTTY: false }, { FORCE_COLOR: '1' })).toBe(true);
+  });
+
+  it('falls back to TTY detection', () => {
+    expect(isColorEnabled({ isTTY: true }, {})).toBe(true);
+    expect(isColorEnabled({ isTTY: false }, {})).toBe(false);
+    expect(isColorEnabled({}, {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the single mutating spinner line with a live results table: one line per provider, printed the moment that provider finishes, while an ora spinner below tracks what's still running.

```
$ librarium run "postgres pooling best practices"

  fanning out to 6 providers

  ◷ openai-deep            deep-research   submitted
  ✓ brave-search           raw-search         0.9s    20 results
  ✗ tavily                 raw-search         0.0s   HTTP 401 Unauthorized
    ↳ falling back to jina-search
  ✓ exa                    ai-grounded        1.8s    25 sources
  ✓ jina-search            raw-search         0.7s     8 results   (fallback for tavily)
  ✓ perplexity-sonar-pro   ai-grounded        2.1s    12 sources
  ✓ gemini-grounded        ai-grounded        3.4s     9 sources

  5 succeeded, 0 failed, 1 async pending
  ▸ 74 unique sources after dedupe (74 total citations)
  ▸ ~/research/agents/librarium/1781220116-postgres-pooling-best-practices/

  ◷ async tasks pending: run `librarium status --wait` to poll and retrieve
```

- ✓ green / ✗ red (compacted reason inline) / ◷ yellow / skipped dim; `raw-search` counts say *results*, AI tiers say *sources*; columns pad to the longest id+tier in the run including configured fallbacks.
- Fallback recovery is visible: failed primary line, indented `↳` notice, then the fallback's own line with `(fallback for …)`.
- New `src/commands/run-format.ts` with pure formatting helpers + 21 unit tests; minimal ANSI handling honoring `NO_COLOR`/`FORCE_COLOR`/TTY (no new dependency).
- `dispatch()` now attaches the provider report to `error` and `async-submitted` progress events (additive only; `completed` already carried it) — backward-compatible for `librarium/core` embedders.
- `--json` mode: stdout is now pure JSON; all pretty output goes to stderr. This also fixes a pre-existing leak where the old summary lines printed to stdout before the manifest.
- Behavior unchanged: exit codes, recovered-primary accounting, and output file writing are untouched.

Presentation-only counterpart to the website's hero terminal demo (librarium-site), which mirrors this format.

## Testing

- 123/123 unit tests (incl. 21 new for formatting), Biome, tsc, tsup build all green.
- Smoke-tested the built CLI with mock script providers across success / error / fallback / async paths; verified progressive printing, non-TTY degradation, and machine-clean `--json` stdout.