### PR TITLE
fix: --yes on answer + seven-groups README prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ librarium mcp
 
 ## Groups
 
-Groups are named collections of provider IDs. Librarium ships with six default groups:
+Groups are named collections of provider IDs. Librarium ships with seven default groups:
 
 | Group | Providers | Use Case |
 |---|---|---|

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -59,6 +59,7 @@ export function registerAnswerCommand(program: Command): void {
       'Stop launching providers once API-reported cost crosses this budget (USD)',
       parseMaxCost,
     )
+    .option('-y, --yes', 'Skip the deep-research pre-flight confirm')
     .option('--json', 'Output run.json to stdout')
     .option(
       '--refine',


### PR DESCRIPTION
Two nits the site-docs sync caught: `answer` claimed run-flag parity but didn't register `-y/--yes` (the preflight can fire through its executeRun path with a deep group); README prose said six default groups while its own table lists seven.