### PR TITLE
Answer integration polish: report, jsonl, wizard, --max-cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ $ librarium answer "what changed in postgres 17 logical replication"
   ▸ ~/research/agents/librarium/1781136000-what-changed-in-postgres-17/
 ```
 
-The synthesis call uses the first available of OpenAI (`gpt-5-mini`), Gemini (`gemini-2.5-flash`), or Perplexity (`sonar`), overridable via an `answer: { provider, model }` config key that falls back to the `refine` config and then to those defaults. Synthesis fails open: if every client fails (quota, auth, timeout), a detailed warning prints and the run summary and output directory still appear, so the research is never lost. The exit code reflects the run, not the synthesis. (`report.html` / `results.jsonl` regeneration does not yet include `answer.md`, and the interactive wizard does not yet offer synthesis -- both are follow-ups.)
+The synthesis call uses the first available of OpenAI (`gpt-5-mini`), Gemini (`gemini-2.5-flash`), or Perplexity (`sonar`), overridable via an `answer: { provider, model }` config key that falls back to the `refine` config and then to those defaults. Synthesis fails open: if every client fails (quota, auth, timeout), a detailed warning prints and the run summary and output directory still appear, so the research is never lost. The exit code reflects the run, not the synthesis. `answer` accepts the same run flags, including `--max-cost`, `--html`, and `--jsonl`. When the run directory contains `answer.md`, both `report.html` (an Answer section leading the report) and `results.jsonl` (an `"type":"answer"` line) pick it up automatically on generation and regeneration. The interactive wizard also offers grounded synthesis after its refine prompt when an LLM client key is configured.
 ### Spend guardrails
 
 Two opt-in guardrails help avoid surprise spend on large fan-outs.
@@ -309,7 +309,7 @@ Generate a self-contained `report.html` for a run directory (default: the most r
 librarium html [run-dir] [--open]
 ```
 
-The report contains the query, run metadata, the provider results table as tabs, with each provider's rendered markdown in a panel below, and the deduped source list with provider attribution. Provider markdown is HTML-escaped, so untrusted output cannot inject script. Results retrieved after the run (async deep research) fill in when the report is regenerated; `status --retrieve` regenerates an existing `report.html` automatically.
+The report contains the query, run metadata, the provider results table as tabs, with each provider's rendered markdown in a panel below, and the deduped source list with provider attribution. When the run directory contains an `answer.md` (from `librarium answer` or the wizard's synthesis toggle), an Answer section leads the report before the provider tabs, showing the synthesizing provider/model dimly. Answer and provider markdown are HTML-escaped with the same untrusted handling, so untrusted output cannot inject script. Results retrieved after the run (async deep research) fill in when the report is regenerated; `status --retrieve` regenerates an existing `report.html` automatically.
 
 ### `jsonl`
 
@@ -322,6 +322,7 @@ librarium jsonl [run-dir]
 The file contains one JSON object per line (JSONL / newline-delimited JSON). Each line can be parsed independently with `JSON.parse`:
 
 - **Line 1 -- run header** (`"type":"run"`): query, slug, timestamp, mode, succeeded/failed/pending counts, unique source count, total citation count, and optional `refinedQueries` (only present when `--refine` was used).
+- **Optional answer line** (`"type":"answer"`): emitted right after the run header when the run directory contains an `answer.md` (from `librarium answer` or the wizard's synthesis toggle). Carries optional `provider` and `model` (from `run.json`'s `answer` metadata) and `content` (the full `answer.md` body).
 - **One line per provider** (`"type":"result"`): id, tier, status, durationMs, citationCount, optional usage object, optional error string, optional fallbackFor string, and `content` (the full markdown from the provider's `.md` file, or `null` when missing or pending).
 - **One line per deduped source** (`"type":"source"`): url, optional title, providers array, citationCount.
 

--- a/src/commands/answer-synthesis.ts
+++ b/src/commands/answer-synthesis.ts
@@ -1,4 +1,10 @@
-import type { DeduplicatedSource, ProviderDispatchResult } from '../types.js';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  DeduplicatedSource,
+  ProviderDispatchResult,
+  RunManifest,
+} from '../types.js';
 
 /**
  * Pure (LLM-free) building blocks for `librarium answer`: prompt assembly from
@@ -39,6 +45,43 @@ export function normalizeSourceLabel(value: string): string {
   return flat.length > SOURCE_LABEL_MAX_CHARS
     ? `${flat.slice(0, SOURCE_LABEL_MAX_CHARS - 1)}…`
     : flat;
+}
+
+/** The grounded answer recovered from a run directory, for report generators. */
+export interface AnswerArtifact {
+  /** Raw answer.md contents (answer body plus its numbered Sources section). */
+  content: string;
+  /** Synthesis provider, from the manifest's additive answer metadata. */
+  provider?: string;
+  /** Synthesis model, from the manifest's additive answer metadata. */
+  model?: string;
+}
+
+/**
+ * Read a run directory's grounded answer for report regeneration. Returns the
+ * answer.md body plus the provider/model recorded in run.json's `answer` field,
+ * or null when the run produced no answer.md. Used by the HTML and JSONL
+ * generators so `librarium html`/`librarium jsonl` and status --retrieve pick
+ * the answer up automatically.
+ */
+export function readAnswerArtifact(
+  runDir: string,
+  manifest: RunManifest,
+): AnswerArtifact | null {
+  const answerPath = join(runDir, 'answer.md');
+  if (!existsSync(answerPath)) return null;
+  let content: string;
+  try {
+    content = readFileSync(answerPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (content.trim().length === 0) return null;
+  return {
+    content,
+    provider: manifest.answer?.provider,
+    model: manifest.answer?.model,
+  };
 }
 
 export interface AnswerSource {

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -19,6 +19,7 @@ import {
   executeRun,
   type PostDispatchContext,
   type PostDispatchResult,
+  parseMaxCost,
   type RunOptions,
 } from './run.js';
 import { dimText, hyperlink, sanitizeForTerminal } from './run-format.js';
@@ -53,6 +54,11 @@ export function registerAnswerCommand(program: Command): void {
     .option('-o, --output <dir>', 'Output base directory')
     .option('--parallel <n>', 'Max parallel requests', Number.parseInt)
     .option('--timeout <n>', 'Timeout per provider in seconds', Number.parseInt)
+    .option(
+      '--max-cost <usd>',
+      'Stop launching providers once API-reported cost crosses this budget (USD)',
+      parseMaxCost,
+    )
     .option('--json', 'Output run.json to stdout')
     .option(
       '--refine',

--- a/src/commands/html-report.ts
+++ b/src/commands/html-report.ts
@@ -8,6 +8,7 @@ import type {
   ProviderReport,
   RunManifest,
 } from '../types.js';
+import { readAnswerArtifact } from './answer-synthesis.js';
 import { readRunEntry } from './browse-data.js';
 import { formatDuration, usageLabel } from './run-format.js';
 
@@ -25,6 +26,12 @@ export interface HtmlReportInput {
   /** Provider markdown contents keyed by report outputFile. */
   providerContents: Record<string, string>;
   sources: DeduplicatedSource[];
+  /**
+   * The synthesized grounded answer (answer.md body) when the run produced one.
+   * Leads the report as an "Answer" section before the provider tabs.
+   * provider/model come from the manifest's additive `answer` metadata.
+   */
+  answer?: { content: string; provider?: string; model?: string };
 }
 
 export function escapeHtml(text: string): string {
@@ -191,6 +198,48 @@ function providerPanelBody(
   return '<p class="pending-note">No output file found for this provider.</p>';
 }
 
+/**
+ * Strip answer.md's leading `# query` heading and its trailing `## Sources`
+ * list so the report renders only the answer body: the query is already the
+ * report's H1 and the deduped sources have their own tab. Defensive: if the
+ * expected structure is absent, the content passes through untouched. Pure
+ * string surgery on already-untrusted markdown; renderMarkdown still escapes
+ * raw HTML and applies safeUrl to links.
+ */
+export function answerBody(content: string): string {
+  let body = content.replace(/\r\n/g, '\n');
+  // Drop a single leading level-1 heading (the echoed query).
+  body = body.replace(/^\s*#[^\S\n]+[^\n]*\n+/, '');
+  // Drop a trailing "## Sources" section through end of file.
+  body = body.replace(/\n#{1,6}[^\S\n]+Sources\b[\s\S]*$/i, '\n');
+  return body.trim();
+}
+
+/**
+ * The "Answer" section that leads the report. Rendered with the same untrusted
+ * handling as provider panels (escaped raw HTML, safeUrl on links). The
+ * provider/model show dimly when recorded in run.json's answer metadata.
+ */
+function answerSection(answer: {
+  content: string;
+  provider?: string;
+  model?: string;
+}): string {
+  const body = answerBody(answer.content);
+  if (body.length === 0) return '';
+  const attribution =
+    answer.provider || answer.model
+      ? `<p class="answer-meta">synthesized by ${escapeHtml(
+          [answer.provider, answer.model].filter(Boolean).join(' / '),
+        )}</p>`
+      : '';
+  return `<section class="answer">
+<p class="eyebrow">answer</p>
+${attribution}
+<div class="answer-body">${renderMarkdown(body)}</div>
+</section>`;
+}
+
 function sourcesSection(sources: DeduplicatedSource[]): string {
   if (sources.length === 0) {
     return '<p class="pending-note">No sources recorded.</p>';
@@ -321,6 +370,15 @@ ol.sources { padding-left: 1.4rem; font-size: 0.9rem; }
 ol.sources li { margin: 0.35rem 0; }
 .error-note { color: #dc2626; font-size: 0.9rem; }
 .pending-note { color: #525252; font-size: 0.9rem; }
+section.answer {
+  margin-top: 2rem;
+  border: 1px solid rgba(10, 10, 10, 0.1);
+  border-radius: 10px;
+  padding: 0.5rem 1.5rem 1.25rem;
+  background: rgba(217, 119, 6, 0.03);
+}
+.answer-meta { color: #a3a3a3; font-size: 0.78rem; margin: 0.25rem 0 0; }
+.answer-body { font-size: 0.97rem; }
 footer {
   border-top: 1px solid rgba(10, 10, 10, 0.1);
   padding: 1.25rem 2rem;
@@ -357,8 +415,11 @@ const SCRIPT = `(function () {
 
 /** Pure generator: manifest plus file contents in, full HTML document out. */
 export function generateHtmlReport(input: HtmlReportInput): string {
-  const { manifest, providerContents, sources } = input;
+  const { manifest, providerContents, sources, answer } = input;
   const reports = manifest.providers;
+
+  const answerHtml =
+    answer && answer.content.trim().length > 0 ? answerSection(answer) : '';
 
   // Default active tab: first successful provider, else the first row.
   const firstSuccess = reports.findIndex((r) => r.status === 'success');
@@ -410,6 +471,7 @@ ${sourcesSection(sources)}
 <p class="eyebrow">query</p>
 <h1>${escapeHtml(manifest.query)}</h1>
 <p class="meta">${escapeHtml(formatReportDate(manifest.timestamp))} &middot; mode ${escapeHtml(manifest.mode)} &middot; ${escapeHtml(talliesLine(manifest))} &middot; ${sources.length} unique sources after dedupe (${manifest.sources.total} total citations)</p>
+${answerHtml}
 <section>
 <p class="eyebrow">providers</p>
 <div class="tabs" role="tablist" aria-label="Provider results">
@@ -499,10 +561,13 @@ export function writeHtmlReport(runDir: string): string | null {
     }
   }
 
+  const answer = readAnswerArtifact(runDir, entry.manifest);
+
   const html = generateHtmlReport({
     manifest: entry.manifest,
     providerContents,
     sources,
+    ...(answer ? { answer } : {}),
   });
   const reportPath = join(runDir, 'report.html');
   safeWriteFile(reportPath, html);

--- a/src/commands/jsonl-report.ts
+++ b/src/commands/jsonl-report.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeWriteFile } from '../core/fs-utils.js';
 import type { DeduplicatedSource, RunManifest } from '../types.js';
+import { readAnswerArtifact } from './answer-synthesis.js';
 import { readRunEntry } from './browse-data.js';
 import { enrichRetrievedReports } from './html-report.js';
 
@@ -19,6 +20,11 @@ export interface JsonlReportInput {
   /** Provider markdown contents keyed by report outputFile. */
   providerContents: Record<string, string>;
   sources: DeduplicatedSource[];
+  /**
+   * The synthesized grounded answer (answer.md body) when the run produced one.
+   * provider/model come from the manifest's additive `answer` metadata.
+   */
+  answer?: { content: string; provider?: string; model?: string };
 }
 
 /** Line 1: run header. */
@@ -35,6 +41,14 @@ interface RunLine {
   uniqueSources: number;
   totalCitations: number;
   refinedQueries?: Partial<Record<string, string>>;
+}
+
+/** Optional line for the grounded synthesized answer (librarium answer). */
+interface AnswerLine {
+  type: 'answer';
+  provider?: string;
+  model?: string;
+  content: string;
 }
 
 /** One line per provider. */
@@ -69,13 +83,15 @@ function replacer(_key: string, value: unknown): unknown {
 }
 
 /** Serialize one JSONL object, dropping undefined-valued keys. */
-function serializeLine(obj: RunLine | ResultLine | SourceLine): string {
+function serializeLine(
+  obj: RunLine | AnswerLine | ResultLine | SourceLine,
+): string {
   return JSON.stringify(obj, replacer);
 }
 
 /** Pure generator: manifest plus file contents in, full JSONL string out. */
 export function generateJsonlReport(input: JsonlReportInput): string {
-  const { manifest, providerContents, sources } = input;
+  const { manifest, providerContents, sources, answer } = input;
   const reports = manifest.providers;
 
   const succeeded = reports.filter((r) => r.status === 'success').length;
@@ -98,6 +114,18 @@ export function generateJsonlReport(input: JsonlReportInput): string {
       ? { refinedQueries: manifest.refinedQueries }
       : {}),
   };
+
+  // The grounded answer (when present) leads the body, right after the run
+  // header. provider/model come from the manifest's additive answer metadata.
+  const answerLine: AnswerLine | null =
+    answer && answer.content.trim().length > 0
+      ? {
+          type: 'answer',
+          provider: answer.provider,
+          model: answer.model,
+          content: answer.content,
+        }
+      : null;
 
   const resultLines: ResultLine[] = reports.map((report) => {
     const content =
@@ -135,6 +163,7 @@ export function generateJsonlReport(input: JsonlReportInput): string {
 
   const lines = [
     serializeLine(runLine),
+    ...(answerLine ? [serializeLine(answerLine)] : []),
     ...resultLines.map((l) => serializeLine(l)),
     ...sourceLines.map((l) => serializeLine(l)),
   ];
@@ -177,10 +206,13 @@ export function writeJsonlReport(runDir: string): string | null {
     }
   }
 
+  const answer = readAnswerArtifact(runDir, entry.manifest);
+
   const jsonl = generateJsonlReport({
     manifest: entry.manifest,
     providerContents,
     sources,
+    ...(answer ? { answer } : {}),
   });
   const reportPath = join(runDir, 'results.jsonl');
   safeWriteFile(reportPath, jsonl);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -111,6 +111,19 @@ export interface ExecuteRunHooks {
   ) => Promise<PostDispatchResult | undefined>;
 }
 
+/**
+ * Strict parser for the shared --max-cost flag. Rejects anything that is not a
+ * finite, positive USD amount so a typo never silently disables the budget
+ * circuit breaker. Shared by `run` and `answer` so both validate identically.
+ */
+export function parseMaxCost(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError('must be a positive number of USD.');
+  }
+  return parsed;
+}
+
 export function registerRunCommand(program: Command): void {
   program
     .command('run')
@@ -129,13 +142,7 @@ export function registerRunCommand(program: Command): void {
     .option(
       '--max-cost <usd>',
       'Stop launching providers once API-reported cost crosses this budget (USD)',
-      (value: string) => {
-        const parsed = Number(value);
-        if (!Number.isFinite(parsed) || parsed <= 0) {
-          throw new InvalidArgumentError('must be a positive number of USD.');
-        }
-        return parsed;
-      },
+      parseMaxCost,
     )
     .option('-y, --yes', 'Skip the deep-research pre-flight confirm')
     .option('--json', 'Output run.json to stdout')

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -5,9 +5,10 @@ import {
 } from '../adapters/node-registry.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import type { Config, ProviderTier } from '../types.js';
+import { synthesizeAnswer } from './answer.js';
 import { browseRunDir } from './browse.js';
 import { resolveRefineClient } from './refine.js';
-import { executeRun, type RunOptions } from './run.js';
+import { type ExecuteRunHooks, executeRun, type RunOptions } from './run.js';
 
 /**
  * Interactive wizard launched by bare `librarium` in a TTY: prompt for the
@@ -132,8 +133,10 @@ export async function runWizard(): Promise<void> {
   });
   if (p.isCancel(mode)) return cancel();
 
-  // Only offer refine when a refine-capable API key is configured.
+  // Refine and synthesis both need an LLM client key; gate both on the same
+  // check so neither prompt appears when no synthesis-capable key is set.
   let refine: boolean | symbol = false;
+  let synthesize: boolean | symbol = false;
   if (resolveRefineClient(config)) {
     p.log.message(
       'Refine rewrites your query three ways with one quick LLM call: a research brief for deep research, a focused question for AI answers, keywords for raw search.',
@@ -143,6 +146,12 @@ export async function runWizard(): Promise<void> {
       initialValue: false,
     });
     if (p.isCancel(refine)) return cancel();
+
+    synthesize = await p.confirm({
+      message: 'Synthesize a grounded answer afterwards?',
+      initialValue: false,
+    });
+    if (p.isCancel(synthesize)) return cancel();
   }
 
   const scopeLabel = group
@@ -163,7 +172,13 @@ export async function runWizard(): Promise<void> {
   if (providers) options.providers = providers;
   if (group) options.group = group;
   if (refine) options.refine = true;
-  const outcome = await executeRun(query.trim(), options);
+
+  // Reuse the exact postDispatch synthesis hook the answer command uses, so the
+  // wizard path produces the same answer.md, run.json metadata, and output.
+  const hooks: ExecuteRunHooks | undefined = synthesize
+    ? { postDispatch: (context) => synthesizeAnswer(context) }
+    : undefined;
+  const outcome = await executeRun(query.trim(), options, hooks);
 
   if (
     outcome.outputDir &&

--- a/tests/answer-command.test.ts
+++ b/tests/answer-command.test.ts
@@ -1,8 +1,12 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { synthesizeAnswer } from '../src/commands/answer.js';
+import {
+  registerAnswerCommand,
+  synthesizeAnswer,
+} from '../src/commands/answer.js';
 import type { PostDispatchContext } from '../src/commands/run.js';
 import type {
   Config,
@@ -73,6 +77,32 @@ function makeContext(
   };
   return { context, lines };
 }
+
+describe('answer command --max-cost flag', () => {
+  function parseAnswer(args: string[]): { maxCost?: number } {
+    const program = new Command();
+    program.exitOverride();
+    registerAnswerCommand(program);
+    let parsed: { maxCost?: number } = {};
+    const cmd = program.commands.find((c) => c.name() === 'answer');
+    if (!cmd) throw new Error('answer command not registered');
+    // Capture the parsed options without executing the (async) action.
+    cmd.action(() => {});
+    program.parse(['node', 'librarium', 'answer', ...args]);
+    parsed = cmd.opts();
+    return parsed;
+  }
+
+  it('registers --max-cost and parses a positive USD amount', () => {
+    expect(parseAnswer(['some query', '--max-cost', '2.50']).maxCost).toBe(2.5);
+  });
+
+  it('rejects a non-positive or non-numeric --max-cost', () => {
+    expect(() => parseAnswer(['q', '--max-cost', '0'])).toThrow();
+    expect(() => parseAnswer(['q', '--max-cost', '-1'])).toThrow();
+    expect(() => parseAnswer(['q', '--max-cost', 'abc'])).toThrow();
+  });
+});
 
 describe('synthesizeAnswer', () => {
   let dir: string;

--- a/tests/html-report.test.ts
+++ b/tests/html-report.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  answerBody,
   enrichRetrievedReports,
   escapeHtml,
   generateHtmlReport,
@@ -368,6 +369,74 @@ describe('generateHtmlReport', () => {
     });
     expect(html).not.toContain('—');
   });
+
+  it('leads with an Answer section before the providers section when answer present', () => {
+    const html = generateHtmlReport({
+      manifest: makeManifest(),
+      providerContents: { 'exa.md': '# x\n\nprovider body' },
+      sources: SOURCES,
+      answer: {
+        content:
+          '# postgres pooling best practices\n\nUse PgBouncer [1].\n\n## Sources\n\n1. PgBouncer docs - https://example.com',
+        provider: 'openai',
+        model: 'gpt-5-mini',
+      },
+    });
+    expect(html).toContain('section class="answer"');
+    expect(html).toContain('Use PgBouncer');
+    expect(html).toContain('synthesized by openai / gpt-5-mini');
+    // Answer section comes before the providers tablist.
+    expect(html.indexOf('section class="answer"')).toBeLessThan(
+      html.indexOf('role="tablist"'),
+    );
+    // The echoed query heading and the trailing Sources list from answer.md are
+    // stripped, so they do not duplicate the report's own H1 / sources tab: the
+    // query only appears once as a heading (the report header), and the answer
+    // body itself does not open with a heading.
+    expect(
+      html.match(/<h1>postgres pooling best practices<\/h1>/g),
+    ).toHaveLength(1);
+    expect(html).toContain('<div class="answer-body"><p>Use PgBouncer');
+  });
+
+  it('omits the Answer section when no answer is provided', () => {
+    const html = generateHtmlReport({
+      manifest: makeManifest(),
+      providerContents: {},
+      sources: SOURCES,
+    });
+    expect(html).not.toContain('section class="answer"');
+  });
+
+  it('escapes raw HTML and neutralizes unsafe links in the answer (untrusted)', () => {
+    const html = generateHtmlReport({
+      manifest: makeManifest(),
+      providerContents: {},
+      sources: [],
+      answer: {
+        content:
+          '# q\n\n<img src=x onerror=alert(1)> and [evil](javascript:alert(1)) link',
+      },
+    });
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img');
+    expect(html).not.toContain('href="javascript:alert(1)"');
+  });
+});
+
+describe('answerBody', () => {
+  it('strips the leading query heading and trailing Sources section', () => {
+    const body = answerBody(
+      '# the query\n\nThe body text [1].\n\n## Sources\n\n1. A - https://a.test',
+    );
+    expect(body).toBe('The body text [1].');
+  });
+
+  it('passes content through untouched when structure is absent', () => {
+    expect(answerBody('just a body with no heading')).toBe(
+      'just a body with no heading',
+    );
+  });
 });
 
 describe('writeHtmlReport', () => {
@@ -399,6 +468,24 @@ describe('writeHtmlReport', () => {
     const html = readFileSync(reportPath as string, 'utf-8');
     expect(html).toContain('Exa findings');
     expect(html).toContain('PgBouncer docs');
+  });
+
+  it('picks up answer.md and run.json answer metadata automatically', () => {
+    const manifest = makeManifest({
+      answer: { provider: 'openai', model: 'gpt-5-mini' },
+    });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+    writeFileSync(join(dir, 'exa.md'), '# Exa findings\n\nhello');
+    writeFileSync(join(dir, 'sources.json'), JSON.stringify(SOURCES));
+    writeFileSync(
+      join(dir, 'answer.md'),
+      '# postgres pooling best practices\n\nUse PgBouncer [1].\n',
+    );
+
+    const html = readFileSync(writeHtmlReport(dir) as string, 'utf-8');
+    expect(html).toContain('section class="answer"');
+    expect(html).toContain('Use PgBouncer');
+    expect(html).toContain('synthesized by openai / gpt-5-mini');
   });
 
   it('fills in retrieved results for reports still marked async-pending', () => {

--- a/tests/jsonl-report.test.ts
+++ b/tests/jsonl-report.test.ts
@@ -331,6 +331,71 @@ describe('generateJsonlReport -- each line parses independently', () => {
     });
     expect(jsonl).not.toContain('—');
   });
+
+  it('emits an answer line right after the run header when answer present', () => {
+    const jsonl = generateJsonlReport({
+      manifest: makeManifest(),
+      providerContents: {},
+      sources: SOURCES,
+      answer: {
+        content: '# q\n\nThe answer is 42 [1].',
+        provider: 'openai',
+        model: 'gpt-5-mini',
+      },
+    });
+    const lines = parseLines(jsonl) as Array<{
+      type: string;
+      provider?: string;
+      model?: string;
+      content?: string;
+    }>;
+    expect(lines[0]?.type).toBe('run');
+    expect(lines[1]?.type).toBe('answer');
+    expect(lines[1]?.provider).toBe('openai');
+    expect(lines[1]?.model).toBe('gpt-5-mini');
+    expect(lines[1]?.content).toContain('The answer is 42');
+    // result/source lines still follow the answer line.
+    expect(lines[2]?.type).toBe('result');
+  });
+
+  it('omits the answer line when no answer is provided', () => {
+    const jsonl = generateJsonlReport({
+      manifest: makeManifest(),
+      providerContents: {},
+      sources: SOURCES,
+    });
+    const lines = parseLines(jsonl) as Array<{ type: string }>;
+    expect(lines.some((l) => l.type === 'answer')).toBe(false);
+  });
+
+  it('omits the answer line when answer content is blank', () => {
+    const jsonl = generateJsonlReport({
+      manifest: makeManifest(),
+      providerContents: {},
+      sources: SOURCES,
+      answer: { content: '   \n  ', provider: 'openai', model: 'gpt-5-mini' },
+    });
+    const lines = parseLines(jsonl) as Array<{ type: string }>;
+    expect(lines.some((l) => l.type === 'answer')).toBe(false);
+  });
+
+  it('omits provider/model keys from the answer line when not recorded', () => {
+    const jsonl = generateJsonlReport({
+      manifest: makeManifest(),
+      providerContents: {},
+      sources: [],
+      answer: { content: 'grounded answer' },
+    });
+    const lines = parseLines(jsonl) as Array<Record<string, unknown>>;
+    const answerLine = lines.find((l) => l.type === 'answer') as Record<
+      string,
+      unknown
+    >;
+    expect(answerLine).toBeDefined();
+    expect('provider' in answerLine).toBe(false);
+    expect('model' in answerLine).toBe(false);
+    expect(answerLine.content).toBe('grounded answer');
+  });
 });
 
 describe('writeJsonlReport', () => {
@@ -370,6 +435,31 @@ describe('writeJsonlReport', () => {
     expect(runLine?.query).toBe('postgres pooling best practices');
     expect(resultLine?.content).toContain('Exa findings');
     expect(sourceLine?.url).toBe('https://example.com/pgbouncer');
+  });
+
+  it('picks up answer.md and run.json answer metadata automatically', () => {
+    const manifest = makeManifest({
+      answer: { provider: 'gemini', model: 'gemini-2.5-flash' },
+    });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+    writeFileSync(join(dir, 'exa.md'), '# Exa findings\n\nhello');
+    writeFileSync(join(dir, 'sources.json'), JSON.stringify(SOURCES));
+    writeFileSync(
+      join(dir, 'answer.md'),
+      '# postgres pooling best practices\n\nUse PgBouncer [1].\n',
+    );
+
+    const reportPath = writeJsonlReport(dir) as string;
+    const lines = parseLines(readFileSync(reportPath, 'utf-8')) as Array<{
+      type: string;
+      provider?: string;
+      model?: string;
+      content?: string;
+    }>;
+    const answerLine = lines.find((l) => l.type === 'answer');
+    expect(answerLine?.provider).toBe('gemini');
+    expect(answerLine?.model).toBe('gemini-2.5-flash');
+    expect(answerLine?.content).toContain('Use PgBouncer');
   });
 
   it('fills in retrieved results for reports still marked async-pending', () => {

--- a/tests/pty/wizard.test.ts
+++ b/tests/pty/wizard.test.ts
@@ -33,9 +33,15 @@ describeMaybe(
       session = null;
     });
 
-    it('drives query → group → mode → confirm → run → decline browse', async () => {
-      // Bare invocation (no args) launches the wizard in a TTY.
-      session = spawnCli({ args: [], config: SINGLE });
+    it('drives query → group → mode → refine → synthesize → confirm → run → decline browse', async () => {
+      // Bare invocation (no args) launches the wizard in a TTY. A mock LLM key
+      // makes the refine + synthesize toggles appear (their gate is only key
+      // presence, not validity); we decline both so no network call happens.
+      session = spawnCli({
+        args: [],
+        config: SINGLE,
+        env: { OPENAI_API_KEY: 'mock-key' },
+      });
 
       // Query prompt.
       await session.waitForText('What do you want to research?');
@@ -53,6 +59,14 @@ describeMaybe(
 
       // Execution mode: accept the default (mixed).
       await session.waitForText('Execution mode');
+      session.write(KEY.ENTER);
+
+      // Refine toggle (shown because a mock LLM key is set): decline (default No).
+      await session.waitForText('Refine the query for each tier first?');
+      session.write(KEY.ENTER);
+
+      // Synthesize toggle (added after refine): decline (default No).
+      await session.waitForText('Synthesize a grounded answer afterwards?');
       session.write(KEY.ENTER);
 
       // Confirm: the summary line must name the smoke group (guards the


### PR DESCRIPTION
## Summary

- **report.html leads with the Answer**: an Answer section (rendered with the same escaping + safeUrl handling as provider content, synthesizing provider/model shown dimly) before the provider tabs; `librarium html` and `status --retrieve` regeneration pick it up automatically. `answerBody()` strips the duplicate heading/sources from answer.md.
- **results.jsonl** gains an optional `{"type":"answer","provider":...,"model":...,"content":...}` line between the run header and result lines.
- **Wizard**: "Synthesize a grounded answer afterwards?" toggle (default No, only offered when an LLM key exists), reusing the answer command's synthesizeAnswer hook. PTY wizard test updated and green.
- **`--max-cost` on answer** with the same strict validation as run (extracted `parseMaxCost`), flowing through the existing budget plumbing.

## Testing

490 unit (+13), PTY 5/5, integration 11/11, lint/tsc/build green, core clean.