### PR TITLE
librarium clear: bulk and interactive result cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `librarium clear` and `librarium cleanup --all`: delete every run directory regardless of age (one implementation, two names). In a terminal `--all` shows an interactive confirm with run count and total size on disk before deleting; in a non-TTY context it refuses unless `--yes` is passed. `--dry-run` lists what would go (count, total size, oldest/newest) without deleting, and deletion reports a human-readable freed-space figure
+- `librarium clear -i` / `cleanup -i`: interactive multiselect of runs (date, query, size, pending-async marker) to delete exactly the chosen ones with a confirm. Runs with pending async tasks are flagged in the list hint and called out in the confirm, since deleting one orphans the server-side task handle
+- Cleanup safety guards: every candidate path is verified to be strictly inside the resolved output base dir before removal, and the command refuses to operate when the base dir resolves to your home directory or a filesystem root
 - Live per-provider results table for `librarium run`: each provider prints an aligned status line as it finishes (✓ success / ✗ error with reason / ◷ async-submitted), with tier, duration, and source/result counts, plus an indented `↳ falling back to …` notice when a fallback fires
 - Resolve-in-place rendering in interactive terminals: all provider rows print at fan-out with an animated spinner glyph and ticking elapsed time, then update in place as results arrive (non-TTY and NO_COLOR environments keep append-on-completion output)
 - End-of-run summary with `▸` unique-source and output-directory lines, and a `librarium status --wait` hint when async tasks are pending

--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ librarium config --json
 
 ### `cleanup`
 
-Remove old output directories.
+Remove output directories. By default deletes runs older than 30 days; `--all`
+deletes every run regardless of age.
 
 ```bash
 # Delete directories older than 30 days (default)
@@ -368,8 +369,42 @@ librarium cleanup
 # Custom age threshold
 librarium cleanup --days 7
 
-# Preview what would be deleted
+# Preview what would be deleted (count, total size, oldest/newest)
 librarium cleanup --dry-run
+
+# Delete every run directory (interactive confirm in a TTY)
+librarium cleanup --all
+
+# Pick exactly which runs to delete from a checklist
+librarium cleanup -i
+
+# JSON output and an alternate output base dir
+librarium cleanup --all --json -o ./agents/librarium
+```
+
+In a terminal, `--all` prompts for confirmation (showing run count and total
+size on disk) before deleting. In a non-interactive context (pipe, CI), pass
+`--yes` to confirm, otherwise the command refuses to delete. Runs that still
+have pending async tasks are flagged in the list and confirm, since deleting
+them orphans the server-side task handle. The command never deletes anything
+outside the resolved output base directory and refuses to operate if that
+directory resolves to your home directory or a filesystem root.
+
+### `clear`
+
+Alias for `librarium cleanup --all`: deletes every run directory. Same flags
+pass through (`--dry-run`, `-i`/`--interactive`, `--yes`, `-o`/`--output`,
+`--json`).
+
+```bash
+# Delete all runs (interactive confirm in a TTY, --yes required in non-TTY)
+librarium clear
+
+# Preview everything that would be removed
+librarium clear --dry-run
+
+# Interactively pick which runs to clear
+librarium clear -i
 ```
 
 ## Groups

--- a/SKILL.md
+++ b/SKILL.md
@@ -80,6 +80,8 @@ Combine findings from multiple providers into a coherent answer. Cross-reference
 | `librarium ls` | List providers and status |
 | `librarium doctor` | Health check providers |
 | `librarium config` | Show resolved config |
+| `librarium cleanup [--days N] [--dry-run]` | Delete run dirs older than N days (default 30) |
+| `librarium clear [--dry-run] [-i] [--yes]` | Delete all run dirs (alias for `cleanup --all`); `-i` to pick interactively |
 
 ## Provider Tiers
 

--- a/src/commands/cleanup-data.ts
+++ b/src/commands/cleanup-data.ts
@@ -1,0 +1,245 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, parse, resolve, sep } from 'node:path';
+import type { AsyncTaskHandle, RunManifest } from '../types.js';
+import { isRunManifest } from './browse-data.js';
+
+/**
+ * Pure helpers for `librarium cleanup` / `librarium clear`: candidate
+ * discovery, size computation, path-safety guards, and pending-async
+ * detection. No interactive or filesystem-mutating code lives here so all
+ * of it stays unit-testable.
+ */
+
+export interface CleanupCandidate {
+  /** Absolute path to the run directory. */
+  dir: string;
+  /** Directory basename. */
+  name: string;
+  /** Run timestamp in ms (from dir name, falling back to mtime). */
+  timeMs: number;
+  /** Whole-day age relative to now. */
+  ageDays: number;
+  /** Total size on disk in bytes. */
+  size: number;
+  /** Query string when a run.json manifest was parseable, else null. */
+  query: string | null;
+  /** True when the run still has pending/running async tasks. */
+  pendingAsync: boolean;
+}
+
+/**
+ * Recursively sum the size in bytes of all files under a directory.
+ */
+export function getDirSize(dirPath: string): number {
+  let size = 0;
+  try {
+    for (const entry of readdirSync(dirPath)) {
+      const fullPath = join(dirPath, entry);
+      try {
+        const stat = statSync(fullPath);
+        if (stat.isFile()) {
+          size += stat.size;
+        } else if (stat.isDirectory()) {
+          size += getDirSize(fullPath);
+        }
+      } catch {
+        // Skip unreadable entries.
+      }
+    }
+  } catch {
+    // Skip unreadable directory.
+  }
+  return size;
+}
+
+/** Human-readable byte size, e.g. "1.4 MB". */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/**
+ * Detect whether a run directory still has pending or running async tasks.
+ * Checks async-tasks.json first (authoritative), falling back to the
+ * run.json provider statuses when the async file is absent.
+ */
+export function hasPendingAsync(dir: string): boolean {
+  const tasksPath = join(dir, 'async-tasks.json');
+  if (existsSync(tasksPath)) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(tasksPath, 'utf-8'));
+      if (Array.isArray(parsed)) {
+        return (parsed as AsyncTaskHandle[]).some(
+          (t) =>
+            t != null && (t.status === 'pending' || t.status === 'running'),
+        );
+      }
+    } catch {
+      // Fall through to manifest check.
+    }
+  }
+
+  const manifestPath = join(dir, 'run.json');
+  if (existsSync(manifestPath)) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+      if (isRunManifest(parsed)) {
+        return (parsed as RunManifest).providers.some(
+          (provider) => provider.status === 'async-pending',
+        );
+      }
+    } catch {
+      // Ignore corrupt manifest.
+    }
+  }
+  return false;
+}
+
+function readQuery(dir: string): string | null {
+  const manifestPath = join(dir, 'run.json');
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    if (isRunManifest(parsed)) return (parsed as RunManifest).query;
+  } catch {
+    // Ignore corrupt manifest.
+  }
+  return null;
+}
+
+export interface DiscoverOptions {
+  /** When true, every run directory is a candidate regardless of age. */
+  all?: boolean;
+  /** Age threshold in days; only used when `all` is false. */
+  days?: number;
+  /** Clock injection for deterministic tests. */
+  now?: number;
+}
+
+/**
+ * Discover run directories under the resolved base dir. With `all`, every
+ * directory qualifies; otherwise only directories older than `days`.
+ * Sorted newest first.
+ */
+export function discoverCandidates(
+  baseDir: string,
+  opts: DiscoverOptions = {},
+): CleanupCandidate[] {
+  if (!existsSync(baseDir)) return [];
+  const now = opts.now ?? Date.now();
+  const all = opts.all ?? false;
+  const days = opts.days ?? 30;
+  const cutoffMs = now - days * 24 * 60 * 60 * 1000;
+
+  const candidates: CleanupCandidate[] = [];
+  for (const name of readdirSync(baseDir)) {
+    const dir = join(baseDir, name);
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+
+    // Run dirs are named "{unix-seconds}-{slug}".
+    const match = name.match(/^(\d+)-/);
+    const timeMs = match ? Number.parseInt(match[1], 10) * 1000 : stat.mtimeMs;
+
+    if (!all && timeMs >= cutoffMs) continue;
+
+    candidates.push({
+      dir,
+      name,
+      timeMs,
+      ageDays: Math.floor((now - timeMs) / (24 * 60 * 60 * 1000)),
+      size: getDirSize(dir),
+      query: readQuery(dir),
+      pendingAsync: hasPendingAsync(dir),
+    });
+  }
+
+  candidates.sort((a, b) => b.timeMs - a.timeMs);
+  return candidates;
+}
+
+/** Summary stats for a set of candidates (count, total size, age range). */
+export interface CandidateSummary {
+  count: number;
+  totalSize: number;
+  oldest: CleanupCandidate | null;
+  newest: CleanupCandidate | null;
+  pendingAsyncCount: number;
+}
+
+export function summarizeCandidates(
+  candidates: CleanupCandidate[],
+): CandidateSummary {
+  if (candidates.length === 0) {
+    return {
+      count: 0,
+      totalSize: 0,
+      oldest: null,
+      newest: null,
+      pendingAsyncCount: 0,
+    };
+  }
+  let totalSize = 0;
+  let oldest = candidates[0];
+  let newest = candidates[0];
+  let pendingAsyncCount = 0;
+  for (const c of candidates) {
+    totalSize += c.size;
+    if (c.timeMs < oldest.timeMs) oldest = c;
+    if (c.timeMs > newest.timeMs) newest = c;
+    if (c.pendingAsync) pendingAsyncCount += 1;
+  }
+  return {
+    count: candidates.length,
+    totalSize,
+    oldest,
+    newest,
+    pendingAsyncCount,
+  };
+}
+
+/**
+ * Refuse to operate when the resolved base dir is the user's home directory
+ * or a filesystem root. Returns a reason string when unsafe, else null.
+ */
+export function unsafeBaseDirReason(baseDir: string): string | null {
+  const resolved = resolve(baseDir);
+  const root = parse(resolved).root;
+  // Normalize away a trailing separator before comparing.
+  const normalized =
+    resolved.length > root.length && resolved.endsWith(sep)
+      ? resolved.slice(0, -sep.length)
+      : resolved;
+
+  if (normalized === root) {
+    return `Refusing to operate on a filesystem root (${resolved}).`;
+  }
+  if (normalized === resolve(homedir())) {
+    return `Refusing to operate on the home directory (${resolved}).`;
+  }
+  return null;
+}
+
+/**
+ * Verify a candidate path is strictly inside the resolved base dir. Guards
+ * against traversal (e.g. "../../etc") and symlink-style escapes by string
+ * containment after resolution. Returns true only when `candidate` is a
+ * proper descendant of `baseDir`.
+ */
+export function isInsideBaseDir(baseDir: string, candidate: string): boolean {
+  const base = resolve(baseDir);
+  const target = resolve(candidate);
+  if (target === base) return false; // never delete the base dir itself
+  const prefix = base.endsWith(sep) ? base : base + sep;
+  return target.startsWith(prefix);
+}

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -1,157 +1,307 @@
-import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as p from '@clack/prompts';
 import type { Command } from 'commander';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import { formatRunDate } from './browse-data.js';
+import {
+  type CleanupCandidate,
+  discoverCandidates,
+  formatSize,
+  isInsideBaseDir,
+  summarizeCandidates,
+  unsafeBaseDirReason,
+} from './cleanup-data.js';
+
+interface CleanupOptions {
+  days: number;
+  all?: boolean;
+  dryRun?: boolean;
+  interactive?: boolean;
+  yes?: boolean;
+  json?: boolean;
+  output?: string;
+}
 
 export function registerCleanupCommand(program: Command): void {
   program
     .command('cleanup')
-    .description('Remove old output directories')
+    .description(
+      'Remove output directories (old by default, or all with --all)',
+    )
     .option(
       '--days <n>',
       'Age threshold in days (default: 30)',
       Number.parseInt,
       30,
     )
+    .option('--all', 'Delete every run directory regardless of age')
+    .option('-i, --interactive', 'Pick which runs to delete from a list')
     .option('--dry-run', 'Show what would be deleted without deleting')
+    .option(
+      '--yes',
+      'Skip the confirmation prompt (required for --all in non-TTY)',
+    )
+    .option('-o, --output <dir>', 'Output base directory')
     .option('--json', 'Output JSON')
-    .action((opts) => {
-      try {
-        const globalConfig = loadConfig();
-        const projectConfig = loadProjectConfig(process.cwd());
-        const config = mergeConfigs(globalConfig, projectConfig);
-        const baseDir = resolve(config.defaults.outputDir);
+    .action(async (opts: CleanupOptions) => {
+      await runCleanup(opts);
+    });
 
-        if (!existsSync(baseDir)) {
-          if (opts.json) {
-            console.log(
-              JSON.stringify({
-                deleted: [],
-                message: 'Output directory does not exist',
-              }),
-            );
-          } else {
-            console.log(
-              'Output directory does not exist. Nothing to clean up.',
-            );
-          }
-          return;
-        }
-
-        const cutoffMs = Date.now() - opts.days * 24 * 60 * 60 * 1000;
-        const entries = readdirSync(baseDir);
-        const toDelete: Array<{ dir: string; age: string; size: number }> = [];
-
-        for (const entry of entries) {
-          const dirPath = join(baseDir, entry);
-          try {
-            const stat = statSync(dirPath);
-            if (!stat.isDirectory()) continue;
-
-            // Extract timestamp from directory name (format: {timestamp}-{slug})
-            const match = entry.match(/^(\d+)-/);
-            const dirTime = match
-              ? Number.parseInt(match[1], 10) * 1000
-              : stat.mtimeMs;
-
-            if (dirTime < cutoffMs) {
-              const ageDays = Math.floor(
-                (Date.now() - dirTime) / (24 * 60 * 60 * 1000),
-              );
-              toDelete.push({
-                dir: dirPath,
-                age: `${ageDays}d`,
-                size: getDirSize(dirPath),
-              });
-            }
-          } catch {}
-        }
-
-        if (toDelete.length === 0) {
-          if (opts.json) {
-            console.log(
-              JSON.stringify({ deleted: [], message: 'Nothing to clean up' }),
-            );
-          } else {
-            console.log(`No output directories older than ${opts.days} days.`);
-          }
-          return;
-        }
-
-        if (opts.json) {
-          if (!opts.dryRun) {
-            for (const item of toDelete) {
-              rmSync(item.dir, { recursive: true, force: true });
-            }
-          }
-          console.log(
-            JSON.stringify(
-              {
-                dryRun: !!opts.dryRun,
-                deleted: toDelete.map((d) => ({
-                  path: d.dir,
-                  age: d.age,
-                  sizeBytes: d.size,
-                })),
-              },
-              null,
-              2,
-            ),
-          );
-          return;
-        }
-
-        const totalSize = toDelete.reduce((sum, d) => sum + d.size, 0);
-        const sizeStr = formatSize(totalSize);
-
-        if (opts.dryRun) {
-          console.log(
-            `\nWould delete ${toDelete.length} directories (${sizeStr}):\n`,
-          );
-          for (const item of toDelete) {
-            console.log(
-              `  ${item.dir} (${item.age} old, ${formatSize(item.size)})`,
-            );
-          }
-          console.log('\nRun without --dry-run to delete.');
-        } else {
-          console.log(
-            `\nDeleting ${toDelete.length} directories (${sizeStr})...\n`,
-          );
-          for (const item of toDelete) {
-            rmSync(item.dir, { recursive: true, force: true });
-            console.log(`  Deleted: ${item.dir} (${item.age} old)`);
-          }
-          console.log('\nCleanup complete.');
-        }
-      } catch (e) {
-        console.error(e instanceof Error ? e.message : String(e));
-        process.exitCode = 1;
-      }
+  // `clear` is an alias for `cleanup --all`: one implementation, two names.
+  program
+    .command('clear')
+    .description('Delete all run directories (alias for `cleanup --all`)')
+    .option('-i, --interactive', 'Pick which runs to delete from a list')
+    .option('--dry-run', 'Show what would be deleted without deleting')
+    .option('--yes', 'Skip the confirmation prompt (required in non-TTY)')
+    .option('-o, --output <dir>', 'Output base directory')
+    .option('--json', 'Output JSON')
+    .action(async (opts: Omit<CleanupOptions, 'days' | 'all'>) => {
+      await runCleanup({ ...opts, all: true, days: 30 });
     });
 }
 
-function getDirSize(dirPath: string): number {
-  let size = 0;
+async function runCleanup(opts: CleanupOptions): Promise<void> {
   try {
-    const entries = readdirSync(dirPath);
-    for (const entry of entries) {
-      const fullPath = join(dirPath, entry);
-      const stat = statSync(fullPath);
-      if (stat.isFile()) {
-        size += stat.size;
-      } else if (stat.isDirectory()) {
-        size += getDirSize(fullPath);
+    const globalConfig = loadConfig();
+    const projectConfig = loadProjectConfig(process.cwd());
+    const config = mergeConfigs(globalConfig, projectConfig);
+    const baseDir = resolve(opts.output ?? config.defaults.outputDir);
+
+    // Safety: never operate on HOME or a filesystem root.
+    const unsafe = unsafeBaseDirReason(baseDir);
+    if (unsafe) {
+      printError(opts, unsafe);
+      process.exitCode = 1;
+      return;
+    }
+
+    const all = !!opts.all || !!opts.interactive;
+    const candidates = discoverCandidates(baseDir, { all, days: opts.days });
+
+    if (candidates.length === 0) {
+      const msg = opts.all
+        ? 'No run directories found.'
+        : `No output directories older than ${opts.days} days.`;
+      if (opts.json) {
+        console.log(JSON.stringify({ deleted: [], message: msg }));
+      } else {
+        console.log(msg);
+      }
+      return;
+    }
+
+    // Interactive selection takes precedence over bulk delete.
+    if (opts.interactive) {
+      await runInteractive(baseDir, candidates, opts);
+      return;
+    }
+
+    if (opts.json) {
+      handleJson(baseDir, candidates, opts);
+      return;
+    }
+
+    const summary = summarizeCandidates(candidates);
+
+    if (opts.dryRun) {
+      console.log(
+        `\nWould delete ${summary.count} ${plural(summary.count, 'directory', 'directories')} (${formatSize(summary.totalSize)}):\n`,
+      );
+      for (const c of candidates) {
+        console.log(`  ${describeLine(c)}`);
+      }
+      if (summary.oldest && summary.newest) {
+        console.log(
+          `\nOldest: ${formatRunDate(summary.oldest.timeMs / 1000)}  Newest: ${formatRunDate(summary.newest.timeMs / 1000)}`,
+        );
+      }
+      if (summary.pendingAsyncCount > 0) {
+        console.log(
+          `\nNote: ${summary.pendingAsyncCount} ${plural(summary.pendingAsyncCount, 'run has', 'runs have')} pending async tasks (deleting orphans the server-side task handle).`,
+        );
+      }
+      console.log('\nRun without --dry-run to delete.');
+      return;
+    }
+
+    // Destructive bulk delete. With --all, require an interactive confirm in a
+    // TTY or an explicit --yes in non-TTY.
+    if (opts.all && !opts.yes) {
+      if (process.stdout.isTTY && process.stdin.isTTY) {
+        const ok = await confirmDelete(summary);
+        if (!ok) {
+          console.log('Aborted.');
+          return;
+        }
+      } else {
+        printError(
+          opts,
+          'Refusing to delete all runs without confirmation. Re-run with --yes (or use --dry-run to preview).',
+        );
+        process.exitCode = 1;
+        return;
       }
     }
-  } catch {
-    // Skip on error
+
+    deleteCandidates(baseDir, candidates, summary, opts);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exitCode = 1;
   }
-  return size;
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+/** Interactive multiselect of runs, then confirm + delete the chosen ones. */
+async function runInteractive(
+  baseDir: string,
+  candidates: CleanupCandidate[],
+  opts: CleanupOptions,
+): Promise<void> {
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    printError(
+      opts,
+      'Interactive selection (-i) requires an interactive terminal.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  p.intro('librarium clear');
+  const selected = await p.multiselect<string>({
+    message: `Select runs to delete (${baseDir})`,
+    options: candidates.map((c) => ({
+      value: c.dir,
+      label: describeLine(c),
+      hint: c.pendingAsync
+        ? 'pending async tasks: deleting orphans the task handle'
+        : undefined,
+    })),
+    required: false,
+  });
+
+  if (p.isCancel(selected) || selected.length === 0) {
+    p.outro('Nothing selected.');
+    return;
+  }
+
+  const chosen = candidates.filter((c) => selected.includes(c.dir));
+  const summary = summarizeCandidates(chosen);
+  const ok = await confirmDelete(summary);
+  if (!ok) {
+    p.outro('Aborted.');
+    return;
+  }
+
+  let freed = 0;
+  let count = 0;
+  for (const c of chosen) {
+    if (!isInsideBaseDir(baseDir, c.dir)) continue;
+    rmSync(c.dir, { recursive: true, force: true, maxRetries: 3 });
+    freed += c.size;
+    count += 1;
+  }
+  p.outro(
+    `Deleted ${count} ${plural(count, 'directory', 'directories')}, freed ${formatSize(freed)}.`,
+  );
+}
+
+/** clack confirm that surfaces count, total size, and pending-async warnings. */
+async function confirmDelete(summary: {
+  count: number;
+  totalSize: number;
+  pendingAsyncCount: number;
+}): Promise<boolean> {
+  if (summary.pendingAsyncCount > 0) {
+    p.log.warn(
+      `${summary.pendingAsyncCount} ${plural(summary.pendingAsyncCount, 'run has', 'runs have')} pending async tasks. Deleting orphans the server-side task handle.`,
+    );
+  }
+  const answer = await p.confirm({
+    message: `Delete ${summary.count} ${plural(summary.count, 'directory', 'directories')} (${formatSize(summary.totalSize)})? This cannot be undone.`,
+    initialValue: false,
+  });
+  return !p.isCancel(answer) && answer === true;
+}
+
+function deleteCandidates(
+  baseDir: string,
+  candidates: CleanupCandidate[],
+  summary: { count: number; totalSize: number },
+  _opts: CleanupOptions,
+): void {
+  console.log(
+    `\nDeleting ${summary.count} ${plural(summary.count, 'directory', 'directories')} (${formatSize(summary.totalSize)})...\n`,
+  );
+  let freed = 0;
+  let count = 0;
+  for (const c of candidates) {
+    if (!isInsideBaseDir(baseDir, c.dir)) {
+      console.warn(`  Skipped (outside base dir): ${c.dir}`);
+      continue;
+    }
+    rmSync(c.dir, { recursive: true, force: true, maxRetries: 3 });
+    freed += c.size;
+    count += 1;
+    console.log(`  Deleted: ${c.dir} (${c.ageDays}d old)`);
+  }
+  console.log(`\nCleanup complete. Freed ${formatSize(freed)}.`);
+}
+
+function handleJson(
+  baseDir: string,
+  candidates: CleanupCandidate[],
+  opts: CleanupOptions,
+): void {
+  let freed = 0;
+  const safe: CleanupCandidate[] = [];
+  for (const c of candidates) {
+    if (!isInsideBaseDir(baseDir, c.dir)) continue;
+    safe.push(c);
+  }
+  if (!opts.dryRun) {
+    for (const c of safe) {
+      rmSync(c.dir, { recursive: true, force: true, maxRetries: 3 });
+      freed += c.size;
+    }
+  }
+  console.log(
+    JSON.stringify(
+      {
+        dryRun: !!opts.dryRun,
+        freedBytes: opts.dryRun ? 0 : freed,
+        deleted: safe.map((c) => ({
+          path: c.dir,
+          age: `${c.ageDays}d`,
+          sizeBytes: c.size,
+          query: c.query,
+          pendingAsync: c.pendingAsync,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function describeLine(c: CleanupCandidate): string {
+  const query = c.query ? truncate(c.query, 50) : '(no manifest)';
+  const flag = c.pendingAsync ? ' [pending async]' : '';
+  return `${formatRunDate(c.timeMs / 1000)}  ${query}  (${c.ageDays}d, ${formatSize(c.size)})${flag}`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
+}
+
+function printError(opts: CleanupOptions, message: string): void {
+  if (opts.json) {
+    console.log(JSON.stringify({ error: message }));
+  } else {
+    console.error(message);
+  }
 }

--- a/tests/cleanup-data.test.ts
+++ b/tests/cleanup-data.test.ts
@@ -1,0 +1,271 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, parse } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  discoverCandidates,
+  formatSize,
+  getDirSize,
+  hasPendingAsync,
+  isInsideBaseDir,
+  summarizeCandidates,
+  unsafeBaseDirReason,
+} from '../src/commands/cleanup-data.js';
+import type { AsyncTaskHandle, RunManifest } from '../src/types.js';
+
+let baseDir: string;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function makeManifest(overrides: Partial<RunManifest> = {}): RunManifest {
+  return {
+    version: 1,
+    timestamp: 1_781_136_000,
+    slug: 'postgres-pooling',
+    query: 'postgres pooling best practices',
+    mode: 'mixed',
+    outputDir: '/tmp/x',
+    providers: [
+      {
+        id: 'exa',
+        tier: 'ai-grounded',
+        status: 'success',
+        durationMs: 1800,
+        wordCount: 100,
+        citationCount: 25,
+        outputFile: 'exa.md',
+        metaFile: 'exa.meta.json',
+      },
+    ],
+    sources: { total: 25, unique: 20, file: 'sources.json' },
+    asyncTasks: [],
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+/** Create a run dir named "{unixSeconds}-{slug}" with optional files. */
+function makeRun(name: string, files: Record<string, string> = {}): string {
+  const dir = join(baseDir, name);
+  mkdirSync(dir, { recursive: true });
+  for (const [file, content] of Object.entries(files)) {
+    writeFileSync(join(dir, file), content);
+  }
+  return dir;
+}
+
+beforeEach(() => {
+  baseDir = join(
+    tmpdir(),
+    `librarium-cleanup-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(baseDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe('formatSize', () => {
+  it('formats bytes, KB, MB, GB', () => {
+    expect(formatSize(512)).toBe('512 B');
+    expect(formatSize(1536)).toBe('1.5 KB');
+    expect(formatSize(1024 * 1024 * 2)).toBe('2.0 MB');
+    expect(formatSize(1024 * 1024 * 1024 * 3)).toBe('3.00 GB');
+  });
+});
+
+describe('getDirSize', () => {
+  it('sums files recursively', () => {
+    const dir = makeRun('100-a', { 'a.md': 'x'.repeat(100) });
+    mkdirSync(join(dir, 'nested'));
+    writeFileSync(join(dir, 'nested', 'b.md'), 'y'.repeat(50));
+    expect(getDirSize(dir)).toBe(150);
+  });
+
+  it('returns 0 for a missing directory', () => {
+    expect(getDirSize(join(baseDir, 'does-not-exist'))).toBe(0);
+  });
+});
+
+describe('discoverCandidates', () => {
+  it('returns empty for a non-existent base dir', () => {
+    expect(discoverCandidates(join(baseDir, 'nope'))).toEqual([]);
+  });
+
+  it('filters by age by default and respects --days', () => {
+    const now = 1_000 * DAY; // arbitrary fixed clock
+    const oldSecs = Math.floor((now - 40 * DAY) / 1000);
+    const recentSecs = Math.floor((now - 5 * DAY) / 1000);
+    makeRun(`${oldSecs}-old`, { 'run.json': JSON.stringify(makeManifest()) });
+    makeRun(`${recentSecs}-recent`, {
+      'run.json': JSON.stringify(makeManifest()),
+    });
+
+    const def = discoverCandidates(baseDir, { now });
+    expect(def.map((c) => c.name)).toEqual([`${oldSecs}-old`]);
+
+    const wide = discoverCandidates(baseDir, { now, days: 3 });
+    expect(wide.map((c) => c.name).sort()).toEqual(
+      [`${oldSecs}-old`, `${recentSecs}-recent`].sort(),
+    );
+  });
+
+  it('all=true returns every directory regardless of age, newest first', () => {
+    const now = 1_000 * DAY;
+    const oldSecs = Math.floor((now - 40 * DAY) / 1000);
+    const recentSecs = Math.floor((now - 1 * DAY) / 1000);
+    makeRun(`${oldSecs}-old`, { 'run.json': JSON.stringify(makeManifest()) });
+    makeRun(`${recentSecs}-recent`, {
+      'run.json': JSON.stringify(makeManifest()),
+    });
+
+    const all = discoverCandidates(baseDir, { all: true, now });
+    expect(all.map((c) => c.name)).toEqual([
+      `${recentSecs}-recent`,
+      `${oldSecs}-old`,
+    ]);
+  });
+
+  it('captures query and ignores non-directories', () => {
+    const now = 1_000 * DAY;
+    const secs = Math.floor((now - 40 * DAY) / 1000);
+    makeRun(`${secs}-x`, {
+      'run.json': JSON.stringify(makeManifest({ query: 'my query' })),
+    });
+    writeFileSync(join(baseDir, 'stray.txt'), 'not a dir');
+
+    const out = discoverCandidates(baseDir, { now });
+    expect(out).toHaveLength(1);
+    expect(out[0].query).toBe('my query');
+  });
+
+  it('falls back to mtime when dir name lacks a timestamp', () => {
+    makeRun('no-timestamp', { 'run.json': JSON.stringify(makeManifest()) });
+    const out = discoverCandidates(baseDir, { all: true });
+    expect(out).toHaveLength(1);
+    expect(out[0].query).toBe('postgres pooling best practices');
+  });
+});
+
+describe('hasPendingAsync', () => {
+  it('is true when async-tasks.json has a pending or running task', () => {
+    const dir = makeRun('100-a', {
+      'async-tasks.json': JSON.stringify([
+        { taskId: 't1', status: 'pending' } as Partial<AsyncTaskHandle>,
+      ]),
+    });
+    expect(hasPendingAsync(dir)).toBe(true);
+  });
+
+  it('is false when async tasks are all completed', () => {
+    const dir = makeRun('100-b', {
+      'async-tasks.json': JSON.stringify([
+        { taskId: 't1', status: 'completed' } as Partial<AsyncTaskHandle>,
+      ]),
+    });
+    expect(hasPendingAsync(dir)).toBe(false);
+  });
+
+  it('falls back to run.json provider status when async file is absent', () => {
+    const dir = makeRun('100-c', {
+      'run.json': JSON.stringify(
+        makeManifest({
+          providers: [
+            {
+              id: 'openai-deep',
+              tier: 'deep-research',
+              status: 'async-pending',
+              durationMs: 0,
+              wordCount: 0,
+              citationCount: 0,
+              outputFile: '',
+              metaFile: '',
+            },
+          ],
+        }),
+      ),
+    });
+    expect(hasPendingAsync(dir)).toBe(true);
+  });
+
+  it('is false for a run dir with no async indicators', () => {
+    const dir = makeRun('100-d', {
+      'run.json': JSON.stringify(makeManifest()),
+    });
+    expect(hasPendingAsync(dir)).toBe(false);
+  });
+});
+
+describe('summarizeCandidates', () => {
+  it('aggregates count, size, oldest/newest, pending-async', () => {
+    const now = 1_000 * DAY;
+    const oldSecs = Math.floor((now - 40 * DAY) / 1000);
+    const newSecs = Math.floor((now - 1 * DAY) / 1000);
+    makeRun(`${oldSecs}-old`, {
+      'run.json': JSON.stringify(makeManifest()),
+      'a.md': 'x'.repeat(100),
+    });
+    makeRun(`${newSecs}-new`, {
+      'async-tasks.json': JSON.stringify([{ taskId: 't', status: 'running' }]),
+      'b.md': 'y'.repeat(200),
+    });
+
+    const candidates = discoverCandidates(baseDir, { all: true, now });
+    const s = summarizeCandidates(candidates);
+    expect(s.count).toBe(2);
+    expect(s.totalSize).toBeGreaterThanOrEqual(300);
+    expect(s.oldest?.name).toBe(`${oldSecs}-old`);
+    expect(s.newest?.name).toBe(`${newSecs}-new`);
+    expect(s.pendingAsyncCount).toBe(1);
+  });
+
+  it('handles an empty list', () => {
+    expect(summarizeCandidates([])).toEqual({
+      count: 0,
+      totalSize: 0,
+      oldest: null,
+      newest: null,
+      pendingAsyncCount: 0,
+    });
+  });
+});
+
+describe('unsafeBaseDirReason', () => {
+  it('refuses the home directory', () => {
+    expect(unsafeBaseDirReason(homedir())).toMatch(/home directory/);
+  });
+
+  it('refuses a filesystem root', () => {
+    const root = parse(process.cwd()).root;
+    expect(unsafeBaseDirReason(root)).toMatch(/filesystem root/);
+  });
+
+  it('allows a normal output dir', () => {
+    expect(unsafeBaseDirReason(baseDir)).toBeNull();
+  });
+});
+
+describe('isInsideBaseDir', () => {
+  it('accepts a proper descendant', () => {
+    expect(isInsideBaseDir(baseDir, join(baseDir, '100-a'))).toBe(true);
+    expect(isInsideBaseDir(baseDir, join(baseDir, 'a', 'b'))).toBe(true);
+  });
+
+  it('rejects the base dir itself', () => {
+    expect(isInsideBaseDir(baseDir, baseDir)).toBe(false);
+  });
+
+  it('rejects traversal outside the base dir', () => {
+    expect(isInsideBaseDir(baseDir, join(baseDir, '..', '..', 'etc'))).toBe(
+      false,
+    );
+    expect(isInsideBaseDir(baseDir, parse(baseDir).root)).toBe(false);
+  });
+
+  it('rejects a sibling that shares a name prefix', () => {
+    expect(isInsideBaseDir(`${baseDir}/runs`, `${baseDir}/runs-evil/x`)).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Ergonomics layer over the existing `cleanup` command for clearing old results:

- `cleanup --all` deletes every run dir regardless of age; `librarium clear` is the alias (one shared implementation). TTY gets a clack confirm with run count + total disk size; non-TTY requires explicit `--yes`.
- `-i/--interactive`: multiselect of runs (date, query, size, `[pending async]` marker) then confirm + delete. Deleting a run with pending async tasks is allowed but called out (orphans the server-side handle).
- `--dry-run` lists count/size/oldest/newest without deleting; deletions report freed space.
- Safety: every candidate verified as a strict descendant of the resolved output base dir (traversal-proof), refusal when the base dir resolves to HOME or a filesystem root, `rmSync` with maxRetries for Windows.

Punted (follow-up): a delete action inside `browse` — skipped deliberately to avoid conflicts with the in-flight pager rework; the helpers in cleanup-data.ts are factored for it.

## Testing

22 new unit tests (discovery filters, size formatting, path-safety guard incl. traversal attempts, pending-async detection); 250 passing on the branch pre-rebase, re-verified post-rebase; Biome, tsc, tsup green; dist/core.js clean of CLI deps. Smoke-tested dry-run, --json, --yes deletion, non-TTY refusal, HOME refusal.