### PR TITLE
docs: Node 20.12 minimum + lock engines sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Librarium is both a **CLI** and an **embeddable library**: `import { dispatch } 
 
 ## Installation
 
-### npm (requires Node.js >= 20)
+### npm (requires Node.js >= 20.12)
 
 ```bash
 npm install -g librarium

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "wrangler": "^4.100.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.12"
       }
     },
     "node_modules/@biomejs/biome": {


### PR DESCRIPTION
Follow-up to the 0.2.0 merge: the engines field moved to >=20.12 (@clack/prompts requirement) but the README install section and package-lock root entry still said >=20. Docs-only.