### PR TITLE
fix: biome formatting in mcp-server tests

### DIFF
--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -13,8 +13,8 @@ import { safeWriteFile } from '../core/fs-utils.js';
 import { deduplicateSources } from '../core/normalizer.js';
 import {
   buildPrompt,
-  createRunDir,
   type CreateRunDirDeps,
+  createRunDir,
   generateSlug,
 } from '../core/prompt-builder.js';
 import { generateSummary } from '../core/synthesis.js';

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3,7 +3,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { initializeProviders } from '../src/adapters/node-registry.js';
 import { createRunDir } from '../src/core/prompt-builder.js';
 import {
@@ -358,9 +366,9 @@ describe('review fixes: selector tightening', () => {
 
 describe('review fixes: path containment', () => {
   it('rejects a runDir outside the output base', () => {
-    expect(() => resolveRunDir(baseDir, join(baseDir, '..', 'outside'))).toThrow(
-      PathContainmentError,
-    );
+    expect(() =>
+      resolveRunDir(baseDir, join(baseDir, '..', 'outside')),
+    ).toThrow(PathContainmentError);
     expect(() => resolveRunDir(baseDir, '/etc')).toThrow(PathContainmentError);
   });
 


### PR DESCRIPTION
CI lint broke on main after #29: the appended review-fix test block wasn't formatter-clean. Formatting only, no behavior change.