### PR TITLE
feat: improve onboarding and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-29
+
 ### Added
+- **Guided first-run onboarding**: bare `librarium` now starts a setup wizard when no usable providers are configured. The flow explains what Librarium does, links to the docs, recommends starter providers, keeps the full provider list available, shows provider descriptions/setup URLs, prompts for API keys with masked input, and saves only providers with usable credentials.
+- **Credential storage choices**: onboarding and `librarium config` support OS keychain storage, private shell env-file storage (`~/.config/librarium/env` or `env.fish`), and config-file fallback. Keychain/config/env references now resolve through the same credential layer across provider dispatch, `answer`, `refine`, the wizard, and MCP research.
+- **First-query guidance from onboarding**: setup now offers to run a first query immediately. When an OpenAI, Gemini, or Perplexity synthesis key is configured, the first query uses the same grounded synthesis hook as `librarium answer` so the terminal shows the synthesized answer and writes `answer.md`; otherwise it shows the provider run summary and explains how to enable synthesis later.
+- **Provider catalog and config menu**: providers now have catalog metadata for setup URLs, descriptions, family labels, recommendations, and alphabetical browsing. `librarium config` can configure providers/API keys and settings such as `defaults.llmWebSearch`.
+- **LLM web search and citations**: LLM-tier providers can use provider-native web search/citations by default, with opt-out via `defaults.llmWebSearch: false` or per-provider `options.webSearch: false`. LLM providers remain opt-in for normal grounded runs.
 - **Provider metering capability registry** (`librarium/core`): every provider now declares a `metering_kind` (`native_cost`, `native_tokens`, `request_priced`, `credit_priced`, `api_unit_priced`, or `manual_unmetered`), visible in `librarium ls` and `ls --json`. A network-free `estimateMetering()` returns a pre-dispatch estimate (`estimatedCostUsd`, `billableUnits`, `unit`, `pricingVersion`, `costConfidence`) without any API call, and `buildProviderMetering()` is the single normalization path used across sync dispatch, fallback, and async retrieval. New `getMeteringKind()`, `estimateMetering()`, `buildProviderMetering()`, and `createEstimateBudgetTracker()` exports.
 - **`--max-estimated-cost <usd>` flag** (and `defaults.maxEstimatedCostUsd`) on `run` and `answer`: a pre-dispatch *reservation* ceiling that reserves each provider's estimated cost before it launches and skips launches once the estimate crosses the ceiling. Independent of the reported-only `--max-cost` (the two never reconcile); providers with no estimable cost reserve `0`.
 - Metering is exposed through dispatch results, `run.json`, per-provider `.meta.json` (CLI run, MCP `research`, and both async-retrieval paths: `status --retrieve` and the MCP `check_async` tool), `results.jsonl`, MCP shaping, and the `usage` command (a separate `est. cost` lane).
+
+### Changed
+- `librarium init` now routes interactive setup through the onboarding wizard. `init --auto` remains non-interactive, but LLM-tier providers stay opt-in even when their shared API keys are present.
+- Explicit `-p` and `--group` selections can use credentialed providers that are not enabled in config, which lets users opt into LLM providers on demand without making them part of default runs.
 
 ### Notes
 - Honesty preserved: `usage.costUsd` remains provider-reported only. Estimates live under `metering.estimate` and never become facts; plan-dependent credit/API-unit providers emit unit metadata without a fabricated USD figure until pricing is configured via provider `options`. Actual-cost provenance is recorded under `metering.actual.source`.
@@ -151,7 +162,9 @@ The first stable release: the 0.1.x research fan-out core plus a complete intera
 - API keys use environment variable references, never stored in plaintext
 - Response size guard (10MB) on HTTP client
 
-[Unreleased]: https://github.com/jkudish/librarium/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/jkudish/librarium/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/jkudish/librarium/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/jkudish/librarium/releases/tag/v1.0.0
 [0.2.0]: https://github.com/jkudish/librarium/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/jkudish/librarium/compare/v0.1.2...v0.1.3
 [0.1.0]: https://github.com/jkudish/librarium/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ The full docs live at **[librarium.agentsy.build](https://librarium.agentsy.buil
 # Install (requires Node.js >= 20.12)
 npm install -g librarium
 
-# Auto-configure: discovers API keys from your environment and enables matching providers
-librarium init --auto
+# Start guided setup if no providers are configured yet
+librarium
 
-# Fan out a research query across providers (live results table)
+# After setup, fan out a research query across providers
 librarium run "PostgreSQL connection pooling best practices"
 
 # Or get one grounded, cited answer synthesized from the results
 librarium answer "what changed in postgres 17 logical replication"
 ```
 
-That's it. Output lands in a timestamped run directory you can read, browse, or feed to a pipeline. Run `librarium` with no arguments for an interactive wizard. See the [full command reference](#commands) and [more install methods](#installation) below.
+On first run, `librarium` opens a guided onboarding wizard: pick providers, choose where API keys should be stored, enter keys with masked prompts, and optionally run a first query. Once at least one usable provider is configured, bare `librarium` opens the research wizard instead. Output lands in a timestamped run directory you can read, browse, or feed to a pipeline. See the [full command reference](#commands) and [more install methods](#installation) below.
 
 ## Features
 
@@ -130,6 +130,17 @@ librarium
 
 Librarium ships with 24 built-in provider adapters organized into four tiers:
 
+The onboarding wizard starts with a short recommended starter list, but the full provider list is always available from setup. Recommendations are meant to get a first successful query quickly:
+
+| Provider | Good for | API Key Env Var |
+|---|---|---|
+| Brave Web Search | Fast raw web results and broad source discovery | `BRAVE_API_KEY` |
+| Perplexity Sonar Pro | Quick grounded AI answers with citations | `PERPLEXITY_API_KEY` |
+| Exa Search | AI-oriented semantic web search | `EXA_API_KEY` |
+| Tavily Search | Agent-focused search and extraction workflows | `TAVILY_API_KEY` |
+
+Some provider families unlock multiple adapters with one key. For example, `PERPLEXITY_API_KEY` can power Perplexity search, grounded answers, and deep research adapters; onboarding explains that rather than making repeated provider rows look accidental.
+
 | Provider | ID | Tier | API Key Env Var |
 |---|---|---|---|
 | Perplexity Sonar Deep Research | `perplexity-sonar-deep` | deep-research | `PERPLEXITY_API_KEY` |
@@ -185,16 +196,23 @@ Providers are categorized into four tiers based on their capabilities, latency, 
 
 - **raw-search** -- Traditional search engine results. Fast responses with many links and snippets, but no AI synthesis. Useful for broad link discovery and verifying specific facts.
 
-- **llm** -- Ungrounded generic LLMs (Claude, OpenAI, Gemini, or anything via OpenRouter). These return the model's direct answer to the research prompt with **no web grounding and no citations**, so they contribute zero sources to the deduplicated source set, `sources.json`, and the report tallies. They exist as an opt-in baseline/contrast layer: run them alongside grounded research to see what the model says on its own versus what grounded providers surface. Because they are ungrounded, they are **excluded from every grounded default group** (`quick`, `fast`, `raw`, `deep`, `comprehensive`, and `all`). Opt in explicitly via `-p claude,openai-chat,...`, a custom group, or `--group llm`. Each provider takes a cheap default model with a per-provider `model` config override.
+- **llm** -- Generic LLM answers from Claude, OpenAI, Gemini, or OpenRouter. They are provider-style model calls, not dedicated research/search APIs. Web search and citations are **on by default** for these adapters, and you can turn that off globally with `defaults.llmWebSearch: false` or per provider with `options.webSearch: false`. They stay **excluded from every grounded default group** (`quick`, `fast`, `raw`, `deep`, `comprehensive`, and `all`) so a normal grounded run does not silently add extra model calls. Opt in explicitly via `-p claude,openai-chat,...`, a custom group, or `--group llm`. Each provider takes a default model with a per-provider `model` config override.
 
-### The LLM tier (ungrounded baseline / contrast)
+### The LLM tier
 
-The `llm` tier is deliberately kept apart from the grounded tiers. Grounded providers earn their place in the source tallies by citing the web; ungrounded LLMs do not, so librarium never silently folds them into a grounded run. `report.tier === 'llm'` rows render a dim `ungrounded` in place of the source count, and the dedupe pipeline, `sources.json`, and report source totals are completely unaffected by their presence. Use the built-in `llm` group (`--group llm`) to run all four at once.
+The `llm` tier is deliberately kept apart from the grounded tiers. These adapters now use their provider's web-search feature by default where available:
 
-**Opt-in, never auto-enabled.** Several llm-tier providers share an API key with their grounded counterparts (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`; Claude uses `ANTHROPIC_API_KEY`). To keep a plain `librarium run` -- which dispatches every *enabled* provider -- from silently calling an ungrounded model, `init` treats the llm tier specially:
+- `claude` uses Anthropic's Messages API web search tool.
+- `openai-chat` uses the OpenAI Responses API with the `web_search` tool.
+- `gemini-chat` uses Gemini Google Search grounding.
+- `openrouter-chat` uses OpenRouter's online/web-search path.
 
-- `librarium init --auto` **does not** enable llm-tier providers, even when their key is present. It prints them as found-but-ungrounded with a hint to opt in.
-- Interactive `librarium init` **lists** the llm-tier providers but leaves them **unchecked** (with an `[ungrounded]` marker), so you must tick them deliberately.
+If you want old-style direct model answers with no web search, set `"llmWebSearch": false` under `defaults`, or set `"options": { "webSearch": false }` on a specific llm provider. When web search is off, llm providers contribute no citations or source URLs.
+
+**Opt-in, never auto-enabled.** Several llm-tier providers share an API key with their grounded counterparts (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`; Claude uses `ANTHROPIC_API_KEY`). To keep a plain `librarium run` -- which dispatches every *enabled* provider -- from silently calling extra LLM APIs, `init` treats the llm tier specially:
+
+- `librarium init --auto` **does not** enable llm-tier providers, even when their key is present. It prints them as found-but-opt-in with a hint to opt in.
+- Interactive setup **lists** the llm-tier providers but does not select them for you, so you must choose them deliberately.
 
 As a result they stay out of the default run unless you explicitly enable them in config. Reach for them on demand via `-p claude,openai-chat,...`, a custom group, or `--group llm` regardless of your init choices.
 
@@ -533,7 +551,7 @@ librarium groups --json
 
 ### `init`
 
-Set up librarium configuration. Auto mode discovers API keys from your environment and enables matching providers.
+Set up librarium configuration. Interactive mode runs the same guided onboarding flow as first-run `librarium`: choose providers, choose credential storage, enter keys, and save only providers with usable credentials. Auto mode remains non-interactive: it discovers API keys from your environment and enables matching grounded providers.
 
 ```bash
 # Auto-discover (non-interactive)
@@ -553,11 +571,14 @@ librarium doctor [--json]
 
 ### `config`
 
-Print the resolved configuration (global merged with project).
+Print the resolved configuration (global merged with project), or open the interactive config menu.
 
 ```bash
 # Show resolved config
 librarium config
+
+# Open provider/settings menu
+librarium config menu
 
 # Show only global config
 librarium config --global
@@ -565,6 +586,8 @@ librarium config --global
 # Output raw JSON
 librarium config --json
 ```
+
+The config menu can configure providers/API keys, credential storage, `defaults.llmWebSearch`, execution mode, output directory, parallelism, and timeouts.
 
 ### `cleanup`
 
@@ -641,7 +664,7 @@ Groups are named collections of provider IDs. Librarium ships with seven default
 | `raw` | perplexity-search, brave-search, jina-search, firecrawl-search, searchapi, serpapi, tavily | Traditional search results |
 | `fast` | perplexity-sonar-pro, gemini-grounded, openrouter-online, perplexity-search, brave-answers, exa, kagi-fastgpt, jina-search, brave-search, firecrawl-search, tavily | Quick results from multiple tiers |
 | `comprehensive` | All deep-research + all ai-grounded | Deep + AI-grounded combined |
-| `llm` | claude, openai-chat, gemini-chat, openrouter-chat | Ungrounded LLM baseline / contrast (no citations) |
+| `llm` | claude, openai-chat, gemini-chat, openrouter-chat | Opt-in LLM answers; web search and citations on by default |
 | `all` | All 20 grounded providers | Maximum grounded coverage (excludes the `llm` tier) |
 
 ### Custom Groups
@@ -741,6 +764,7 @@ The optional `defaults.maxCostUsd` key sets a default cost budget for runs (the 
     "asyncTimeout": 1800,
     "asyncPollInterval": 10,
     "mode": "mixed",
+    "llmWebSearch": true,
     "maxCostUsd": 0.5,
     "maxEstimatedCostUsd": 0.25
   },
@@ -770,7 +794,39 @@ The optional `defaults.maxCostUsd` key sets a default cost budget for runs (the 
 }
 ```
 
-API keys use the `$ENV_VAR` pattern -- the value `"$PERPLEXITY_API_KEY"` resolves to `process.env.PERPLEXITY_API_KEY` at runtime. Keys are never stored in plaintext.
+API keys can be stored three ways:
+
+1. **OS keychain**: recommended when available. Config stores a reference such as `"keychain:PERPLEXITY_API_KEY"` and the secret lives outside the config file.
+2. **Shell environment variables**: config stores a reference such as `"$PERPLEXITY_API_KEY"`. The onboarding wizard writes exports to `~/.config/librarium/env` (or `env.fish`) with `0600` permissions and, with confirmation, adds a non-secret source line to your detected shell profile.
+3. **Config file**: explicit fallback. Config stores the literal key in `~/.config/librarium/config.json`, which is written with `0600` permissions.
+
+The CLI cannot change the parent shell's live environment. If you choose shell environment variables, open a new terminal or source your shell profile before expecting the key to exist in future sessions.
+
+LLM providers use web search and citations by default. Turn that off globally with:
+
+```json
+{
+  "defaults": {
+    "llmWebSearch": false
+  }
+}
+```
+
+Or turn it off for one provider:
+
+```json
+{
+  "providers": {
+    "openai-chat": {
+      "apiKey": "$OPENAI_API_KEY",
+      "enabled": true,
+      "options": {
+        "webSearch": false
+      }
+    }
+  }
+}
+```
 
 Some providers support optional model overrides. Gemini Deep Research defaults to the `deep-research-preview-04-2026` agent; set `model` to `deep-research-max-preview-04-2026` for the heavier (and more expensive) variant:
 
@@ -1017,7 +1073,7 @@ await initializeProviders({ credentials });
 
 const config: Config = {
   version: 1,
-  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'sync' },
+  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'sync', llmWebSearch: true },
   providers: {
     'gemini-grounded': { enabled: true },
     'openrouter-online': { enabled: true },
@@ -1071,7 +1127,7 @@ await initializeProviders({ credentials });
 
 const config = {
   version: 1 as const,
-  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'sync' as const },
+  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'sync' as const, llmWebSearch: true },
   providers: { 'my-search': { enabled: true } },
   // npm: { type: 'npm', module: 'my-search-provider', export: 'default' }
   // script: { type: 'script', command: './providers/my-search.mjs' }
@@ -1114,7 +1170,7 @@ await initializeProviders({ credentials });
 
 const config: Config = {
   version: 1,
-  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'mixed' },
+  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'mixed', llmWebSearch: true },
   providers: {
     'openai-deep': { enabled: true },        // deep-research -> async
     'gemini-grounded': { enabled: true },    // ai-grounded -> sync, inline
@@ -1241,7 +1297,7 @@ Groups:
   deep           -- Thorough async research (minutes)
   fast           -- Quick results from multiple tiers
   comprehensive  -- Deep + AI-grounded combined
-  llm            -- Ungrounded LLM baseline / contrast (no citations)
+  llm            -- Opt-in LLM answers; web search/citations on by default
   all            -- All 20 grounded providers (excludes the llm tier)
 
 Output lands in ./agents/librarium/<timestamp>-<slug>/:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,4 +1,5 @@
 import type {
+  Citation,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -9,11 +10,22 @@ import { BaseProvider, type BaseProviderOptions } from './base.js';
 interface AnthropicTextBlock {
   type?: string;
   text?: string;
+  citations?: AnthropicCitation[];
+}
+
+interface AnthropicCitation {
+  type?: string;
+  url?: string;
+  title?: string;
+  cited_text?: string;
 }
 
 interface AnthropicUsage {
   input_tokens?: number;
   output_tokens?: number;
+  server_tool_use?: {
+    web_search_requests?: number;
+  };
 }
 
 interface AnthropicResponse {
@@ -29,6 +41,7 @@ interface AnthropicResponse {
 
 export interface ClaudeProviderOptions extends BaseProviderOptions {
   model?: string;
+  webSearch?: boolean;
 }
 
 const DEFAULT_CLAUDE_MODEL = 'claude-haiku-4-5';
@@ -36,18 +49,20 @@ const ANTHROPIC_VERSION = '2023-06-01';
 const MAX_TOKENS = 4096;
 
 /**
- * Claude (Anthropic) ungrounded LLM provider.
- * Returns the model's direct answer with NO citations -- baseline/contrast.
- * Tier: llm (sync, ungrounded)
+ * Claude LLM provider.
+ * Uses Anthropic web search by default for current answers and citations.
+ * Tier: llm (sync)
  */
 export class ClaudeProvider extends BaseProvider {
   readonly id = 'claude';
   readonly tier: ProviderTier = 'llm';
   readonly model: string;
+  readonly webSearch: boolean;
 
   constructor(options: ClaudeProviderOptions = {}) {
     super(options);
     this.model = options.model?.trim() || DEFAULT_CLAUDE_MODEL;
+    this.webSearch = options.webSearch ?? true;
   }
 
   async execute(
@@ -58,6 +73,21 @@ export class ClaudeProvider extends BaseProvider {
     const apiKey = this.getApiKey();
 
     try {
+      const body: Record<string, unknown> = {
+        model: this.model,
+        max_tokens: MAX_TOKENS,
+        messages: [{ role: 'user', content: query }],
+      };
+      if (this.webSearch) {
+        body.tools = [
+          {
+            type: 'web_search_20250305',
+            name: 'web_search',
+            max_uses: 5,
+          },
+        ];
+      }
+
       const response = await this.request<AnthropicResponse>(
         'https://api.anthropic.com/v1/messages',
         {
@@ -66,11 +96,7 @@ export class ClaudeProvider extends BaseProvider {
             'x-api-key': apiKey,
             'anthropic-version': ANTHROPIC_VERSION,
           },
-          body: {
-            model: this.model,
-            max_tokens: MAX_TOKENS,
-            messages: [{ role: 'user', content: query }],
-          },
+          body,
           timeout: options.timeout * 1000,
           signal: options.signal,
         },
@@ -97,6 +123,7 @@ export class ClaudeProvider extends BaseProvider {
           .filter(Boolean)
           .join('\n')
           .trim() ?? '';
+      const citations = this.extractCitations(data.content);
 
       if (!content) {
         // A 200 with no usable text is not a success: surface the model's
@@ -119,7 +146,7 @@ export class ClaudeProvider extends BaseProvider {
         provider: this.id,
         tier: this.tier,
         content,
-        citations: [],
+        citations,
         durationMs,
         model: data.model ?? this.model,
         tokenUsage: {
@@ -161,5 +188,34 @@ export class ClaudeProvider extends BaseProvider {
           : undefined,
       raw: usage,
     };
+  }
+
+  private extractCitations(blocks?: AnthropicTextBlock[]): Citation[] {
+    if (!Array.isArray(blocks)) return [];
+
+    const seen = new Set<string>();
+    const citations: Citation[] = [];
+
+    for (const block of blocks) {
+      if (block.type !== 'text' || !Array.isArray(block.citations)) continue;
+      for (const citation of block.citations) {
+        if (
+          citation.type !== 'web_search_result_location' ||
+          !citation.url ||
+          seen.has(citation.url)
+        ) {
+          continue;
+        }
+        seen.add(citation.url);
+        citations.push({
+          url: citation.url,
+          title: citation.title,
+          snippet: citation.cited_text,
+          provider: this.id,
+        });
+      }
+    }
+
+    return citations;
   }
 }

--- a/src/adapters/gemini-chat.ts
+++ b/src/adapters/gemini-chat.ts
@@ -1,4 +1,5 @@
 import type {
+  Citation,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -14,8 +15,28 @@ interface GeminiChatCandidate {
   content?: {
     parts?: GeminiChatPart[];
   };
+  groundingMetadata?: GeminiGroundingMetadata;
   finishReason?: string;
   finishMessage?: string;
+}
+
+interface GeminiGroundingMetadata {
+  groundingChunks?: GeminiGroundingChunk[];
+  groundingSupports?: GeminiGroundingSupport[];
+}
+
+interface GeminiGroundingChunk {
+  web?: {
+    uri?: string;
+    title?: string;
+  };
+}
+
+interface GeminiGroundingSupport {
+  segment?: {
+    text?: string;
+  };
+  groundingChunkIndices?: number[];
 }
 
 interface GeminiChatPromptFeedback {
@@ -42,24 +63,26 @@ interface GeminiChatResponse {
 
 export interface GeminiChatProviderOptions extends BaseProviderOptions {
   model?: string;
+  webSearch?: boolean;
 }
 
 const DEFAULT_GEMINI_CHAT_MODEL = 'gemini-2.5-flash';
 
 /**
- * Gemini ungrounded LLM provider.
- * Plain generateContent with NO googleSearch tool -- direct answer, no citations.
- * Distinct from gemini-grounded (which grounds via Google Search).
- * Tier: llm (sync, ungrounded)
+ * Gemini LLM provider.
+ * Uses Google Search grounding by default for current answers and citations.
+ * Tier: llm (sync)
  */
 export class GeminiChatProvider extends BaseProvider {
   readonly id = 'gemini-chat';
   readonly tier: ProviderTier = 'llm';
   readonly model: string;
+  readonly webSearch: boolean;
 
   constructor(options: GeminiChatProviderOptions = {}) {
     super(options);
     this.model = options.model?.trim() || DEFAULT_GEMINI_CHAT_MODEL;
+    this.webSearch = options.webSearch ?? true;
   }
 
   async execute(
@@ -70,6 +93,13 @@ export class GeminiChatProvider extends BaseProvider {
     const apiKey = this.getApiKey();
 
     try {
+      const body: Record<string, unknown> = {
+        contents: [{ parts: [{ text: query }] }],
+      };
+      if (this.webSearch) {
+        body.tools = [{ googleSearch: {} }];
+      }
+
       const response = await this.request<GeminiChatResponse>(
         `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent`,
         {
@@ -79,9 +109,7 @@ export class GeminiChatProvider extends BaseProvider {
           headers: {
             'x-goog-api-key': apiKey,
           },
-          body: {
-            contents: [{ parts: [{ text: query }] }],
-          },
+          body,
           timeout: options.timeout * 1000,
           signal: options.signal,
         },
@@ -119,6 +147,7 @@ export class GeminiChatProvider extends BaseProvider {
           .filter(Boolean)
           .join('\n')
           .trim() ?? '';
+      const citations = this.extractCitations(candidate);
 
       if (!content) {
         // A 200 with no usable text is not a success: surface a prompt-level
@@ -155,7 +184,7 @@ export class GeminiChatProvider extends BaseProvider {
         provider: this.id,
         tier: this.tier,
         content,
-        citations: [],
+        citations,
         durationMs,
         model: data.modelVersion ?? this.model,
         tokenUsage: {
@@ -193,5 +222,37 @@ export class GeminiChatProvider extends BaseProvider {
       totalTokens: metadata.totalTokenCount,
       raw: metadata,
     };
+  }
+
+  private extractCitations(candidate?: GeminiChatCandidate): Citation[] {
+    const metadata = candidate?.groundingMetadata;
+    const chunks = metadata?.groundingChunks;
+    if (!Array.isArray(chunks)) return [];
+
+    const snippets = new Map<number, string>();
+    for (const support of metadata?.groundingSupports ?? []) {
+      const snippet = support.segment?.text?.trim();
+      if (!snippet) continue;
+      for (const index of support.groundingChunkIndices ?? []) {
+        if (!snippets.has(index)) snippets.set(index, snippet);
+      }
+    }
+
+    const seen = new Set<string>();
+    const citations: Citation[] = [];
+
+    chunks.forEach((chunk, index) => {
+      const url = chunk.web?.uri;
+      if (!url || seen.has(url)) return;
+      seen.add(url);
+      citations.push({
+        url,
+        title: chunk.web?.title,
+        snippet: snippets.get(index),
+        provider: this.id,
+      });
+    });
+
+    return citations;
   }
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,7 +1,13 @@
 import { resolveProviderId } from '../constants.js';
-import type { CredentialContext } from '../core/credentials.js';
-import { hasCredential } from '../core/credentials.js';
+import {
+  type CredentialContext,
+  describeCredentialReference,
+} from '../core/credentials.js';
 import { getMeteringKind } from '../core/metering.js';
+import {
+  providerCredentialRef,
+  providerHasCredential,
+} from '../core/provider-selection.js';
 import type { Config, Provider, ProviderMeta, ProviderTier } from '../types.js';
 import { BaseProvider } from './base.js';
 import { BraveAnswersProvider } from './brave-answers.js';
@@ -32,7 +38,10 @@ import { YouResearchProvider } from './you-research.js';
 const providers = new Map<string, Provider>();
 
 export type ProviderInitConfig = Partial<
-  Pick<Config, 'providers' | 'customProviders' | 'trustedProviderIds'>
+  Pick<
+    Config,
+    'defaults' | 'providers' | 'customProviders' | 'trustedProviderIds'
+  >
 > & {
   credentials?: CredentialContext;
 };
@@ -83,6 +92,13 @@ export function getProviderMeta(
   return getAllProviders().map((p) => {
     const providerConfig = config[p.id];
     const requiresApiKey = p.requiresApiKey ?? true;
+    const credentialRef = providerCredentialRef(p, providerConfig);
+    const credentialInfo = describeCredentialReference(
+      requiresApiKey ? credentialRef : undefined,
+    );
+    const hasApiKey = requiresApiKey
+      ? providerHasCredential(p, providerConfig, credentials)
+      : true;
     return {
       id: p.id,
       displayName: p.displayName,
@@ -92,11 +108,12 @@ export function getProviderMeta(
       enabled: providerConfig?.enabled ?? false,
       configured: providerConfig !== undefined,
       meteringKind: getMeteringKind(p.id),
-      hasApiKey: requiresApiKey
-        ? providerConfig
-          ? hasCredential(providerConfig.apiKey, credentials)
-          : hasCredential(p.envVar ? `$${p.envVar}` : undefined, credentials)
-        : true,
+      hasApiKey,
+      credentialSource: requiresApiKey
+        ? hasApiKey
+          ? credentialInfo.source
+          : 'missing'
+        : 'literal',
     };
   });
 }
@@ -111,6 +128,7 @@ export async function initializeProviders(
   providers.clear();
   const providerConfig = config.providers ?? {};
   const credentials = config.credentials ?? {};
+  const llmWebSearch = config.defaults?.llmWebSearch ?? true;
 
   const builtIns: Provider[] = [
     // Deep Research (async capable)
@@ -139,12 +157,27 @@ export async function initializeProviders(
     new SerpApiProvider(),
     new TavilyProvider(),
 
-    // LLM (ungrounded baseline/contrast -- sync, no citations)
-    new ClaudeProvider({ model: providerConfig.claude?.model }),
-    new OpenAIChatProvider({ model: providerConfig['openai-chat']?.model }),
-    new GeminiChatProvider({ model: providerConfig['gemini-chat']?.model }),
+    // LLM (sync). Providers are opt-in, and web search/citations are on by
+    // default unless disabled globally or per-provider via options.webSearch.
+    new ClaudeProvider({
+      model: providerConfig.claude?.model,
+      webSearch: providerWebSearch('claude', providerConfig, llmWebSearch),
+    }),
+    new OpenAIChatProvider({
+      model: providerConfig['openai-chat']?.model,
+      webSearch: providerWebSearch('openai-chat', providerConfig, llmWebSearch),
+    }),
+    new GeminiChatProvider({
+      model: providerConfig['gemini-chat']?.model,
+      webSearch: providerWebSearch('gemini-chat', providerConfig, llmWebSearch),
+    }),
     new OpenRouterChatProvider({
       model: providerConfig['openrouter-chat']?.model,
+      webSearch: providerWebSearch(
+        'openrouter-chat',
+        providerConfig,
+        llmWebSearch,
+      ),
     }),
   ];
 
@@ -165,4 +198,13 @@ export async function initializeProviders(
     loadedCustomProviders: [],
     skippedCustomProviders: [],
   };
+}
+
+function providerWebSearch(
+  id: string,
+  providers: NonNullable<Config['providers']>,
+  fallback: boolean,
+): boolean {
+  const configured = providers[id]?.options?.webSearch;
+  return typeof configured === 'boolean' ? configured : fallback;
 }

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1,4 +1,5 @@
 import type {
+  Citation,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -32,28 +33,72 @@ interface OpenAIChatResponse {
   };
 }
 
+interface OpenAIResponseAnnotation {
+  type?: string;
+  url?: string;
+  title?: string;
+}
+
+interface OpenAIResponseContent {
+  type?: string;
+  text?: string;
+  annotations?: OpenAIResponseAnnotation[];
+}
+
+interface OpenAIResponseOutputItem {
+  type?: string;
+  content?: OpenAIResponseContent[];
+}
+
+interface OpenAIResponsesUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+}
+
+interface OpenAIResponsesResponse {
+  model?: string;
+  output?: OpenAIResponseOutputItem[];
+  usage?: OpenAIResponsesUsage;
+  error?: {
+    message?: string;
+    type?: string;
+  };
+}
+
 export interface OpenAIChatProviderOptions extends BaseProviderOptions {
   model?: string;
+  webSearch?: boolean;
 }
 
 const DEFAULT_OPENAI_CHAT_MODEL = 'gpt-5-mini';
 
 /**
- * OpenAI chat completions ungrounded LLM provider.
- * Returns the model's direct answer with NO citations -- baseline/contrast.
- * Tier: llm (sync, ungrounded)
+ * OpenAI LLM provider.
+ * Uses Responses API web search by default for current answers and citations.
+ * Tier: llm (sync)
  */
 export class OpenAIChatProvider extends BaseProvider {
   readonly id = 'openai-chat';
   readonly tier: ProviderTier = 'llm';
   readonly model: string;
+  readonly webSearch: boolean;
 
   constructor(options: OpenAIChatProviderOptions = {}) {
     super(options);
     this.model = options.model?.trim() || DEFAULT_OPENAI_CHAT_MODEL;
+    this.webSearch = options.webSearch ?? true;
   }
 
   async execute(
+    query: string,
+    options: ProviderOptions,
+  ): Promise<ProviderResult> {
+    if (this.webSearch) return this.executeWithWebSearch(query, options);
+    return this.executeChatCompletions(query, options);
+  }
+
+  private async executeChatCompletions(
     query: string,
     options: ProviderOptions,
   ): Promise<ProviderResult> {
@@ -142,6 +187,86 @@ export class OpenAIChatProvider extends BaseProvider {
     }
   }
 
+  private async executeWithWebSearch(
+    query: string,
+    options: ProviderOptions,
+  ): Promise<ProviderResult> {
+    const start = performance.now();
+    const apiKey = this.getApiKey();
+
+    try {
+      const response = await this.request<OpenAIResponsesResponse>(
+        'https://api.openai.com/v1/responses',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: {
+            model: this.model,
+            input: query,
+            tools: [{ type: 'web_search' }],
+            tool_choice: 'auto',
+          },
+          timeout: options.timeout * 1000,
+          signal: options.signal,
+        },
+      );
+
+      const durationMs = Math.round(performance.now() - start);
+      const data = response.data;
+
+      if (response.status !== 200 || data.error) {
+        return {
+          provider: this.id,
+          tier: this.tier,
+          content: '',
+          citations: [],
+          durationMs,
+          error: data.error?.message ?? this.formatError(response.status, data),
+        };
+      }
+
+      const outputText = this.extractResponseText(data.output);
+      const citations = this.extractResponseCitations(data.output);
+
+      if (!outputText) {
+        return {
+          provider: this.id,
+          tier: this.tier,
+          content: '',
+          citations: [],
+          durationMs,
+          error: 'OpenAI returned an empty response (no output text returned)',
+        };
+      }
+
+      return {
+        provider: this.id,
+        tier: this.tier,
+        content: outputText,
+        citations,
+        durationMs,
+        model: data.model ?? this.model,
+        tokenUsage: {
+          input: data.usage?.input_tokens,
+          output: data.usage?.output_tokens,
+        },
+        usage: this.extractResponsesUsage(data.usage),
+      };
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start);
+      return {
+        provider: this.id,
+        tier: this.tier,
+        content: '',
+        citations: [],
+        durationMs,
+        error: this.formatCatchError(err),
+      };
+    }
+  }
+
   async test(): Promise<{ ok: boolean; error?: string }> {
     const result = await this.execute('ping', { timeout: 10 });
     if (!result.error) return { ok: true };
@@ -156,5 +281,62 @@ export class OpenAIChatProvider extends BaseProvider {
       totalTokens: usage.total_tokens,
       raw: usage,
     };
+  }
+
+  private extractResponsesUsage(
+    usage?: OpenAIResponsesUsage,
+  ): ProviderUsage | undefined {
+    if (!usage) return undefined;
+    return {
+      inputTokens: usage.input_tokens,
+      outputTokens: usage.output_tokens,
+      totalTokens: usage.total_tokens,
+      raw: usage,
+    };
+  }
+
+  private extractResponseText(output?: OpenAIResponseOutputItem[]): string {
+    if (!Array.isArray(output)) return '';
+    return output
+      .filter((item) => item.type === 'message')
+      .flatMap((item) => item.content ?? [])
+      .filter((content) => content.type === 'output_text')
+      .map((content) => content.text ?? '')
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+  }
+
+  private extractResponseCitations(
+    output?: OpenAIResponseOutputItem[],
+  ): Citation[] {
+    if (!Array.isArray(output)) return [];
+
+    const seen = new Set<string>();
+    const citations: Citation[] = [];
+
+    for (const item of output) {
+      if (item.type !== 'message') continue;
+      for (const content of item.content ?? []) {
+        if (!Array.isArray(content.annotations)) continue;
+        for (const annotation of content.annotations) {
+          if (
+            annotation.type !== 'url_citation' ||
+            !annotation.url ||
+            seen.has(annotation.url)
+          ) {
+            continue;
+          }
+          seen.add(annotation.url);
+          citations.push({
+            url: annotation.url,
+            title: annotation.title,
+            provider: this.id,
+          });
+        }
+      }
+    }
+
+    return citations;
   }
 }

--- a/src/adapters/openrouter-chat.ts
+++ b/src/adapters/openrouter-chat.ts
@@ -1,4 +1,5 @@
 import type {
+  Citation,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -6,9 +7,19 @@ import type {
 } from '../types.js';
 import { BaseProvider, type BaseProviderOptions } from './base.js';
 
+interface OpenRouterAnnotation {
+  type?: string;
+  url_citation?: {
+    url?: string;
+    title?: string;
+    content?: string;
+  };
+}
+
 interface OpenRouterChatMessage {
   content?: string;
   refusal?: string | null;
+  annotations?: OpenRouterAnnotation[];
 }
 
 interface OpenRouterChatChoice {
@@ -34,25 +45,28 @@ interface OpenRouterChatResponse {
 
 export interface OpenRouterChatProviderOptions extends BaseProviderOptions {
   model?: string;
+  webSearch?: boolean;
 }
 
 // Cheap, capable default. Override via config `model`.
 const DEFAULT_OPENROUTER_CHAT_MODEL = 'openai/gpt-4o-mini';
 
 /**
- * OpenRouter ungrounded LLM provider.
- * Plain chat completions through OpenRouter -- direct answer, no citations.
+ * OpenRouter LLM provider.
+ * Uses OpenRouter web search by default for current answers and citations.
  * Distinct from openrouter-online (which grounds via the `:online` suffix).
- * Tier: llm (sync, ungrounded)
+ * Tier: llm (sync)
  */
 export class OpenRouterChatProvider extends BaseProvider {
   readonly id = 'openrouter-chat';
   readonly tier: ProviderTier = 'llm';
   readonly model: string;
+  readonly webSearch: boolean;
 
   constructor(options: OpenRouterChatProviderOptions = {}) {
     super(options);
     this.model = options.model?.trim() || DEFAULT_OPENROUTER_CHAT_MODEL;
+    this.webSearch = options.webSearch ?? true;
   }
 
   async execute(
@@ -73,7 +87,7 @@ export class OpenRouterChatProvider extends BaseProvider {
             'X-Title': 'librarium',
           },
           body: {
-            model: this.model,
+            model: this.requestModel,
             messages: [{ role: 'user', content: query }],
             // Opt into usage accounting so the response reports cost in USD.
             usage: { include: true },
@@ -99,6 +113,7 @@ export class OpenRouterChatProvider extends BaseProvider {
 
       const choice = data.choices?.[0];
       const content = choice?.message?.content?.trim() ?? '';
+      const citations = this.extractCitations(choice?.message?.annotations);
 
       if (!content) {
         // A 200 with no usable text is not a success: surface a refusal or the
@@ -126,9 +141,9 @@ export class OpenRouterChatProvider extends BaseProvider {
         provider: this.id,
         tier: this.tier,
         content,
-        citations: [],
+        citations,
         durationMs,
-        model: data.model ?? this.model,
+        model: data.model ?? this.requestModel,
         tokenUsage: {
           input: data.usage?.prompt_tokens,
           output: data.usage?.completion_tokens,
@@ -163,5 +178,32 @@ export class OpenRouterChatProvider extends BaseProvider {
       costUsd: usage.cost,
       raw: usage,
     };
+  }
+
+  private get requestModel(): string {
+    if (!this.webSearch || this.model.endsWith(':online')) return this.model;
+    return `${this.model}:online`;
+  }
+
+  private extractCitations(annotations?: OpenRouterAnnotation[]): Citation[] {
+    if (!Array.isArray(annotations)) return [];
+
+    const seen = new Set<string>();
+    const citations: Citation[] = [];
+
+    for (const annotation of annotations) {
+      if (annotation.type !== 'url_citation') continue;
+      const citation = annotation.url_citation;
+      if (!citation?.url || seen.has(citation.url)) continue;
+      seen.add(citation.url);
+      citations.push({
+        url: citation.url,
+        title: citation.title,
+        snippet: citation.content,
+        provider: this.id,
+      });
+    }
+
+    return citations;
   }
 }

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import type { Command } from 'commander';
 import { safeWriteFile } from '../core/fs-utils.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type { Config, ProviderDispatchResult } from '../types.js';
 import {
   type AnswerSource,
@@ -170,7 +171,11 @@ async function runSynthesis(
   answerSources: AnswerSource[],
 ): Promise<{ provider: string; model: string; text: string }> {
   const preference = preferenceFromConfig(config, 'answer', 'refine');
-  const clients = resolveLlmClients(preference, process.env);
+  const clients = resolveLlmClients(preference, {
+    env: process.env,
+    config,
+    credentials: createNodeCredentialContext(),
+  });
   if (clients.length === 0) {
     throw new Error(
       preference?.provider

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -234,7 +234,6 @@ function deleteCandidates(
     `\nDeleting ${summary.count} ${plural(summary.count, 'directory', 'directories')} (${formatSize(summary.totalSize)})...\n`,
   );
   let freed = 0;
-  let count = 0;
   for (const c of candidates) {
     if (!isInsideBaseDir(baseDir, c.dir)) {
       console.warn(`  Skipped (outside base dir): ${c.dir}`);
@@ -242,7 +241,6 @@ function deleteCandidates(
     }
     rmSync(c.dir, { recursive: true, force: true, maxRetries: 3 });
     freed += c.size;
-    count += 1;
     console.log(`  Deleted: ${c.dir} (${c.ageDays}d old)`);
   }
   console.log(`\nCleanup complete. Freed ${formatSize(freed)}.`);

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,14 +1,36 @@
+import * as p from '@clack/prompts';
 import type { Command } from 'commander';
-import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import {
+  CONFIG_FILE,
+  loadConfig,
+  loadProjectConfig,
+  mergeConfigs,
+  saveConfig,
+} from '../core/config.js';
+import type { Config, Defaults } from '../types.js';
+import { runOnboardingWizard } from './onboarding.js';
 
 export function registerConfigCommand(program: Command): void {
   program
     .command('config')
-    .description('Print resolved configuration')
+    .description('Print or edit librarium configuration')
+    .argument('[action]', 'Use "menu" to edit settings')
     .option('--json', 'Output raw JSON')
     .option('--global', 'Show only global config (ignore project config)')
-    .action((opts) => {
+    .option('--menu', 'Open the interactive config menu')
+    .action(async (action, opts) => {
       try {
+        if (opts.menu || action === 'menu') {
+          await runConfigMenu();
+          return;
+        }
+
+        if (action) {
+          throw new Error(
+            `Unknown config action "${action}". Use "librarium config menu" to edit settings.`,
+          );
+        }
+
         const globalConfig = loadConfig();
 
         if (opts.global) {
@@ -38,6 +60,253 @@ export function registerConfigCommand(program: Command): void {
         process.exitCode = 1;
       }
     });
+}
+
+function cancel(): void {
+  p.cancel('Cancelled.');
+  process.exitCode = 130;
+}
+
+async function runConfigMenu(): Promise<void> {
+  p.intro('Librarium config');
+  p.log.message(`Editing global config: ${CONFIG_FILE}`);
+
+  let config = loadConfig();
+
+  while (true) {
+    const choice = await p.select<string>({
+      message: 'What do you want to configure?',
+      options: [
+        {
+          value: 'providers',
+          label: 'Providers and API keys',
+          hint: 'Add keys, enable providers, and choose secret storage',
+        },
+        {
+          value: 'llm-web-search',
+          label: `LLM web search: ${config.defaults.llmWebSearch ? 'on' : 'off'}`,
+          hint: 'Use web search and citations for llm providers',
+        },
+        {
+          value: 'mode',
+          label: `Default mode: ${config.defaults.mode}`,
+          hint: 'sync, async, or mixed',
+        },
+        {
+          value: 'output-dir',
+          label: 'Output directory',
+          hint: config.defaults.outputDir,
+        },
+        {
+          value: 'limits',
+          label: 'Parallelism and timeouts',
+          hint: `${config.defaults.maxParallel} parallel, ${config.defaults.timeout}s sync timeout`,
+        },
+        {
+          value: 'print',
+          label: 'Show current config',
+          hint: 'Print the resolved global settings in this menu',
+        },
+        {
+          value: 'done',
+          label: 'Done',
+          hint: 'Save and exit',
+        },
+      ],
+    });
+    if (p.isCancel(choice)) return cancel();
+
+    if (choice === 'done') {
+      p.outro('config saved');
+      return;
+    }
+
+    if (choice === 'providers') {
+      await runOnboardingWizard({ welcome: false, offerFirstRun: false });
+      config = loadConfig();
+      continue;
+    }
+
+    if (choice === 'llm-web-search') {
+      const updated = await promptLlmWebSearch(config);
+      if (!updated) return cancel();
+      config = updated;
+      continue;
+    }
+
+    if (choice === 'mode') {
+      const updated = await promptMode(config);
+      if (!updated) return cancel();
+      config = updated;
+      continue;
+    }
+
+    if (choice === 'output-dir') {
+      const updated = await promptOutputDir(config);
+      if (!updated) return cancel();
+      config = updated;
+      continue;
+    }
+
+    if (choice === 'limits') {
+      const updated = await promptLimits(config);
+      if (!updated) return cancel();
+      config = updated;
+      continue;
+    }
+
+    if (choice === 'print') {
+      printConfig(
+        config as unknown as Record<string, unknown>,
+        'Global Config',
+      );
+    }
+  }
+}
+
+async function promptLlmWebSearch(config: Config): Promise<Config | null> {
+  const choice = await p.select<string>({
+    message: 'Use web search and citations for llm providers?',
+    options: [
+      {
+        value: 'on',
+        label: 'On',
+        hint: 'Default: Claude/OpenAI/Gemini/OpenRouter search when useful',
+      },
+      {
+        value: 'off',
+        label: 'Off',
+        hint: 'LLM providers answer directly without web citations',
+      },
+    ],
+    initialValue: config.defaults.llmWebSearch ? 'on' : 'off',
+  });
+  if (p.isCancel(choice)) return null;
+
+  const next = {
+    ...config,
+    defaults: {
+      ...config.defaults,
+      llmWebSearch: choice === 'on',
+    },
+  };
+  saveConfig(next);
+  p.log.success(
+    `LLM web search ${next.defaults.llmWebSearch ? 'enabled' : 'disabled'}.`,
+  );
+  return next;
+}
+
+async function promptMode(config: Config): Promise<Config | null> {
+  const mode = await p.select<Defaults['mode']>({
+    message: 'Choose the default execution mode',
+    options: [
+      {
+        value: 'mixed',
+        label: 'mixed',
+        hint: 'Run sync providers and poll async research providers',
+      },
+      {
+        value: 'sync',
+        label: 'sync',
+        hint: 'Run only synchronous providers',
+      },
+      {
+        value: 'async',
+        label: 'async',
+        hint: 'Submit only async deep-research providers',
+      },
+    ],
+    initialValue: config.defaults.mode,
+  });
+  if (p.isCancel(mode)) return null;
+
+  const next = {
+    ...config,
+    defaults: { ...config.defaults, mode },
+  };
+  saveConfig(next);
+  p.log.success(`Default mode set to ${mode}.`);
+  return next;
+}
+
+async function promptOutputDir(config: Config): Promise<Config | null> {
+  const outputDir = await p.text({
+    message: 'Output directory',
+    placeholder: config.defaults.outputDir,
+    validate: (value) =>
+      value?.trim().length ? undefined : 'Enter an output directory',
+  });
+  if (p.isCancel(outputDir)) return null;
+
+  const next = {
+    ...config,
+    defaults: { ...config.defaults, outputDir: outputDir.trim() },
+  };
+  saveConfig(next);
+  p.log.success(`Output directory set to ${next.defaults.outputDir}.`);
+  return next;
+}
+
+async function promptLimits(config: Config): Promise<Config | null> {
+  const maxParallel = await promptPositiveInteger(
+    'Max parallel providers',
+    config.defaults.maxParallel,
+  );
+  if (maxParallel === null) return null;
+
+  const timeout = await promptPositiveInteger(
+    'Sync provider timeout in seconds',
+    config.defaults.timeout,
+  );
+  if (timeout === null) return null;
+
+  const asyncTimeout = await promptPositiveInteger(
+    'Async research timeout in seconds',
+    config.defaults.asyncTimeout,
+  );
+  if (asyncTimeout === null) return null;
+
+  const asyncPollInterval = await promptPositiveInteger(
+    'Async poll interval in seconds',
+    config.defaults.asyncPollInterval,
+  );
+  if (asyncPollInterval === null) return null;
+
+  const next = {
+    ...config,
+    defaults: {
+      ...config.defaults,
+      maxParallel,
+      timeout,
+      asyncTimeout,
+      asyncPollInterval,
+    },
+  };
+  saveConfig(next);
+  p.log.success('Parallelism and timeouts updated.');
+  return next;
+}
+
+async function promptPositiveInteger(
+  label: string,
+  currentValue: number,
+): Promise<number | null> {
+  const value = await p.text({
+    message: `${label} (${currentValue})`,
+    placeholder: String(currentValue),
+    validate: (input) => {
+      const trimmed = input?.trim() ?? '';
+      if (!trimmed) return undefined;
+      const parsed = Number(trimmed);
+      return Number.isInteger(parsed) && parsed > 0
+        ? undefined
+        : 'Enter a positive integer';
+    },
+  });
+  if (p.isCancel(value)) return null;
+  const trimmed = value.trim();
+  return trimmed ? Number(trimmed) : currentValue;
 }
 
 function printConfig(config: Record<string, unknown>, title: string): void {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,12 +4,9 @@ import {
   getAllProviders,
   initializeProviders,
 } from '../adapters/node-registry.js';
-import {
-  hasApiKey,
-  loadConfig,
-  loadProjectConfig,
-  mergeConfigs,
-} from '../core/config.js';
+import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import { providerHasCredential } from '../core/provider-selection.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 
 interface DoctorResult {
   id: string;
@@ -32,7 +29,7 @@ export function registerDoctorCommand(program: Command): void {
         const globalConfig = loadConfig();
         const projectConfig = loadProjectConfig(process.cwd());
         const config = mergeConfigs(globalConfig, projectConfig);
-        const credentials = { env: process.env };
+        const credentials = createNodeCredentialContext();
         const initResult = await initializeProviders({
           ...config,
           credentials,
@@ -49,9 +46,7 @@ export function registerDoctorCommand(program: Command): void {
           const enabled = providerConfig?.enabled ?? false;
           const requiresApiKey = provider.requiresApiKey ?? true;
           const keyPresent = requiresApiKey
-            ? providerConfig
-              ? hasApiKey(providerConfig.apiKey, process.env)
-              : !!process.env[provider.envVar]
+            ? providerHasCredential(provider, providerConfig, credentials)
             : true;
 
           if (!enabled) {

--- a/src/commands/html-report.ts
+++ b/src/commands/html-report.ts
@@ -71,7 +71,6 @@ const markdown = new Marked({
       tokens: unknown;
     }): string {
       const title = token.title ? ` title="${escapeHtml(token.title)}"` : '';
-      // biome-ignore lint/suspicious/noExplicitAny: marked renderer this-binding
       const body = (this as any).parser.parseInline(token.tokens);
       const href = safeUrl(token.href);
       if (href === null) {
@@ -103,9 +102,7 @@ function countLabel(report: ProviderReport): string {
   if (report.status === 'async-pending') return 'submitted';
   if (report.status === 'skipped') return 'skipped';
   if (report.status === 'error') return report.error ? 'error' : 'error';
-  // Ungrounded llm-tier providers contribute no sources by design; mirror the
-  // terminal table and render "ungrounded" instead of "0 sources".
-  if (report.tier === 'llm') return 'ungrounded';
+  if (report.tier === 'llm' && report.citationCount === 0) return 'direct';
   const noun = report.tier === 'raw-search' ? 'results' : 'sources';
   return `${report.citationCount} ${noun}`;
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,9 +3,10 @@ import { initializeProviders } from '../adapters/node-registry.js';
 import {
   computeInitProviderChoices,
   PROVIDER_DISPLAY_NAMES,
-  PROVIDER_ENV_VARS,
 } from '../constants.js';
 import { loadConfig, saveConfig } from '../core/config.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
+import { runOnboardingWizard } from './onboarding.js';
 
 export function registerInitCommand(program: Command): void {
   program
@@ -17,7 +18,8 @@ export function registerInitCommand(program: Command): void {
     )
     .action(async (opts) => {
       try {
-        await initializeProviders({ credentials: { env: process.env } });
+        const credentials = createNodeCredentialContext();
+        await initializeProviders({ credentials });
 
         const existingConfig = loadConfig();
 
@@ -38,12 +40,12 @@ export function registerInitCommand(program: Command): void {
               console.log(`  [+] ${displayName} — ${envVar} found, enabled`);
               enabledCount++;
             } else if (keyPresent && isLlm) {
-              // llm-tier providers are ungrounded and opt-in: never enabled by
-              // --auto even when their (shared) API key is present. Leave any
-              // existing config untouched.
+              // llm-tier providers are opt-in: never enabled by --auto even
+              // when their (shared) API key is present. Leave any existing
+              // config untouched.
               if (!existingConfig.providers[id]) {
                 console.log(
-                  `  [ ] ${displayName} — ${envVar} found, but ungrounded (opt-in; enable with \`-p ${id}\` or \`--group llm\`)`,
+                  `  [ ] ${displayName} — ${envVar} found, but llm-tier providers are opt-in (enable with \`-p ${id}\` or \`--group llm\`)`,
                 );
               } else {
                 console.log(`  [~] ${displayName}: using existing config`);
@@ -64,61 +66,7 @@ export function registerInitCommand(program: Command): void {
           return;
         }
 
-        // Interactive mode
-        const { checkbox } = await import('@inquirer/prompts');
-
-        console.log('\nWelcome to librarium!\n');
-        console.log('This will set up your provider configuration.\n');
-
-        // Show available providers and their env var status
-        const providerChoices: Array<{
-          name: string;
-          value: string;
-          checked: boolean;
-        }> = [];
-
-        for (const choice of computeInitProviderChoices(process.env)) {
-          const { id, keyPresent, isLlm, enableByDefault } = choice;
-          const displayName = PROVIDER_DISPLAY_NAMES[id] || id;
-          const status = keyPresent ? ' (API key found)' : ' (API key missing)';
-          // llm-tier providers are listed but left unchecked, with an
-          // "ungrounded" hint, so the user must opt in explicitly.
-          const hint = isLlm ? ' [ungrounded]' : '';
-          providerChoices.push({
-            name: `${displayName}${status}${hint}`,
-            value: id,
-            checked: enableByDefault,
-          });
-        }
-
-        const selectedProviders = await checkbox({
-          message: 'Select providers to enable:',
-          choices: providerChoices,
-        });
-
-        // Build provider configs
-        for (const id of selectedProviders) {
-          const envVar = PROVIDER_ENV_VARS[id];
-          existingConfig.providers[id] = {
-            apiKey: `$${envVar}`,
-            enabled: true,
-          };
-        }
-
-        // Disable unselected providers that were previously enabled
-        for (const id of Object.keys(PROVIDER_ENV_VARS)) {
-          if (existingConfig.providers[id] && !selectedProviders.includes(id)) {
-            existingConfig.providers[id].enabled = false;
-          }
-        }
-
-        saveConfig(existingConfig);
-
-        console.log(
-          `\nConfig saved with ${selectedProviders.length} providers enabled.`,
-        );
-        console.log('Config location: ~/.config/librarium/config.json');
-        console.log('\nRun `librarium doctor` to verify connectivity.\n');
+        await runOnboardingWizard();
       } catch (e) {
         console.error(e instanceof Error ? e.message : String(e));
         process.exitCode = 1;

--- a/src/commands/llm-client.ts
+++ b/src/commands/llm-client.ts
@@ -1,3 +1,9 @@
+import { PROVIDER_ENV_VARS } from '../constants.js';
+import {
+  type CredentialContext,
+  type EnvRecord,
+  resolveCredential,
+} from '../core/credentials.js';
 import type { Config } from '../types.js';
 
 /**
@@ -25,6 +31,12 @@ export interface LlmClientPreference {
   model?: string;
 }
 
+export interface LlmClientResolutionOptions {
+  env?: EnvRecord;
+  config?: Config;
+  credentials?: CredentialContext;
+}
+
 const CLIENT_DEFAULTS: Record<LlmProvider, { envVar: string; model: string }> =
   {
     openai: { envVar: 'OPENAI_API_KEY', model: 'gpt-5-mini' },
@@ -41,8 +53,9 @@ const CLIENT_DEFAULTS: Record<LlmProvider, { envVar: string; model: string }> =
  */
 export function resolveLlmClients(
   preference: LlmClientPreference | undefined,
-  env: NodeJS.ProcessEnv = process.env,
+  envOrOptions: EnvRecord | LlmClientResolutionOptions = process.env,
 ): LlmClient[] {
+  const options = normalizeResolutionOptions(envOrOptions);
   const preferred = preference?.provider;
   const order: LlmProvider[] = preferred
     ? [preferred]
@@ -50,8 +63,8 @@ export function resolveLlmClients(
 
   const clients: LlmClient[] = [];
   for (const provider of order) {
-    const { envVar, model } = CLIENT_DEFAULTS[provider];
-    const apiKey = env[envVar];
+    const { model } = CLIENT_DEFAULTS[provider];
+    const apiKey = resolveLlmApiKey(provider, options);
     if (!apiKey) continue;
     clients.push({
       provider,
@@ -60,6 +73,55 @@ export function resolveLlmClients(
     });
   }
   return clients;
+}
+
+function normalizeResolutionOptions(
+  envOrOptions: EnvRecord | LlmClientResolutionOptions,
+): Required<Pick<LlmClientResolutionOptions, 'env'>> &
+  Omit<LlmClientResolutionOptions, 'env'> {
+  if (isResolutionOptions(envOrOptions)) {
+    return {
+      ...envOrOptions,
+      env: envOrOptions.env ?? process.env,
+    };
+  }
+  return { env: envOrOptions };
+}
+
+function isResolutionOptions(
+  value: EnvRecord | LlmClientResolutionOptions,
+): value is LlmClientResolutionOptions {
+  const candidate = value as LlmClientResolutionOptions;
+  return (
+    candidate.config !== undefined ||
+    candidate.credentials !== undefined ||
+    (candidate.env !== undefined && typeof candidate.env === 'object')
+  );
+}
+
+function resolveLlmApiKey(
+  provider: LlmProvider,
+  options: Required<Pick<LlmClientResolutionOptions, 'env'>> &
+    Omit<LlmClientResolutionOptions, 'env'>,
+): string | undefined {
+  const envVar = CLIENT_DEFAULTS[provider].envVar;
+  const credentials = { ...options.credentials, env: options.env };
+  const envKey = resolveCredential(`$${envVar}`, credentials);
+  if (envKey) return envKey;
+
+  if (!options.config) return undefined;
+
+  for (const [providerId, providerEnvVar] of Object.entries(
+    PROVIDER_ENV_VARS,
+  )) {
+    if (providerEnvVar !== envVar) continue;
+    const apiKeyRef = options.config.providers[providerId]?.apiKey;
+    if (!apiKeyRef) continue;
+    const resolved = resolveCredential(apiKeyRef, credentials);
+    if (resolved) return resolved;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -4,6 +4,7 @@ import {
   initializeProviders,
 } from '../adapters/node-registry.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import { dimText, isColorEnabled } from './run-format.js';
 
 export function registerLsCommand(program: Command): void {
@@ -16,7 +17,7 @@ export function registerLsCommand(program: Command): void {
         const globalConfig = loadConfig();
         const projectConfig = loadProjectConfig(process.cwd());
         const config = mergeConfigs(globalConfig, projectConfig);
-        const credentials = { env: process.env };
+        const credentials = createNodeCredentialContext();
         const initResult = await initializeProviders({
           ...config,
           credentials,
@@ -58,6 +59,13 @@ export function registerLsCommand(program: Command): void {
         );
         const enabledWidth = Math.max('Enabled'.length, 'Yes'.length);
         const apiKeyWidth = Math.max('API Key'.length, 'Not configured'.length);
+        const credentialSourceWidth = Math.max(
+          'Credential'.length,
+          'Keychain'.length,
+          'Environment'.length,
+          'Config file'.length,
+          'Missing'.length,
+        );
         const color = isColorEnabled(process.stdout);
 
         // Table header
@@ -69,6 +77,7 @@ export function registerLsCommand(program: Command): void {
           'Source'.padEnd(sourceWidth),
           'Enabled'.padEnd(enabledWidth),
           'API Key'.padEnd(apiKeyWidth),
+          'Credential'.padEnd(credentialSourceWidth),
         ].join('  ');
 
         console.log(`\n${header}`);
@@ -84,6 +93,14 @@ export function registerLsCommand(program: Command): void {
             : configured
               ? 'Missing'
               : 'Not configured';
+          const credentialSource =
+            p.credentialSource === 'keychain'
+              ? 'Keychain'
+              : p.credentialSource === 'env'
+                ? 'Environment'
+                : p.credentialSource === 'literal'
+                  ? 'Config file'
+                  : 'Missing';
           const row = [
             p.id.padEnd(idWidth),
             p.displayName.padEnd(nameWidth),
@@ -92,6 +109,7 @@ export function registerLsCommand(program: Command): void {
             p.source.padEnd(sourceWidth),
             enabled.padEnd(enabledWidth),
             apiKey.padEnd(apiKeyWidth),
+            credentialSource.padEnd(credentialSourceWidth),
           ].join('  ');
           console.log(configured ? row : dimText(row, color));
         }

--- a/src/commands/onboarding.ts
+++ b/src/commands/onboarding.ts
@@ -38,6 +38,8 @@ import {
   writeKeychainCredential,
 } from '../node-credentials.js';
 import type { Config, Provider } from '../types.js';
+import { synthesizeAnswer } from './answer.js';
+import { preferenceFromConfig, resolveLlmClients } from './llm-client.js';
 import { executeRun } from './run.js';
 
 type CredentialStorage = 'keychain' | 'env' | 'config';
@@ -386,27 +388,47 @@ export function reusableCredentialRef(
   return hasCredential(envRef, credentials) ? envRef : undefined;
 }
 
-export function firstQueryGuidance(providerId?: string): string {
+export function firstQueryGuidance(
+  providerId?: string,
+  synthesize = false,
+): string {
   const providerFlag = providerId ? ` -p ${providerId}` : '';
+  const command = synthesize ? 'answer' : 'run';
   return [
     'Run `librarium` any time to open the guided research wizard.',
     '',
     'Or start directly with:',
-    `  librarium run "compare flutter vs react native"${providerFlag}`,
+    `  librarium ${command} "compare flutter vs react native"${providerFlag}`,
   ].join('\n');
 }
 
-function showFirstQueryGuidance(providerId?: string): void {
-  p.note(firstQueryGuidance(providerId), 'Try your first query');
+function showFirstQueryGuidance(providerId?: string, synthesize = false): void {
+  p.note(firstQueryGuidance(providerId, synthesize), 'Try your first query');
+}
+
+function hasSynthesisClient(
+  config: Config,
+  credentials: CredentialContext,
+): boolean {
+  return (
+    resolveLlmClients(preferenceFromConfig(config, 'answer', 'refine'), {
+      env: process.env,
+      config,
+      credentials,
+    }).length > 0
+  );
 }
 
 async function offerFirstQuery(
   usableSelected: string[],
+  config: Config,
+  credentials: CredentialContext,
   offerFirstRun: boolean,
 ): Promise<void> {
   const firstProvider = usableSelected[0];
+  const synthesize = hasSynthesisClient(config, credentials);
   if (!offerFirstRun) {
-    showFirstQueryGuidance(firstProvider);
+    showFirstQueryGuidance(firstProvider, synthesize);
     return;
   }
 
@@ -416,8 +438,18 @@ async function offerFirstQuery(
   });
   if (p.isCancel(firstRun)) return cancel();
   if (!firstRun) {
-    showFirstQueryGuidance(firstProvider);
+    showFirstQueryGuidance(firstProvider, synthesize);
     return;
+  }
+
+  if (synthesize) {
+    p.log.message(
+      'A synthesis key is configured, so Librarium will print a grounded answer after the provider run.',
+    );
+  } else {
+    p.log.message(
+      'No synthesis key is configured yet, so this first query will show the provider run summary. Add OPENAI_API_KEY, GEMINI_API_KEY, or PERPLEXITY_API_KEY later to use `librarium answer`.',
+    );
   }
 
   const query = await p.text({
@@ -426,11 +458,17 @@ async function offerFirstQuery(
     validate: (value) => (value?.trim().length ? undefined : 'Enter a query'),
   });
   if (p.isCancel(query)) return cancel();
-  await executeRun(query.trim(), {
-    providers: [firstProvider],
-    mode: 'sync',
-    skipPreflightConfirm: true,
-  });
+  await executeRun(
+    query.trim(),
+    {
+      providers: [firstProvider],
+      mode: 'sync',
+      skipPreflightConfirm: true,
+    },
+    synthesize
+      ? { postDispatch: (context) => synthesizeAnswer(context) }
+      : undefined,
+  );
 }
 
 export async function runOnboardingWizard(
@@ -522,7 +560,12 @@ export async function runOnboardingWizard(
       .map((provider) => provider.id)
       .filter((id) => usable.includes(id));
     if (usableSelected.length > 0) {
-      await offerFirstQuery(usableSelected, offerFirstRun);
+      await offerFirstQuery(
+        usableSelected,
+        updatedConfig,
+        updatedCredentials,
+        offerFirstRun,
+      );
     } else {
       showFirstQueryGuidance(selected[0]?.id);
     }
@@ -580,7 +623,12 @@ export async function runOnboardingWizard(
     `${usableSelected.length} provider(s) configured: ${usableSelected.join(', ')}`,
   );
 
-  await offerFirstQuery(usableSelected, offerFirstRun);
+  await offerFirstQuery(
+    usableSelected,
+    updatedConfig,
+    updatedCredentials,
+    offerFirstRun,
+  );
 
   p.outro('setup complete');
 }

--- a/src/commands/onboarding.ts
+++ b/src/commands/onboarding.ts
@@ -386,6 +386,53 @@ export function reusableCredentialRef(
   return hasCredential(envRef, credentials) ? envRef : undefined;
 }
 
+export function firstQueryGuidance(providerId?: string): string {
+  const providerFlag = providerId ? ` -p ${providerId}` : '';
+  return [
+    'Run `librarium` any time to open the guided research wizard.',
+    '',
+    'Or start directly with:',
+    `  librarium run "compare flutter vs react native"${providerFlag}`,
+  ].join('\n');
+}
+
+function showFirstQueryGuidance(providerId?: string): void {
+  p.note(firstQueryGuidance(providerId), 'Try your first query');
+}
+
+async function offerFirstQuery(
+  usableSelected: string[],
+  offerFirstRun: boolean,
+): Promise<void> {
+  const firstProvider = usableSelected[0];
+  if (!offerFirstRun) {
+    showFirstQueryGuidance(firstProvider);
+    return;
+  }
+
+  const firstRun = await p.confirm({
+    message: 'Run a first query now?',
+    initialValue: true,
+  });
+  if (p.isCancel(firstRun)) return cancel();
+  if (!firstRun) {
+    showFirstQueryGuidance(firstProvider);
+    return;
+  }
+
+  const query = await p.text({
+    message: 'What should Librarium research first?',
+    placeholder: 'e.g. compare flutter vs react native',
+    validate: (value) => (value?.trim().length ? undefined : 'Enter a query'),
+  });
+  if (p.isCancel(query)) return cancel();
+  await executeRun(query.trim(), {
+    providers: [firstProvider],
+    mode: 'sync',
+    skipPreflightConfirm: true,
+  });
+}
+
 export async function runOnboardingWizard(
   options: OnboardingWizardOptions = {},
 ): Promise<void> {
@@ -460,6 +507,25 @@ export async function runOnboardingWizard(
     }
     saveConfig(globalConfig);
     p.log.success('Selected providers were already configured.');
+    const updatedConfig = loadMergedConfig();
+    const updatedCredentials = createNodeCredentialContext();
+    await initializeProviders({
+      ...updatedConfig,
+      credentials: updatedCredentials,
+    });
+    const usable = usableProviderIds(
+      updatedConfig,
+      getAllProviders(),
+      updatedCredentials,
+    );
+    const usableSelected = selected
+      .map((provider) => provider.id)
+      .filter((id) => usable.includes(id));
+    if (usableSelected.length > 0) {
+      await offerFirstQuery(usableSelected, offerFirstRun);
+    } else {
+      showFirstQueryGuidance(selected[0]?.id);
+    }
     p.outro('setup complete');
     return;
   }
@@ -514,28 +580,7 @@ export async function runOnboardingWizard(
     `${usableSelected.length} provider(s) configured: ${usableSelected.join(', ')}`,
   );
 
-  if (offerFirstRun) {
-    const firstRun = await p.confirm({
-      message: 'Run a first query now?',
-      initialValue: true,
-    });
-    if (p.isCancel(firstRun)) return cancel();
-    if (!firstRun) {
-      p.outro('setup complete');
-      return;
-    }
-    const query = await p.text({
-      message: 'What should Librarium research first?',
-      placeholder: 'e.g. compare flutter vs react native',
-      validate: (value) => (value?.trim().length ? undefined : 'Enter a query'),
-    });
-    if (p.isCancel(query)) return cancel();
-    await executeRun(query.trim(), {
-      providers: [usableSelected[0]],
-      mode: 'sync',
-      skipPreflightConfirm: true,
-    });
-  }
+  await offerFirstQuery(usableSelected, offerFirstRun);
 
   p.outro('setup complete');
 }

--- a/src/commands/onboarding.ts
+++ b/src/commands/onboarding.ts
@@ -1,0 +1,541 @@
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import * as p from '@clack/prompts';
+import {
+  getAllProviders,
+  initializeProviders,
+} from '../adapters/node-registry.js';
+import { computeInitProviderChoices, PROVIDER_ENV_VARS } from '../constants.js';
+import {
+  loadConfig,
+  loadProjectConfig,
+  mergeConfigs,
+  saveConfig,
+} from '../core/config.js';
+import {
+  type CredentialContext,
+  hasCredential,
+  keychainCredentialRef,
+} from '../core/credentials.js';
+import {
+  getProviderCatalogEntry,
+  providerTierLabel,
+  recommendedProviderCatalogEntries,
+  sortedProviderCatalogEntries,
+} from '../core/provider-catalog.js';
+import { usableProviderIds } from '../core/provider-selection.js';
+import {
+  createNodeCredentialContext,
+  isKeychainAvailable,
+  writeKeychainCredential,
+} from '../node-credentials.js';
+import type { Config, Provider } from '../types.js';
+import { executeRun } from './run.js';
+
+type CredentialStorage = 'keychain' | 'env' | 'config';
+
+interface KeyPrompt {
+  envVar: string;
+  providerIds: string[];
+  label: string;
+  setupUrl?: string;
+}
+
+interface OnboardingWizardOptions {
+  welcome?: boolean;
+  offerFirstRun?: boolean;
+}
+
+interface ShellProfile {
+  path: string;
+  shell: 'fish' | 'sh';
+}
+
+function cancel(): void {
+  p.cancel('Cancelled.');
+  process.exitCode = 130;
+}
+
+function loadMergedConfig(): Config {
+  return mergeConfigs(loadConfig(), loadProjectConfig(process.cwd()));
+}
+
+function providerHint(provider: Provider): string {
+  const catalog = getProviderCatalogEntry(provider.id);
+  const parts = [
+    providerTierLabel(provider.tier),
+    catalog?.bestFor ?? catalog?.description,
+  ].filter(Boolean);
+  return parts.join(' · ');
+}
+
+function providerLabel(provider: Provider): string {
+  const catalog = getProviderCatalogEntry(provider.id);
+  return catalog
+    ? `${catalog.family}: ${catalog.displayName}`
+    : provider.displayName;
+}
+
+function optionForProvider(provider: Provider) {
+  return {
+    value: provider.id,
+    label: providerLabel(provider),
+    hint: providerHint(provider),
+  };
+}
+
+function providersByIds(ids: string[], providers: Provider[]): Provider[] {
+  const byId = new Map(providers.map((provider) => [provider.id, provider]));
+  return ids
+    .map((id) => byId.get(id))
+    .filter((provider): provider is Provider => Boolean(provider));
+}
+
+function selectedKeyPrompts(selected: Provider[]): KeyPrompt[] {
+  const byEnvVar = new Map<string, KeyPrompt>();
+  for (const provider of selected) {
+    const envVar = PROVIDER_ENV_VARS[provider.id] ?? provider.envVar;
+    if (!envVar) continue;
+    const catalog = getProviderCatalogEntry(provider.id);
+    const existing = byEnvVar.get(envVar);
+    if (existing) {
+      existing.providerIds.push(provider.id);
+      continue;
+    }
+    byEnvVar.set(envVar, {
+      envVar,
+      providerIds: [provider.id],
+      label: catalog?.family ?? provider.displayName,
+      setupUrl: catalog?.setupUrl,
+    });
+  }
+  return [...byEnvVar.values()];
+}
+
+function providerEnvVar(provider: Provider): string {
+  return PROVIDER_ENV_VARS[provider.id] ?? provider.envVar;
+}
+
+function detectShellProfile(): ShellProfile | null {
+  const shell = process.env.SHELL ?? '';
+  if (shell.endsWith('/fish')) {
+    return {
+      path: join(homedir(), '.config', 'fish', 'config.fish'),
+      shell: 'fish',
+    };
+  }
+  if (shell.endsWith('/bash'))
+    return { path: join(homedir(), '.bashrc'), shell: 'sh' };
+  if (shell.endsWith('/zsh'))
+    return { path: join(homedir(), '.zshrc'), shell: 'sh' };
+  return { path: join(homedir(), '.profile'), shell: 'sh' };
+}
+
+function quoteForShell(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function exportLine(
+  envVar: string,
+  value: string,
+  shell: 'fish' | 'sh',
+): string {
+  return shell === 'fish'
+    ? `set -gx ${envVar} ${quoteForShell(value)}`
+    : `export ${envVar}=${quoteForShell(value)}`;
+}
+
+function envFilePath(shell: ShellProfile['shell']): string {
+  return join(
+    homedir(),
+    '.config',
+    'librarium',
+    shell === 'fish' ? 'env.fish' : 'env',
+  );
+}
+
+function sourceLine(path: string, shell: ShellProfile['shell']): string {
+  return shell === 'fish'
+    ? `source ${quoteForShell(path)}`
+    : `[ -f ${quoteForShell(path)} ] && . ${quoteForShell(path)}`;
+}
+
+async function maybeAppendEnvExports(
+  keys: Map<string, string>,
+): Promise<boolean> {
+  const profile = detectShellProfile();
+  if (!profile) return true;
+
+  const destination = envFilePath(profile.shell);
+  const lines = [...keys.entries()].map(([envVar, value]) =>
+    exportLine(envVar, value, profile.shell),
+  );
+  const variables = [...keys.keys()].join(', ');
+  mkdirSync(dirname(destination), { recursive: true });
+  writeFileSync(
+    destination,
+    `# librarium provider API keys\n${lines.join('\n')}\n`,
+    { mode: 0o600 },
+  );
+  chmodSync(destination, 0o600);
+
+  p.log.message(
+    `Saved ${lines.length} API key export(s) to ${destination} with owner-only permissions.`,
+  );
+  const source = sourceLine(destination, profile.shell);
+  const append = await p.confirm({
+    message: `Load these variables from ${profile.path} automatically?`,
+    initialValue: false,
+  });
+  if (p.isCancel(append)) {
+    cancel();
+    return false;
+  }
+  if (!append) {
+    p.note(
+      [
+        'Librarium did not print raw API keys to the terminal.',
+        `To load ${variables}, add this line to your shell profile:`,
+        source,
+      ].join('\n'),
+      'Manual shell setup',
+    );
+    return true;
+  }
+
+  mkdirSync(dirname(profile.path), { recursive: true });
+  const existingProfile = existsSync(profile.path)
+    ? readFileSync(profile.path, 'utf8')
+    : '';
+  if (!existingProfile.includes(source)) {
+    appendFileSync(
+      profile.path,
+      `\n# librarium provider API keys\n${source}\n`,
+    );
+  }
+  p.log.success(
+    `Updated ${profile.path}. Open a new shell or run source ${profile.path}.`,
+  );
+  return true;
+}
+
+async function selectProviders(
+  providers: Provider[],
+): Promise<string[] | null> {
+  const selectionMode = await p.select<string>({
+    message: 'Choose providers to configure',
+    options: [
+      {
+        value: 'recommended',
+        label: 'Recommended starters',
+        hint: 'A short list for a successful first run',
+      },
+      {
+        value: 'all',
+        label: 'Browse all providers',
+        hint: 'Grouped by tier and provider family',
+      },
+      {
+        value: 'auto',
+        label: 'Configure from existing environment variables',
+        hint: 'Use keys already present in this shell',
+      },
+    ],
+  });
+  if (p.isCancel(selectionMode)) return null;
+
+  if (selectionMode === 'auto') {
+    return computeInitProviderChoices(process.env)
+      .filter((choice) => choice.enableByDefault)
+      .map((choice) => choice.id);
+  }
+
+  const catalogEntries =
+    selectionMode === 'recommended'
+      ? recommendedProviderCatalogEntries()
+      : sortedProviderCatalogEntries().sort((a, b) =>
+          a.displayName.localeCompare(b.displayName),
+        );
+  const catalogIds = catalogEntries.map((entry) => entry.id);
+  const choices = providersByIds(catalogIds, providers).map(optionForProvider);
+
+  const picked = await p.multiselect<string>({
+    message:
+      selectionMode === 'recommended'
+        ? 'Select recommended providers'
+        : 'Select providers',
+    options: choices,
+    required: true,
+  });
+  if (p.isCancel(picked)) return null;
+  return picked;
+}
+
+async function selectCredentialStorage(): Promise<CredentialStorage | null> {
+  const options: Array<{
+    value: CredentialStorage;
+    label: string;
+    hint: string;
+  }> = [];
+
+  if (isKeychainAvailable()) {
+    options.push({
+      value: 'keychain',
+      label: 'OS keychain',
+      hint: 'Recommended, stores secrets outside config',
+    });
+  }
+
+  options.push(
+    {
+      value: 'env',
+      label: 'Shell environment variables',
+      hint: 'Portable, stores exports in a private shell env file',
+    },
+    {
+      value: 'config',
+      label: 'Config file',
+      hint: 'Stores keys in ~/.config/librarium/config.json',
+    },
+  );
+
+  const storage = await p.select<CredentialStorage>({
+    message: 'How should Librarium store API keys?',
+    options,
+  });
+  if (p.isCancel(storage)) return null;
+  return storage;
+}
+
+async function promptForKeys(
+  prompts: KeyPrompt[],
+): Promise<Map<string, string> | null> {
+  const keys = new Map<string, string>();
+  for (const prompt of prompts) {
+    const providerList = prompt.providerIds.join(', ');
+    if (prompt.setupUrl) {
+      p.log.message(`${prompt.label}: ${prompt.setupUrl}`);
+    }
+    const value = await p.password({
+      message: `Enter ${prompt.envVar} for ${providerList}`,
+      validate: (input) =>
+        input?.trim().length ? undefined : 'Enter an API key',
+    });
+    if (p.isCancel(value)) return null;
+    keys.set(prompt.envVar, value.trim());
+  }
+  return keys;
+}
+
+function enableSelectedProviders(
+  config: Config,
+  selected: Provider[],
+  storage: CredentialStorage,
+  keys: Map<string, string>,
+  credentials: CredentialContext,
+): void {
+  for (const provider of selected) {
+    const envVar = providerEnvVar(provider);
+    const key = keys.get(envVar);
+
+    let apiKey: string | undefined;
+    if (key) {
+      if (storage === 'keychain') {
+        apiKey = keychainCredentialRef(envVar);
+      } else if (storage === 'env') {
+        apiKey = `$${envVar}`;
+      } else {
+        apiKey = key;
+      }
+    } else {
+      apiKey = reusableCredentialRef(config, selected, envVar, credentials);
+    }
+    if (!apiKey) continue;
+
+    config.providers[provider.id] = {
+      ...config.providers[provider.id],
+      apiKey,
+      enabled: true,
+    };
+  }
+}
+
+export function reusableCredentialRef(
+  config: Config,
+  selected: Provider[],
+  envVar: string,
+  credentials: CredentialContext,
+): string | undefined {
+  for (const provider of selected) {
+    if (providerEnvVar(provider) !== envVar) continue;
+    const configuredRef = config.providers[provider.id]?.apiKey;
+    if (configuredRef && hasCredential(configuredRef, credentials)) {
+      return configuredRef;
+    }
+  }
+
+  const envRef = `$${envVar}`;
+  return hasCredential(envRef, credentials) ? envRef : undefined;
+}
+
+export async function runOnboardingWizard(
+  options: OnboardingWizardOptions = {},
+): Promise<void> {
+  const welcome = options.welcome ?? true;
+  const offerFirstRun = options.offerFirstRun ?? true;
+
+  if (welcome) {
+    p.intro('Welcome to Librarium');
+    p.log.message(
+      "Let's get you to a first successful research run. Librarium uses provider APIs to search, answer, and research in parallel, so setup starts by connecting at least one API key.",
+    );
+    p.log.message(
+      'You can start with a recommended provider, browse the full list, and choose where secrets are stored: OS keychain, shell environment variables, or the config file.',
+    );
+
+    const explain = await p.confirm({
+      message: 'Want a quick explainer before setup?',
+      initialValue: false,
+    });
+    if (p.isCancel(explain)) return cancel();
+    if (explain) {
+      p.note(
+        [
+          'Librarium is a research fan-out CLI. You ask one question, it sends that query to multiple search, grounded-answer, and deep-research providers, then writes a structured run directory with provider outputs, deduped sources, summaries, and optional reports.',
+          '',
+          'Docs: https://librarium.agentsy.build',
+        ].join('\n'),
+        'What Librarium Does',
+      );
+    }
+  } else {
+    p.intro('Provider setup');
+  }
+
+  const globalConfig = loadConfig();
+  const config = loadMergedConfig();
+  const credentials = createNodeCredentialContext();
+  const initResult = await initializeProviders({ ...config, credentials });
+  for (const warning of initResult.warnings) {
+    console.error(`[librarium] warning: ${warning}`);
+  }
+
+  const providers = getAllProviders();
+  const selectedIds = await selectProviders(providers);
+  if (!selectedIds) return cancel();
+
+  if (selectedIds.length === 0) {
+    p.log.warn('No provider API keys were found in your environment.');
+    return;
+  }
+
+  const selected = providersByIds(selectedIds, providers);
+  const keyPrompts = selectedKeyPrompts(selected).filter((prompt) => {
+    return !reusableCredentialRef(
+      globalConfig,
+      selected,
+      prompt.envVar,
+      credentials,
+    );
+  });
+
+  if (keyPrompts.length === 0) {
+    for (const provider of selected) {
+      const envVar = providerEnvVar(provider);
+      globalConfig.providers[provider.id] = {
+        ...globalConfig.providers[provider.id],
+        apiKey:
+          reusableCredentialRef(globalConfig, selected, envVar, credentials) ??
+          `$${envVar}`,
+        enabled: true,
+      };
+    }
+    saveConfig(globalConfig);
+    p.log.success('Selected providers were already configured.');
+    p.outro('setup complete');
+    return;
+  }
+
+  const storage = await selectCredentialStorage();
+  if (!storage) return cancel();
+
+  const keys = await promptForKeys(keyPrompts);
+  if (!keys) return cancel();
+
+  for (const [envVar, key] of keys) {
+    if (storage === 'keychain') {
+      writeKeychainCredential(envVar, key);
+    }
+    if (storage === 'env') {
+      process.env[envVar] = key;
+    }
+  }
+
+  if (storage === 'env') {
+    const envReady = await maybeAppendEnvExports(keys);
+    if (!envReady) return;
+  }
+
+  enableSelectedProviders(globalConfig, selected, storage, keys, credentials);
+  saveConfig(globalConfig);
+
+  const updatedConfig = loadMergedConfig();
+  const updatedCredentials = createNodeCredentialContext();
+  await initializeProviders({
+    ...updatedConfig,
+    credentials: updatedCredentials,
+  });
+  const usable = usableProviderIds(
+    updatedConfig,
+    getAllProviders(),
+    updatedCredentials,
+  );
+  const usableSelected = selected
+    .map((provider) => provider.id)
+    .filter((id) => usable.includes(id));
+
+  if (usableSelected.length === 0) {
+    p.log.warn(
+      'Configuration was saved, but no selected provider has a usable key in this shell. Run `librarium doctor` after refreshing your environment.',
+    );
+    p.outro('setup incomplete');
+    return;
+  }
+
+  p.log.success(
+    `${usableSelected.length} provider(s) configured: ${usableSelected.join(', ')}`,
+  );
+
+  if (offerFirstRun) {
+    const firstRun = await p.confirm({
+      message: 'Run a first query now?',
+      initialValue: true,
+    });
+    if (p.isCancel(firstRun)) return cancel();
+    if (!firstRun) {
+      p.outro('setup complete');
+      return;
+    }
+    const query = await p.text({
+      message: 'What should Librarium research first?',
+      placeholder: 'e.g. compare flutter vs react native',
+      validate: (value) => (value?.trim().length ? undefined : 'Enter a query'),
+    });
+    if (p.isCancel(query)) return cancel();
+    await executeRun(query.trim(), {
+      providers: [usableSelected[0]],
+      mode: 'sync',
+      skipPreflightConfirm: true,
+    });
+  }
+
+  p.outro('setup complete');
+}

--- a/src/commands/refine.ts
+++ b/src/commands/refine.ts
@@ -1,5 +1,7 @@
 import type { Command } from 'commander';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import type { CredentialContext, EnvRecord } from '../core/credentials.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type { Config, ProviderTier } from '../types.js';
 import {
   callWithCascade,
@@ -18,7 +20,7 @@ import {
 export interface RefinedQueries {
   // Partial: refine only produces variants for grounded tiers. The `llm` tier
   // has no refined variant -- its providers fall back to the base query in the
-  // dispatcher (ungrounded baseline/contrast uses the prompt as-is).
+  // dispatcher (llm-tier providers use the prompt as-is).
   tierQueries: Partial<Record<ProviderTier, string>>;
   suggestedGroup?: string;
 }
@@ -100,17 +102,19 @@ export type RefineClient = LlmClient;
  */
 export function resolveRefineClients(
   config: Config,
-  env: NodeJS.ProcessEnv = process.env,
+  env: EnvRecord = process.env,
+  credentials?: CredentialContext,
 ): RefineClient[] {
-  return resolveLlmClients(config.refine, env);
+  return resolveLlmClients(config.refine, { env, config, credentials });
 }
 
 /** First usable refine client, or null. */
 export function resolveRefineClient(
   config: Config,
-  env: NodeJS.ProcessEnv = process.env,
+  env: EnvRecord = process.env,
+  credentials?: CredentialContext,
 ): RefineClient | null {
-  return resolveRefineClients(config, env)[0] ?? null;
+  return resolveRefineClients(config, env, credentials)[0] ?? null;
 }
 
 /**
@@ -142,10 +146,11 @@ const REFINE_TIMEOUT_MS = 30_000;
 export async function refineQuery(
   query: string,
   config: Config,
-  env: NodeJS.ProcessEnv = process.env,
+  env: EnvRecord = process.env,
   onWarning?: (message: string) => void,
+  credentials?: CredentialContext,
 ): Promise<RefinedQueries> {
-  const clients = resolveRefineClients(config, env);
+  const clients = resolveRefineClients(config, env, credentials);
   if (clients.length === 0) {
     throw new Error(
       config.refine?.provider
@@ -178,8 +183,13 @@ export function registerRefineCommand(program: Command): void {
           loadConfig(),
           loadProjectConfig(process.cwd()),
         );
-        const refined = await refineQuery(query, config, process.env, (w) =>
-          console.error(`refine: ${w}`),
+        const credentials = createNodeCredentialContext();
+        const refined = await refineQuery(
+          query,
+          config,
+          process.env,
+          (w) => console.error(`refine: ${w}`),
+          credentials,
         );
         if (opts.json) {
           console.log(JSON.stringify(refined, null, 2));

--- a/src/commands/run-format.ts
+++ b/src/commands/run-format.ts
@@ -86,10 +86,10 @@ export function usageLabel(
 }
 
 function citationLabel(report: ProviderReport, color = false): string {
-  // Ungrounded LLM providers contribute no sources by design; rendering a
-  // dim "ungrounded" reads better than "0 sources".
-  if (report.tier === 'llm') {
-    return paint('ungrounded'.padStart(11), ANSI.dim, color);
+  // LLM providers can run with web search disabled. In that direct-answer
+  // path, "direct" is clearer than showing "0 sources".
+  if (report.tier === 'llm' && report.citationCount === 0) {
+    return paint('direct'.padStart(11), ANSI.dim, color);
   }
   const noun = report.tier === 'raw-search' ? 'results' : 'sources';
   return `${String(report.citationCount).padStart(3)} ${noun}`;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,7 +8,6 @@ import {
   getAllProviders,
   initializeProviders,
 } from '../adapters/node-registry.js';
-import { resolveProviderIds, resolveProviderTokens } from '../constants.js';
 import { saveAsyncTasks } from '../core/async-manager.js';
 import {
   BUDGET_SKIP_REASON,
@@ -25,7 +24,12 @@ import {
   generateSlug,
   resolveOutputDir,
 } from '../core/prompt-builder.js';
+import {
+  ProviderSelectionError,
+  resolveProviderSelection,
+} from '../core/provider-selection.js';
 import { generateSummary } from '../core/synthesis.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type {
   Citation,
   Config,
@@ -216,7 +220,7 @@ export async function executeRun(
       }
 
       const config = mergeConfigs(globalConfig, projectConfig, cliFlags);
-      const credentials = { env: process.env };
+      const credentials = createNodeCredentialContext();
       const initResult = await initializeProviders({
         ...config,
         credentials,
@@ -225,76 +229,24 @@ export async function executeRun(
         console.error(`[librarium] warning: ${warning}`);
       }
 
-      // Resolve provider list
       let providerIds: string[];
-      if (opts.providers) {
-        // CLI tokens accept canonical IDs, legacy aliases, or display names.
-        // The name index covers registered providers plus any configured
-        // provider keys (e.g. an untrusted custom provider). Configured-only
-        // IDs still resolve so they flow into the existing warn-and-skip path
-        // rather than erroring as unknown here.
-        const nameIndex = getAllProviders().map((provider) => ({
-          id: provider.id,
-          displayName: provider.displayName,
-        }));
-        const registeredIds = new Set(nameIndex.map((entry) => entry.id));
-        for (const configuredId of Object.keys(config.providers)) {
-          if (!registeredIds.has(configuredId)) {
-            nameIndex.push({ id: configuredId, displayName: configuredId });
-          }
-        }
-        const resolution = resolveProviderTokens(opts.providers, nameIndex);
-        for (const warning of resolution.warnings) {
-          console.error(`[librarium] warning: ${warning}`);
-        }
-        if (resolution.errors.length > 0) {
-          spinner.fail(resolution.errors.join('\n'));
-          process.exitCode = 2;
-          return { exitCode: 2 };
-        }
-        providerIds = resolution.ids;
-      } else if (opts.group) {
-        const group = config.groups[opts.group];
-        if (!group) {
-          spinner.fail(`Unknown group: ${opts.group}`);
-          process.exitCode = 2;
-          return { exitCode: 2 };
-        }
-        providerIds = resolveProviderIds(group);
-      } else {
-        // Default: use all enabled providers
-        providerIds = resolveProviderIds(
-          Object.entries(config.providers)
-            .filter(([, p]) => p.enabled)
-            .map(([id]) => id),
-        );
-      }
 
-      if (providerIds.length === 0) {
-        spinner.fail(
-          'No providers selected. Run `librarium init` to configure providers.',
+      try {
+        providerIds = resolveProviderSelection(
+          config,
+          { providers: opts.providers, group: opts.group },
+          getAllProviders(),
+          {
+            includeConfiguredOnly: true,
+            requireUsable: true,
+            strictExplicitCredentials: true,
+            credentials,
+            onWarn: (warning) => console.error(warning),
+          },
         );
-        process.exitCode = 2;
-        return { exitCode: 2 };
-      }
-
-      const availableProviderIds = new Set(
-        getAllProviders().map((provider) => provider.id),
-      );
-      const unavailableProviders = providerIds.filter(
-        (id) => !availableProviderIds.has(id),
-      );
-      if (unavailableProviders.length > 0) {
-        console.error(
-          `[librarium] warning: Provider(s) not registered and will be skipped: ${unavailableProviders.join(', ')}`,
-        );
-        providerIds = providerIds.filter((id) => availableProviderIds.has(id));
-      }
-
-      if (providerIds.length === 0) {
-        spinner.fail(
-          'No valid providers selected after validation. Check provider trust/availability in config.',
-        );
+      } catch (e) {
+        if (!(e instanceof ProviderSelectionError)) throw e;
+        spinner.fail(e.message);
         process.exitCode = 2;
         return { exitCode: 2 };
       }
@@ -350,7 +302,13 @@ export async function executeRun(
           if (wasSpinning) spinner.start();
         };
         try {
-          refined = await refineQuery(query, config, process.env, warn);
+          refined = await refineQuery(
+            query,
+            config,
+            process.env,
+            warn,
+            credentials,
+          );
           spinner.stop();
         } catch (e) {
           spinner.stop();

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -15,6 +15,7 @@ import { normalizeUsage } from '../core/dispatcher.js';
 import { safeWriteFile } from '../core/fs-utils.js';
 import { buildProviderMetering } from '../core/metering.js';
 import { deduplicateSources } from '../core/normalizer.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type {
   AsyncTaskHandle,
   Citation,
@@ -255,9 +256,10 @@ export function registerStatusCommand(program: Command): void {
         const globalConfig = loadConfig();
         const projectConfig = loadProjectConfig(process.cwd());
         const config = mergeConfigs(globalConfig, projectConfig);
+        const credentials = createNodeCredentialContext();
         const initResult = await initializeProviders({
           ...config,
-          credentials: { env: process.env },
+          credentials,
         });
         for (const warning of initResult.warnings) {
           console.error(`[librarium] warning: ${warning}`);

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -4,9 +4,15 @@ import {
   initializeProviders,
 } from '../adapters/node-registry.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import {
+  providerHasCredential,
+  usableProviderIds,
+} from '../core/provider-selection.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type { Config, ProviderTier } from '../types.js';
 import { synthesizeAnswer } from './answer.js';
 import { browseRunDir } from './browse.js';
+import { runOnboardingWizard } from './onboarding.js';
 import { resolveRefineClient } from './refine.js';
 import { type ExecuteRunHooks, executeRun, type RunOptions } from './run.js';
 
@@ -47,9 +53,10 @@ function enabledProviderIds(config: Config): string[] {
 
 export async function runWizard(): Promise<void> {
   const config = mergeConfigs(loadConfig(), loadProjectConfig(process.cwd()));
+  const credentials = createNodeCredentialContext();
   const initResult = await initializeProviders({
     ...config,
-    credentials: { env: process.env },
+    credentials,
   });
   for (const warning of initResult.warnings) {
     console.error(`[librarium] warning: ${warning}`);
@@ -57,6 +64,12 @@ export async function runWizard(): Promise<void> {
   const tierById = new Map<string, ProviderTier>(
     getAllProviders().map((provider) => [provider.id, provider.tier]),
   );
+  const usable = usableProviderIds(config, getAllProviders(), credentials);
+
+  if (usable.length === 0) {
+    await runOnboardingWizard();
+    return;
+  }
 
   p.intro('librarium');
 
@@ -69,13 +82,15 @@ export async function runWizard(): Promise<void> {
   if (p.isCancel(query)) return cancel();
 
   // Provider scope: enabled set, a group, or hand-picked providers.
-  const enabled = enabledProviderIds(config);
+  const enabled = enabledProviderIds(config).filter((id) =>
+    usable.includes(id),
+  );
   const scope = await p.select<string>({
     message: 'Which providers?',
     options: [
       {
         value: 'enabled',
-        label: 'all enabled providers',
+        label: 'all usable providers',
         hint: groupHint(enabled, tierById),
       },
       ...Object.entries(config.groups).map(([name, ids]) => ({
@@ -100,7 +115,17 @@ export async function runWizard(): Promise<void> {
       options: getAllProviders().map((provider) => ({
         value: provider.id,
         label: provider.id,
-        hint: `${provider.tier}${config.providers[provider.id]?.enabled ? '' : ', not enabled in config'}`,
+        hint: `${provider.tier}${
+          config.providers[provider.id]?.enabled
+            ? providerHasCredential(
+                provider,
+                config.providers[provider.id],
+                credentials,
+              )
+              ? ''
+              : ', missing API key'
+            : ', not enabled in config'
+        }`,
       })),
       required: true,
     });
@@ -137,7 +162,7 @@ export async function runWizard(): Promise<void> {
   // check so neither prompt appears when no synthesis-capable key is set.
   let refine: boolean | symbol = false;
   let synthesize: boolean | symbol = false;
-  if (resolveRefineClient(config)) {
+  if (resolveRefineClient(config, process.env, credentials)) {
     p.log.message(
       'Refine rewrites your query three ways with one quick LLM call: a research brief for deep research, a focused question for AI answers, keywords for raw search.',
     );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -385,9 +385,9 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'you-research',
     'kagi-fastgpt',
   ],
-  // Ungrounded generic LLMs (tier `llm`). Opt-in only: excluded from every
-  // grounded group above and from `all`. Returns the model's direct answer
-  // with no citations -- baseline/contrast alongside grounded research.
+  // Generic LLMs (tier `llm`). Opt-in only: excluded from every default
+  // grounded group above and from `all`. They can use provider web search and
+  // citations by default, but remain separate from the grounded provider tier.
   llm: ['claude', 'openai-chat', 'gemini-chat', 'openrouter-chat'],
   // `all` is the explicit grounded-all roster (every registered grounded
   // provider). The `llm` tier is intentionally excluded -- it is opt-in via
@@ -417,17 +417,16 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
 };
 
 /**
- * Provider IDs in the ungrounded `llm` tier. These return the model's direct
- * answer with no web grounding or citations, so they are opt-in only: never
- * auto-enabled by `init --auto` and never pre-checked in interactive `init`.
- * The default `run` path (all enabled providers) therefore excludes them
- * unless the user explicitly enabled them in config.
+ * Provider IDs in the `llm` tier. These are opt-in only: never auto-enabled by
+ * `init --auto` and never pre-checked in interactive `init`. The default `run`
+ * path (all enabled providers) therefore excludes them unless the user
+ * explicitly enabled them in config.
  */
 export const LLM_TIER_PROVIDER_IDS: ReadonlySet<string> = new Set(
   DEFAULT_GROUPS.llm,
 );
 
-/** True when the provider id belongs to the ungrounded `llm` tier. */
+/** True when the provider id belongs to the opt-in `llm` tier. */
 export function isLlmTierProvider(id: string): boolean {
   return LLM_TIER_PROVIDER_IDS.has(resolveProviderId(id));
 }
@@ -438,7 +437,7 @@ export interface InitProviderChoice {
   envVar: string;
   /** Whether the matching env var is present in the environment. */
   keyPresent: boolean;
-  /** Whether this provider is in the ungrounded `llm` tier. */
+  /** Whether this provider is in the opt-in `llm` tier. */
   isLlm: boolean;
   /**
    * Whether `init --auto` should enable this provider, and whether interactive

--- a/src/core-entry.ts
+++ b/src/core-entry.ts
@@ -34,4 +34,6 @@ export * from './core/http-client.js';
 export * from './core/metering.js';
 export * from './core/normalizer.js';
 export * from './core/prompt-builder.js';
+export * from './core/provider-catalog.js';
+export * from './core/provider-selection.js';
 export * from './types.js';

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,6 +26,7 @@ const DEFAULT_CONFIG: Config = {
     asyncTimeout: 1800,
     asyncPollInterval: 10,
     mode: 'mixed',
+    llmWebSearch: true,
   },
   providers: {},
   customProviders: {},

--- a/src/core/credentials.ts
+++ b/src/core/credentials.ts
@@ -2,9 +2,45 @@ export type EnvRecord = Record<string, string | undefined>;
 
 export type CredentialResolver = (value: string) => string | undefined;
 
+export const KEYCHAIN_CREDENTIAL_PREFIX = 'keychain:';
+
 export interface CredentialContext {
   env?: EnvRecord;
   resolveCredential?: CredentialResolver;
+}
+
+export type CredentialSource = 'env' | 'keychain' | 'literal' | 'missing';
+
+export interface CredentialReferenceInfo {
+  source: CredentialSource;
+  name?: string;
+}
+
+export function keychainCredentialRef(name: string): string {
+  return `${KEYCHAIN_CREDENTIAL_PREFIX}${name}`;
+}
+
+export function isKeychainCredentialRef(value: string): boolean {
+  return value.startsWith(KEYCHAIN_CREDENTIAL_PREFIX);
+}
+
+export function keychainCredentialName(value: string): string | undefined {
+  if (!isKeychainCredentialRef(value)) return undefined;
+  const name = value.slice(KEYCHAIN_CREDENTIAL_PREFIX.length).trim();
+  return name.length > 0 ? name : undefined;
+}
+
+export function describeCredentialReference(
+  value: string | undefined,
+): CredentialReferenceInfo {
+  if (!value) return { source: 'missing' };
+  if (value.startsWith('$')) {
+    const name = value.slice(1).trim();
+    return name ? { source: 'env', name } : { source: 'missing' };
+  }
+  const keychainName = keychainCredentialName(value);
+  if (keychainName) return { source: 'keychain', name: keychainName };
+  return { source: 'literal' };
 }
 
 /**
@@ -15,11 +51,16 @@ export function resolveCredential(
   context: CredentialContext = {},
 ): string | undefined {
   if (context.resolveCredential) {
-    return context.resolveCredential(value);
+    const resolved = context.resolveCredential(value);
+    if (resolved !== undefined) return resolved;
   }
 
   if (value.startsWith('$')) {
     return context.env?.[value.slice(1)];
+  }
+
+  if (isKeychainCredentialRef(value)) {
+    return undefined;
   }
 
   return value;

--- a/src/core/provider-catalog.ts
+++ b/src/core/provider-catalog.ts
@@ -1,0 +1,289 @@
+import { PROVIDER_DISPLAY_NAMES, PROVIDER_ENV_VARS } from '../constants.js';
+import type { ProviderTier } from '../types.js';
+
+export interface ProviderCatalogEntry {
+  id: string;
+  family: string;
+  displayName: string;
+  envVar: string;
+  tier: ProviderTier;
+  description: string;
+  bestFor: string;
+  setupUrl: string;
+  recommended?: boolean;
+  order: number;
+}
+
+type ProviderCatalogInput = Omit<
+  ProviderCatalogEntry,
+  'displayName' | 'envVar'
+>;
+
+const entries: ProviderCatalogInput[] = [
+  {
+    id: 'brave-search',
+    family: 'Brave',
+    tier: 'raw-search',
+    description: 'Fast raw web search from Brave’s independent index.',
+    bestFor: 'Broad source discovery and a low-friction first provider.',
+    setupUrl: 'https://brave.com/search/api/',
+    recommended: true,
+    order: 10,
+  },
+  {
+    id: 'perplexity-sonar-pro',
+    family: 'Perplexity',
+    tier: 'ai-grounded',
+    description: 'Grounded AI answers with citations through Sonar.',
+    bestFor: 'Quick synthesized answers with source attribution.',
+    setupUrl: 'https://docs.perplexity.ai/docs/getting-started/quickstart',
+    recommended: true,
+    order: 20,
+  },
+  {
+    id: 'exa',
+    family: 'Exa',
+    tier: 'ai-grounded',
+    description: 'AI-oriented web search for finding relevant pages quickly.',
+    bestFor: 'Semantic source discovery and agentic web search.',
+    setupUrl: 'https://exa.ai/docs/reference/getting-started',
+    recommended: true,
+    order: 30,
+  },
+  {
+    id: 'tavily',
+    family: 'Tavily',
+    tier: 'raw-search',
+    description: 'Search and extraction APIs designed for AI agents.',
+    bestFor: 'Agent workflows that need focused search results.',
+    setupUrl: 'https://docs.tavily.com/documentation/quickstart',
+    recommended: true,
+    order: 40,
+  },
+  {
+    id: 'openai-deep',
+    family: 'OpenAI',
+    tier: 'deep-research',
+    description: 'OpenAI deep research for slower, more thorough reports.',
+    bestFor: 'Important questions where depth matters more than latency.',
+    setupUrl: 'https://platform.openai.com/api-keys',
+    order: 110,
+  },
+  {
+    id: 'openai-deep-o3',
+    family: 'OpenAI',
+    tier: 'deep-research',
+    description: 'OpenAI deep research with the heavier o3 model.',
+    bestFor: 'Higher-effort research when cost and latency are acceptable.',
+    setupUrl: 'https://platform.openai.com/api-keys',
+    order: 111,
+  },
+  {
+    id: 'openai-chat',
+    family: 'OpenAI',
+    tier: 'llm',
+    description: 'OpenAI model answer with optional web search citations.',
+    bestFor: 'Direct OpenAI answers; web search is on by default.',
+    setupUrl: 'https://platform.openai.com/api-keys',
+    order: 510,
+  },
+  {
+    id: 'gemini-grounded',
+    family: 'Gemini',
+    tier: 'ai-grounded',
+    description: 'Gemini answers with Google-grounded search.',
+    bestFor: 'Fast grounded answers from the Gemini ecosystem.',
+    setupUrl: 'https://ai.google.dev/gemini-api/docs/api-key',
+    order: 120,
+  },
+  {
+    id: 'gemini-deep',
+    family: 'Gemini',
+    tier: 'deep-research',
+    description: 'Gemini deep research for longer-running investigations.',
+    bestFor: 'Deeper Gemini-backed research.',
+    setupUrl: 'https://ai.google.dev/gemini-api/docs/api-key',
+    order: 121,
+  },
+  {
+    id: 'gemini-chat',
+    family: 'Gemini',
+    tier: 'llm',
+    description: 'Gemini model answer with optional Google Search grounding.',
+    bestFor: 'Direct Gemini answers; web search is on by default.',
+    setupUrl: 'https://ai.google.dev/gemini-api/docs/api-key',
+    order: 520,
+  },
+  {
+    id: 'perplexity-sonar-deep',
+    family: 'Perplexity',
+    tier: 'deep-research',
+    description: 'Perplexity Sonar deep research for comprehensive reports.',
+    bestFor: 'Longer Perplexity research runs.',
+    setupUrl: 'https://docs.perplexity.ai/docs/getting-started/quickstart',
+    order: 130,
+  },
+  {
+    id: 'perplexity-deep-research',
+    family: 'Perplexity',
+    tier: 'deep-research',
+    description: 'Perplexity deep research using the dedicated research API.',
+    bestFor: 'Deep Perplexity-backed reports.',
+    setupUrl: 'https://docs.perplexity.ai/docs/getting-started/quickstart',
+    order: 131,
+  },
+  {
+    id: 'perplexity-advanced-deep',
+    family: 'Perplexity',
+    tier: 'deep-research',
+    description: 'Higher-effort Perplexity deep research.',
+    bestFor: 'More exhaustive Perplexity runs.',
+    setupUrl: 'https://docs.perplexity.ai/docs/getting-started/quickstart',
+    order: 132,
+  },
+  {
+    id: 'perplexity-search',
+    family: 'Perplexity',
+    tier: 'raw-search',
+    description: 'Perplexity search results without full AI synthesis.',
+    bestFor: 'Fast Perplexity source discovery.',
+    setupUrl: 'https://docs.perplexity.ai/docs/getting-started/quickstart',
+    order: 133,
+  },
+  {
+    id: 'brave-answers',
+    family: 'Brave',
+    tier: 'ai-grounded',
+    description: 'Brave AI answers with web grounding.',
+    bestFor: 'A Brave-backed synthesized answer layer.',
+    setupUrl: 'https://brave.com/search/api/',
+    order: 140,
+  },
+  {
+    id: 'openrouter-online',
+    family: 'OpenRouter',
+    tier: 'ai-grounded',
+    description: 'Online search through OpenRouter-compatible models.',
+    bestFor: 'Using one OpenRouter account for online model access.',
+    setupUrl: 'https://openrouter.ai/docs/quickstart',
+    order: 150,
+  },
+  {
+    id: 'openrouter-chat',
+    family: 'OpenRouter',
+    tier: 'llm',
+    description: 'OpenRouter model answer with optional web search citations.',
+    bestFor: 'Direct OpenRouter answers; web search is on by default.',
+    setupUrl: 'https://openrouter.ai/docs/quickstart',
+    order: 530,
+  },
+  {
+    id: 'you-research',
+    family: 'You.com',
+    tier: 'ai-grounded',
+    description: 'You.com research API for real-time web intelligence.',
+    bestFor: 'Cited research through You.com APIs.',
+    setupUrl: 'https://you.com/docs/administration/api-keys',
+    order: 160,
+  },
+  {
+    id: 'kagi-fastgpt',
+    family: 'Kagi',
+    tier: 'ai-grounded',
+    description: 'Kagi FastGPT answers backed by Kagi search.',
+    bestFor: 'Kagi users who want premium search-backed answers.',
+    setupUrl: 'https://help.kagi.com/kagi/api/fastgpt.html',
+    order: 170,
+  },
+  {
+    id: 'jina-search',
+    family: 'Jina AI',
+    tier: 'raw-search',
+    description: 'Jina Search Foundation APIs for search-oriented retrieval.',
+    bestFor: 'Search and reader workflows in the Jina ecosystem.',
+    setupUrl: 'https://jina.ai/reader/',
+    order: 180,
+  },
+  {
+    id: 'firecrawl-search',
+    family: 'Firecrawl',
+    tier: 'raw-search',
+    description: 'Firecrawl search for web search and extraction workflows.',
+    bestFor: 'Search plus downstream scraping/extraction workflows.',
+    setupUrl: 'https://docs.firecrawl.dev/api-reference/v2-introduction',
+    order: 190,
+  },
+  {
+    id: 'searchapi',
+    family: 'SearchAPI',
+    tier: 'raw-search',
+    description: 'SERP scraping API for structured search results.',
+    bestFor: 'Google-style SERP data and structured search output.',
+    setupUrl: 'https://www.searchapi.io/',
+    order: 200,
+  },
+  {
+    id: 'serpapi',
+    family: 'SerpApi',
+    tier: 'raw-search',
+    description: 'Real-time SERP API with structured search results.',
+    bestFor: 'Search-engine result pages with rich structured data.',
+    setupUrl: 'https://serpapi.com/users/sign_up',
+    order: 210,
+  },
+  {
+    id: 'claude',
+    family: 'Anthropic',
+    tier: 'llm',
+    description: 'Claude model answer with optional web search citations.',
+    bestFor: 'Direct Claude answers; web search is on by default.',
+    setupUrl: 'https://platform.claude.com/docs',
+    order: 500,
+  },
+];
+
+export const PROVIDER_CATALOG: Record<string, ProviderCatalogEntry> =
+  Object.fromEntries(
+    entries.map((entry) => [
+      entry.id,
+      {
+        ...entry,
+        displayName: PROVIDER_DISPLAY_NAMES[entry.id] ?? entry.id,
+        envVar: PROVIDER_ENV_VARS[entry.id] ?? '',
+      },
+    ]),
+  );
+
+export function getProviderCatalogEntry(
+  id: string,
+): ProviderCatalogEntry | undefined {
+  return PROVIDER_CATALOG[id];
+}
+
+export function sortedProviderCatalogEntries(
+  ids?: Iterable<string>,
+): ProviderCatalogEntry[] {
+  const allowed = ids ? new Set(ids) : undefined;
+  return Object.values(PROVIDER_CATALOG)
+    .filter((entry) => !allowed || allowed.has(entry.id))
+    .sort(
+      (a, b) => a.order - b.order || a.displayName.localeCompare(b.displayName),
+    );
+}
+
+export function recommendedProviderCatalogEntries(): ProviderCatalogEntry[] {
+  return sortedProviderCatalogEntries().filter((entry) => entry.recommended);
+}
+
+export function providerTierLabel(tier: ProviderTier): string {
+  switch (tier) {
+    case 'deep-research':
+      return 'Deep research';
+    case 'ai-grounded':
+      return 'Grounded answers';
+    case 'raw-search':
+      return 'Raw search';
+    case 'llm':
+      return 'LLM answers';
+  }
+}

--- a/src/core/provider-selection.ts
+++ b/src/core/provider-selection.ts
@@ -1,0 +1,260 @@
+import {
+  type ProviderNameEntry,
+  resolveProviderIds,
+  resolveProviderTokens,
+} from '../constants.js';
+import type { Config, Provider } from '../types.js';
+import type { CredentialContext } from './credentials.js';
+import { hasCredential } from './credentials.js';
+
+export class ProviderSelectionError extends Error {}
+
+export interface ProviderSelectionArgs {
+  providers?: string[];
+  group?: string;
+}
+
+export interface ProviderSelectionOptions {
+  includeConfiguredOnly?: boolean;
+  requireUsable?: boolean;
+  strictExplicitCredentials?: boolean;
+  allowDisabledWithCredentials?: boolean;
+  credentials?: CredentialContext;
+  onWarn?: (message: string) => void;
+}
+
+export interface ProviderAvailabilityResult {
+  providerIds: string[];
+  unavailable: string[];
+  disabled: string[];
+  missingCredentials: string[];
+}
+
+function providerMap(providers: Provider[]): Map<string, Provider> {
+  return new Map(providers.map((provider) => [provider.id, provider]));
+}
+
+export function providerCredentialRef(
+  provider: Pick<Provider, 'envVar'>,
+  config: { apiKey?: string } | undefined,
+): string | undefined {
+  return (
+    config?.apiKey ?? (provider.envVar ? `$${provider.envVar}` : undefined)
+  );
+}
+
+export function providerHasCredential(
+  provider: Pick<Provider, 'envVar' | 'requiresApiKey'>,
+  config: { apiKey?: string } | undefined,
+  credentials: CredentialContext = {},
+): boolean {
+  if ((provider.requiresApiKey ?? true) === false) return true;
+  return hasCredential(providerCredentialRef(provider, config), credentials);
+}
+
+export function buildProviderNameIndex(
+  providers: Provider[],
+  config: Config,
+  includeConfiguredOnly = false,
+): ProviderNameEntry[] {
+  const nameIndex = providers.map((provider) => ({
+    id: provider.id,
+    displayName: provider.displayName,
+  }));
+  if (!includeConfiguredOnly) return nameIndex;
+
+  const registeredIds = new Set(nameIndex.map((entry) => entry.id));
+  for (const configuredId of Object.keys(config.providers)) {
+    if (!registeredIds.has(configuredId)) {
+      nameIndex.push({ id: configuredId, displayName: configuredId });
+    }
+  }
+  return nameIndex;
+}
+
+export function resolveProviderSelection(
+  config: Config,
+  args: ProviderSelectionArgs,
+  providers: Provider[],
+  options: ProviderSelectionOptions = {},
+): string[] {
+  const onWarn = options.onWarn ?? (() => {});
+  let providerIds: string[];
+
+  if (args.providers !== undefined) {
+    const tokens = args.providers
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0);
+    if (tokens.length === 0) {
+      throw new ProviderSelectionError(
+        'The `providers` array was provided but contains no usable provider ids. Omit `providers` to use the default enabled set, or pass at least one provider id.',
+      );
+    }
+
+    const resolution = resolveProviderTokens(
+      tokens,
+      buildProviderNameIndex(
+        providers,
+        config,
+        options.includeConfiguredOnly ?? false,
+      ),
+    );
+    for (const warning of resolution.warnings) {
+      onWarn(`[librarium] warning: ${warning}`);
+    }
+    if (resolution.errors.length > 0) {
+      throw new ProviderSelectionError(resolution.errors.join(' '));
+    }
+    providerIds = resolution.ids;
+  } else if (args.group !== undefined) {
+    const groupName = args.group.trim();
+    if (groupName.length === 0) {
+      throw new ProviderSelectionError(
+        'The `group` was provided but is empty. Omit `group` to use the default enabled set, or pass a configured group name.',
+      );
+    }
+    const group = config.groups[groupName];
+    if (!group) {
+      throw new ProviderSelectionError(`Unknown group: ${groupName}`);
+    }
+    providerIds = resolveProviderIds(group);
+  } else {
+    providerIds = resolveProviderIds(
+      Object.entries(config.providers)
+        .filter(([, providerConfig]) => providerConfig.enabled)
+        .map(([id]) => id),
+    );
+  }
+
+  if (providerIds.length === 0) {
+    throw new ProviderSelectionError(
+      'No providers selected. Run `librarium init` or bare `librarium` to configure providers.',
+    );
+  }
+
+  if (!options.requireUsable) {
+    const registered = new Set(providers.map((provider) => provider.id));
+    const filtered = providerIds.filter((id) => registered.has(id));
+    if (filtered.length === 0) {
+      throw new ProviderSelectionError(
+        'No valid providers selected after validation. Check provider availability in config.',
+      );
+    }
+    return filtered;
+  }
+
+  const availability = filterProviderAvailability(
+    config,
+    providerIds,
+    providers,
+    options.credentials,
+    {
+      allowDisabledWithCredentials:
+        options.allowDisabledWithCredentials ??
+        (args.providers !== undefined || args.group !== undefined),
+    },
+  );
+
+  if (
+    options.strictExplicitCredentials &&
+    args.providers !== undefined &&
+    (availability.disabled.length > 0 ||
+      availability.missingCredentials.length > 0)
+  ) {
+    const problems = [
+      ...availability.disabled.map((id) => `${id} is not enabled`),
+      ...availability.missingCredentials.map(
+        (id) => `${id} is missing an API key`,
+      ),
+    ];
+    throw new ProviderSelectionError(problems.join('; '));
+  }
+
+  for (const id of availability.unavailable) {
+    onWarn(`[librarium] warning: ${id} is not registered and will be skipped`);
+  }
+  for (const id of availability.disabled) {
+    onWarn(`[librarium] warning: ${id} is not enabled and will be skipped`);
+  }
+  for (const id of availability.missingCredentials) {
+    onWarn(
+      `[librarium] warning: ${id} is missing an API key and will be skipped`,
+    );
+  }
+
+  if (availability.providerIds.length === 0) {
+    throw new ProviderSelectionError(
+      'No usable providers selected. Run bare `librarium` to configure at least one API key.',
+    );
+  }
+
+  return availability.providerIds;
+}
+
+export function filterProviderAvailability(
+  config: Config,
+  providerIds: string[],
+  providers: Provider[],
+  credentials: CredentialContext = {},
+  options: Pick<ProviderSelectionOptions, 'allowDisabledWithCredentials'> = {},
+): ProviderAvailabilityResult {
+  const byId = providerMap(providers);
+  const available: string[] = [];
+  const unavailable: string[] = [];
+  const disabled: string[] = [];
+  const missingCredentials: string[] = [];
+
+  for (const id of providerIds) {
+    const provider = byId.get(id);
+    if (!provider) {
+      unavailable.push(id);
+      continue;
+    }
+
+    const providerConfig = config.providers[id];
+    const hasAvailableCredential = providerHasCredential(
+      provider,
+      providerConfig,
+      credentials,
+    );
+    if (!providerConfig?.enabled) {
+      if (options.allowDisabledWithCredentials && hasAvailableCredential) {
+        available.push(id);
+        continue;
+      }
+      disabled.push(id);
+      continue;
+    }
+
+    if (!hasAvailableCredential) {
+      missingCredentials.push(id);
+      continue;
+    }
+
+    available.push(id);
+  }
+
+  return {
+    providerIds: available,
+    unavailable,
+    disabled,
+    missingCredentials,
+  };
+}
+
+export function usableProviderIds(
+  config: Config,
+  providers: Provider[],
+  credentials: CredentialContext = {},
+): string[] {
+  return filterProviderAvailability(
+    config,
+    resolveProviderIds(
+      Object.entries(config.providers)
+        .filter(([, providerConfig]) => providerConfig.enabled)
+        .map(([id]) => id),
+    ),
+    providers,
+    credentials,
+  ).providerIds;
+}

--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -4,7 +4,6 @@ import {
   initializeProviders,
 } from '../adapters/node-registry.js';
 import { type RefinedQueries, refineQuery } from '../commands/refine.js';
-import { resolveProviderIds, resolveProviderTokens } from '../constants.js';
 import { saveAsyncTasks } from '../core/async-manager.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import type { CredentialContext } from '../core/credentials.js';
@@ -17,7 +16,12 @@ import {
   createRunDir,
   generateSlug,
 } from '../core/prompt-builder.js';
+import {
+  ProviderSelectionError,
+  resolveProviderSelection as resolveProviderSelectionCore,
+} from '../core/provider-selection.js';
 import { generateSummary } from '../core/synthesis.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type {
   Citation,
   Config,
@@ -73,7 +77,7 @@ export interface SilentRunResult {
   totalDurationMs: number;
 }
 
-export class ResearchInputError extends Error {}
+export { ProviderSelectionError as ResearchInputError };
 
 function defaultLoadMergedConfig(cliFlags: Partial<Defaults>): Config {
   const globalConfig = loadConfig();
@@ -98,68 +102,9 @@ export function resolveProviderSelection(
   args: Pick<SilentRunArgs, 'providers' | 'group'>,
   onWarn: (message: string) => void = () => {},
 ): string[] {
-  let providerIds: string[];
-
-  if (args.providers !== undefined) {
-    // Explicitly provided: trim tokens and reject an empty selection rather
-    // than silently falling through to group/defaults.
-    const tokens = args.providers
-      .map((token) => token.trim())
-      .filter((token) => token.length > 0);
-    if (tokens.length === 0) {
-      throw new ResearchInputError(
-        'The `providers` array was provided but contains no usable provider ids. Omit `providers` to use the default enabled set, or pass at least one provider id.',
-      );
-    }
-    const known = getAllProviders().map((provider) => ({
-      id: provider.id,
-      displayName: provider.displayName,
-    }));
-    const resolution = resolveProviderTokens(tokens, known);
-    for (const warning of resolution.warnings) {
-      onWarn(`[librarium] warning: ${warning}`);
-    }
-    if (resolution.errors.length > 0) {
-      throw new ResearchInputError(resolution.errors.join(' '));
-    }
-    providerIds = resolution.ids;
-  } else if (args.group !== undefined) {
-    // Explicitly provided group: empty/whitespace is a caller mistake.
-    const groupName = args.group.trim();
-    if (groupName.length === 0) {
-      throw new ResearchInputError(
-        'The `group` was provided but is empty. Omit `group` to use the default enabled set, or pass a configured group name.',
-      );
-    }
-    const group = config.groups[groupName];
-    if (!group) {
-      throw new ResearchInputError(`Unknown group: ${groupName}`);
-    }
-    providerIds = resolveProviderIds(group);
-  } else {
-    providerIds = resolveProviderIds(
-      Object.entries(config.providers)
-        .filter(([, p]) => p.enabled)
-        .map(([id]) => id),
-    );
-  }
-
-  if (providerIds.length === 0) {
-    throw new ResearchInputError(
-      'No providers selected. Run `librarium init` to configure providers.',
-    );
-  }
-
-  // For group/default selections (already-canonical ids), drop any not present
-  // in the registry. Explicit provider tokens were already validated above.
-  const available = new Set(getAllProviders().map((provider) => provider.id));
-  const filtered = providerIds.filter((id) => available.has(id));
-  if (filtered.length === 0) {
-    throw new ResearchInputError(
-      'No valid providers selected after validation. Check provider availability in config.',
-    );
-  }
-  return filtered;
+  return resolveProviderSelectionCore(config, args, getAllProviders(), {
+    onWarn,
+  });
 }
 
 /** Write per-provider markdown + meta files for a completed dispatch. */
@@ -209,7 +154,7 @@ export async function runResearchSilent(
 ): Promise<SilentRunResult> {
   const onWarn =
     deps.onWarn ?? ((message: string) => process.stderr.write(`${message}\n`));
-  const credentials = deps.credentials ?? { env: process.env };
+  const credentials = deps.credentials ?? createNodeCredentialContext();
 
   const cliFlags: Partial<Defaults> = {};
   if (args.mode) cliFlags.mode = args.mode;
@@ -223,14 +168,28 @@ export async function runResearchSilent(
     onWarn(`[librarium] warning: ${warning}`);
   }
 
-  const providerIds = resolveProviderSelection(config, args, onWarn);
+  const providerIds = resolveProviderSelectionCore(
+    config,
+    args,
+    getAllProviders(),
+    {
+      credentials,
+      requireUsable: true,
+      strictExplicitCredentials: true,
+      onWarn,
+    },
+  );
 
   // Optional one-shot LLM refine. Never allowed to break the run.
   let refined: RefinedQueries | null = null;
   if (args.refine) {
     try {
-      refined = await refineQuery(args.query, config, process.env, (message) =>
-        onWarn(`[librarium] refine: ${message}`),
+      refined = await refineQuery(
+        args.query,
+        config,
+        process.env,
+        (message) => onWarn(`[librarium] refine: ${message}`),
+        credentials,
       );
     } catch (e) {
       onWarn(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import {
 } from '../adapters/node-registry.js';
 import { VERSION } from '../constants.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import { createNodeCredentialContext } from '../node-credentials.js';
 import type { Config } from '../types.js';
 import { checkAsyncTasks } from './async.js';
 import {
@@ -199,7 +200,8 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
     async (args): Promise<CallToolResult> => {
       try {
         const config = loadMergedConfig();
-        await initialize({ ...config, credentials: { env: process.env } });
+        const credentials = createNodeCredentialContext();
+        await initialize({ ...config, credentials });
         const baseDir = resolve(config.defaults.outputDir);
         const runDir = resolveRunDir(baseDir, args.runDir);
         if (!runDir) {
@@ -229,7 +231,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
     async (): Promise<CallToolResult> => {
       try {
         const config = loadMergedConfig();
-        const credentials = { env: process.env };
+        const credentials = createNodeCredentialContext();
         const initResult = await initialize({ ...config, credentials });
         for (const warning of initResult.warnings) {
           onWarn(`[librarium] warning: ${warning}`);
@@ -243,6 +245,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
             source: p.source,
             enabled: p.enabled,
             keyConfigured: p.hasApiKey,
+            credentialSource: p.credentialSource,
             configured: p.configured !== false,
           })),
         });

--- a/src/node-credentials.ts
+++ b/src/node-credentials.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { platform } from 'node:os';
+import {
+  type CredentialContext,
+  keychainCredentialName,
+} from './core/credentials.js';
+
+const KEYCHAIN_SERVICE = 'librarium';
+const MACOS_SECURITY = '/usr/bin/security';
+
+export function isKeychainAvailable(): boolean {
+  return platform() === 'darwin' && existsSync(MACOS_SECURITY);
+}
+
+export function readKeychainCredential(name: string): string | undefined {
+  if (!isKeychainAvailable()) return undefined;
+
+  const result = spawnSync(
+    MACOS_SECURITY,
+    ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-a', name, '-w'],
+    { encoding: 'utf8' },
+  );
+
+  if (result.status !== 0) return undefined;
+  const value = result.stdout.replace(/\n$/, '');
+  return value.length > 0 ? value : undefined;
+}
+
+export function writeKeychainCredential(name: string, value: string): void {
+  if (!isKeychainAvailable()) {
+    throw new Error('OS keychain storage is not available on this system.');
+  }
+
+  const result = spawnSync(
+    MACOS_SECURITY,
+    [
+      'add-generic-password',
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-a',
+      name,
+      '-w',
+      value,
+      '-U',
+    ],
+    { encoding: 'utf8' },
+  );
+
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    throw new Error(
+      detail
+        ? `Failed to store keychain credential: ${detail}`
+        : 'Failed to store keychain credential.',
+    );
+  }
+}
+
+export function deleteKeychainCredential(name: string): void {
+  if (!isKeychainAvailable()) return;
+  spawnSync(
+    MACOS_SECURITY,
+    ['delete-generic-password', '-s', KEYCHAIN_SERVICE, '-a', name],
+    { encoding: 'utf8' },
+  );
+}
+
+export function createNodeCredentialContext(
+  env: NodeJS.ProcessEnv = process.env,
+): CredentialContext {
+  return {
+    env,
+    resolveCredential: (value) => {
+      const name = keychainCredentialName(value);
+      return name ? readKeychainCredential(name) : undefined;
+    },
+  };
+}

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -19,6 +19,7 @@ import { getAllProviders, registerProvider } from './adapters/index.js';
 import type { Config } from './types.js';
 
 export type { CustomProviderLoadResult } from './adapters/custom.js';
+export * from './node-credentials.js';
 
 export interface LoadCustomProvidersOptions {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,7 @@ export interface ProviderMeta {
   source: ProviderSource;
   enabled: boolean;
   hasApiKey: boolean;
+  credentialSource: 'env' | 'keychain' | 'literal' | 'missing';
   /** False when the provider has no entry in config (e.g. added after init). */
   configured?: boolean;
   /** How this provider is metered/priced (from the metering registry). */
@@ -251,6 +252,7 @@ export const DefaultsSchema = z.object({
   asyncTimeout: z.number().default(1800),
   asyncPollInterval: z.number().default(10),
   mode: z.enum(['sync', 'async', 'mixed']).default('mixed'),
+  llmWebSearch: z.boolean().default(true),
   // Optional runtime spend circuit breaker. Honest budget: only API-reported
   // costs count toward it (see src/core/budget.ts). Unset means no limit.
   maxCostUsd: z.number().optional(),
@@ -299,6 +301,7 @@ export const ProjectConfigSchema = z.object({
       asyncTimeout: z.number().optional(),
       asyncPollInterval: z.number().optional(),
       mode: z.enum(['sync', 'async', 'mixed']).optional(),
+      llmWebSearch: z.boolean().optional(),
       maxCostUsd: z.number().optional(),
       maxEstimatedCostUsd: z.number().optional(),
     })

--- a/tests/adapters/llm-providers.test.ts
+++ b/tests/adapters/llm-providers.test.ts
@@ -13,7 +13,7 @@ function jsonResponse(status: number, data: unknown): Response {
   } as Response;
 }
 
-describe('llm providers (ungrounded)', () => {
+describe('llm providers', () => {
   const originalFetch = globalThis.fetch;
 
   afterAll(() => {
@@ -26,12 +26,23 @@ describe('llm providers (ungrounded)', () => {
 
   // --- Claude (Anthropic Messages API) ---
 
-  it('calls the Anthropic Messages API and returns no citations', async () => {
+  it('calls the Anthropic Messages API with web search and extracts citations', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse(200, {
         model: 'claude-haiku-4-5',
         content: [
-          { type: 'text', text: 'Direct answer.' },
+          {
+            type: 'text',
+            text: 'Direct answer.',
+            citations: [
+              {
+                type: 'web_search_result_location',
+                url: 'https://example.com/claude',
+                title: 'Claude Source',
+                cited_text: 'Quoted context.',
+              },
+            ],
+          },
           { type: 'text', text: 'Second block.' },
         ],
         usage: { input_tokens: 5, output_tokens: 9 },
@@ -48,7 +59,14 @@ describe('llm providers (ungrounded)', () => {
     expect(result.provider).toBe('claude');
     expect(result.tier).toBe('llm');
     expect(result.content).toBe('Direct answer.\nSecond block.');
-    expect(result.citations).toEqual([]);
+    expect(result.citations).toEqual([
+      {
+        url: 'https://example.com/claude',
+        title: 'Claude Source',
+        snippet: 'Quoted context.',
+        provider: 'claude',
+      },
+    ]);
     expect(result.model).toBe('claude-haiku-4-5');
     expect(result.usage).toMatchObject({
       inputTokens: 5,
@@ -65,6 +83,7 @@ describe('llm providers (ungrounded)', () => {
       model: 'claude-haiku-4-5',
       max_tokens: 4096,
       messages: [{ role: 'user', content: 'what is rust?' }],
+      tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }],
     });
   });
 
@@ -105,16 +124,37 @@ describe('llm providers (ungrounded)', () => {
     expect(result.error).toBe('bad model');
   });
 
-  // --- OpenAI chat completions ---
+  // --- OpenAI Responses API / chat completions ---
 
-  it('calls OpenAI chat completions and returns no citations', async () => {
+  it('calls OpenAI Responses API with web search and extracts citations', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse(200, {
         model: 'gpt-5-mini',
-        choices: [{ message: { content: 'OpenAI answer.' } }],
+        output: [
+          {
+            type: 'web_search_call',
+            status: 'completed',
+          },
+          {
+            type: 'message',
+            content: [
+              {
+                type: 'output_text',
+                text: 'OpenAI answer.',
+                annotations: [
+                  {
+                    type: 'url_citation',
+                    url: 'https://example.com/openai',
+                    title: 'OpenAI Source',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
         usage: {
-          prompt_tokens: 4,
-          completion_tokens: 6,
+          input_tokens: 4,
+          output_tokens: 6,
           total_tokens: 10,
         },
       }),
@@ -130,7 +170,13 @@ describe('llm providers (ungrounded)', () => {
     expect(result.provider).toBe('openai-chat');
     expect(result.tier).toBe('llm');
     expect(result.content).toBe('OpenAI answer.');
-    expect(result.citations).toEqual([]);
+    expect(result.citations).toEqual([
+      {
+        url: 'https://example.com/openai',
+        title: 'OpenAI Source',
+        provider: 'openai-chat',
+      },
+    ]);
     expect(result.usage).toMatchObject({
       inputTokens: 4,
       outputTokens: 6,
@@ -138,10 +184,38 @@ describe('llm providers (ungrounded)', () => {
     });
 
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+    expect(url).toBe('https://api.openai.com/v1/responses');
     expect((options.headers as Record<string, string>).Authorization).toBe(
       'Bearer openai-key',
     );
+    expect(JSON.parse(options.body as string)).toEqual({
+      model: 'gpt-5-mini',
+      input: 'hello',
+      tools: [{ type: 'web_search' }],
+      tool_choice: 'auto',
+    });
+  });
+
+  it('can disable OpenAI web search and use chat completions', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse(200, {
+        model: 'gpt-5-mini',
+        choices: [{ message: { content: 'OpenAI answer.' } }],
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const provider = new OpenAIChatProvider({
+      webSearch: false,
+      credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
+    });
+    const result = await provider.execute('hello', { timeout: 10 });
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe('OpenAI answer.');
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
     expect(JSON.parse(options.body as string)).toEqual({
       model: 'gpt-5-mini',
       messages: [{ role: 'user', content: 'hello' }],
@@ -156,6 +230,7 @@ describe('llm providers (ungrounded)', () => {
     );
 
     const provider = new OpenAIChatProvider({
+      webSearch: false,
       credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
     });
     const result = await provider.execute('hi', { timeout: 10 });
@@ -164,12 +239,32 @@ describe('llm providers (ungrounded)', () => {
     expect(result.error).toBe('unknown model');
   });
 
-  // --- Gemini chat (ungrounded generateContent, no googleSearch tool) ---
+  // --- Gemini chat ---
 
-  it('calls Gemini generateContent without grounding and returns no citations', async () => {
+  it('calls Gemini generateContent with Google Search and extracts citations', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse(200, {
-        candidates: [{ content: { parts: [{ text: 'Gemini answer.' }] } }],
+        candidates: [
+          {
+            content: { parts: [{ text: 'Gemini answer.' }] },
+            groundingMetadata: {
+              groundingChunks: [
+                {
+                  web: {
+                    uri: 'https://example.com/gemini',
+                    title: 'Gemini Source',
+                  },
+                },
+              ],
+              groundingSupports: [
+                {
+                  segment: { text: 'Gemini answer.' },
+                  groundingChunkIndices: [0],
+                },
+              ],
+            },
+          },
+        ],
         usageMetadata: {
           promptTokenCount: 3,
           candidatesTokenCount: 7,
@@ -189,7 +284,14 @@ describe('llm providers (ungrounded)', () => {
     expect(result.provider).toBe('gemini-chat');
     expect(result.tier).toBe('llm');
     expect(result.content).toBe('Gemini answer.');
-    expect(result.citations).toEqual([]);
+    expect(result.citations).toEqual([
+      {
+        url: 'https://example.com/gemini',
+        title: 'Gemini Source',
+        snippet: 'Gemini answer.',
+        provider: 'gemini-chat',
+      },
+    ]);
     expect(result.usage).toMatchObject({
       inputTokens: 3,
       outputTokens: 7,
@@ -204,9 +306,9 @@ describe('llm providers (ungrounded)', () => {
     expect((options.headers as Record<string, string>)['x-goog-api-key']).toBe(
       'gemini-key',
     );
-    // No googleSearch tool -- this is the ungrounded path.
     expect(JSON.parse(options.body as string)).toEqual({
       contents: [{ parts: [{ text: 'explain x' }] }],
+      tools: [{ googleSearch: {} }],
     });
   });
 
@@ -226,13 +328,29 @@ describe('llm providers (ungrounded)', () => {
     expect(result.error).toContain('API key not valid');
   });
 
-  // --- OpenRouter chat (ungrounded, with cost accounting) ---
+  // --- OpenRouter chat (with cost accounting) ---
 
-  it('calls OpenRouter chat with usage accounting and extracts cost', async () => {
+  it('calls OpenRouter chat with web search, usage accounting, and citations', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse(200, {
-        model: 'openai/gpt-4o-mini',
-        choices: [{ message: { content: 'OpenRouter answer.' } }],
+        model: 'openai/gpt-4o-mini:online',
+        choices: [
+          {
+            message: {
+              content: 'OpenRouter answer.',
+              annotations: [
+                {
+                  type: 'url_citation',
+                  url_citation: {
+                    url: 'https://example.com/openrouter',
+                    title: 'OpenRouter Source',
+                    content: 'Source excerpt.',
+                  },
+                },
+              ],
+            },
+          },
+        ],
         usage: {
           prompt_tokens: 4,
           completion_tokens: 8,
@@ -252,7 +370,14 @@ describe('llm providers (ungrounded)', () => {
     expect(result.provider).toBe('openrouter-chat');
     expect(result.tier).toBe('llm');
     expect(result.content).toBe('OpenRouter answer.');
-    expect(result.citations).toEqual([]);
+    expect(result.citations).toEqual([
+      {
+        url: 'https://example.com/openrouter',
+        title: 'OpenRouter Source',
+        snippet: 'Source excerpt.',
+        provider: 'openrouter-chat',
+      },
+    ]);
     expect(result.usage).toMatchObject({
       inputTokens: 4,
       outputTokens: 8,
@@ -266,7 +391,7 @@ describe('llm providers (ungrounded)', () => {
       'Bearer openrouter-key',
     );
     expect(JSON.parse(options.body as string)).toEqual({
-      model: 'openai/gpt-4o-mini',
+      model: 'openai/gpt-4o-mini:online',
       messages: [{ role: 'user', content: 'hello' }],
       usage: { include: true },
     });
@@ -346,6 +471,7 @@ describe('llm providers (ungrounded)', () => {
     );
 
     const provider = new OpenAIChatProvider({
+      webSearch: false,
       credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
     });
     const result = await provider.execute('hi', { timeout: 10 });
@@ -369,6 +495,7 @@ describe('llm providers (ungrounded)', () => {
     );
 
     const provider = new OpenAIChatProvider({
+      webSearch: false,
       credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
     });
     const result = await provider.execute('hi', { timeout: 10 });
@@ -382,6 +509,7 @@ describe('llm providers (ungrounded)', () => {
       .mockResolvedValueOnce(jsonResponse(200, { model: 'gpt-5-mini' }));
 
     const provider = new OpenAIChatProvider({
+      webSearch: false,
       credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
     });
     const result = await provider.execute('hi', { timeout: 10 });

--- a/tests/answer-command.test.ts
+++ b/tests/answer-command.test.ts
@@ -24,6 +24,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
     },
     providers: {},
     customProviders: {},

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -50,6 +50,7 @@ describe('loadConfig', () => {
     expect(config.defaults.asyncTimeout).toBe(1800);
     expect(config.defaults.asyncPollInterval).toBe(10);
     expect(config.defaults.mode).toBe('mixed');
+    expect(config.defaults.llmWebSearch).toBe(true);
     expect(config.customProviders).toEqual({});
     expect(config.trustedProviderIds).toEqual([]);
     expect(config.groups).toHaveProperty('deep');
@@ -84,6 +85,7 @@ describe('loadConfig', () => {
     expect(config.defaults.maxParallel).toBe(4);
     expect(config.defaults.timeout).toBe(60);
     expect(config.defaults.mode).toBe('sync');
+    expect(config.defaults.llmWebSearch).toBe(true);
     expect(config.providers['perplexity-sonar-pro']).toBeDefined();
     expect(config.providers['perplexity-sonar-pro'].enabled).toBe(true);
     // Default groups should be merged in
@@ -144,6 +146,7 @@ describe('mergeConfigs', () => {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
     },
     providers: {
       'perplexity-sonar-pro': {
@@ -314,6 +317,7 @@ describe('validateFallbacks', () => {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
     },
     providers,
     customProviders: {},

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeCredentialReference,
+  hasCredential,
+  keychainCredentialName,
+  keychainCredentialRef,
+  resolveCredential,
+} from '../src/core/credentials.js';
+
+describe('credential references', () => {
+  it('describes env, keychain, literal, and missing references', () => {
+    expect(describeCredentialReference('$BRAVE_API_KEY')).toEqual({
+      source: 'env',
+      name: 'BRAVE_API_KEY',
+    });
+    expect(describeCredentialReference('keychain:BRAVE_API_KEY')).toEqual({
+      source: 'keychain',
+      name: 'BRAVE_API_KEY',
+    });
+    expect(describeCredentialReference('literal-key')).toEqual({
+      source: 'literal',
+    });
+    expect(describeCredentialReference(undefined)).toEqual({
+      source: 'missing',
+    });
+  });
+
+  it('builds and parses keychain references', () => {
+    const ref = keychainCredentialRef('PERPLEXITY_API_KEY');
+    expect(ref).toBe('keychain:PERPLEXITY_API_KEY');
+    expect(keychainCredentialName(ref)).toBe('PERPLEXITY_API_KEY');
+    expect(keychainCredentialName('$PERPLEXITY_API_KEY')).toBeUndefined();
+  });
+
+  it('lets an injected resolver handle keychain references and falls back to env vars', () => {
+    const context = {
+      env: { EXA_API_KEY: 'env-key' },
+      resolveCredential: (value: string) =>
+        value === 'keychain:BRAVE_API_KEY' ? 'keychain-key' : undefined,
+    };
+
+    expect(resolveCredential('keychain:BRAVE_API_KEY', context)).toBe(
+      'keychain-key',
+    );
+    expect(resolveCredential('$EXA_API_KEY', context)).toBe('env-key');
+    expect(hasCredential('keychain:BRAVE_API_KEY', context)).toBe(true);
+  });
+
+  it('treats unresolved keychain references as missing credentials', () => {
+    const context = {
+      resolveCredential: () => undefined,
+    };
+
+    expect(
+      resolveCredential('keychain:BRAVE_API_KEY', context),
+    ).toBeUndefined();
+    expect(hasCredential('keychain:BRAVE_API_KEY', context)).toBe(false);
+  });
+});

--- a/tests/default-groups.test.ts
+++ b/tests/default-groups.test.ts
@@ -18,7 +18,7 @@ const GROUNDED_GROUPS = [
 ] as const;
 
 describe('default groups -- llm tier', () => {
-  it('defines an llm group with exactly the four ungrounded providers', () => {
+  it('defines an llm group with exactly the four opt-in providers', () => {
     expect(DEFAULT_GROUPS.llm).toEqual([...LLM_PROVIDERS]);
   });
 

--- a/tests/dispatcher-budget.test.ts
+++ b/tests/dispatcher-budget.test.ts
@@ -24,6 +24,7 @@ function makeConfig(
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'sync',
+      llmWebSearch: true,
     },
     providers,
     groups: {},

--- a/tests/dispatcher-fallback.test.ts
+++ b/tests/dispatcher-fallback.test.ts
@@ -30,6 +30,7 @@ function makeConfig(
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
     },
     providers,
     groups: {},

--- a/tests/fixtures/config/mock-config.ts
+++ b/tests/fixtures/config/mock-config.ts
@@ -82,6 +82,7 @@ export function buildMockConfig(spec: MockConfigSpec): Record<string, unknown> {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: spec.mode ?? 'sync',
+      llmWebSearch: true,
     },
     providers,
     customProviders,

--- a/tests/html-report.test.ts
+++ b/tests/html-report.test.ts
@@ -306,7 +306,7 @@ describe('generateHtmlReport', () => {
     );
   });
 
-  it('labels successful llm-tier rows "ungrounded" instead of "0 sources"', () => {
+  it('labels direct llm-tier rows "direct" instead of "0 sources"', () => {
     const html = generateHtmlReport({
       manifest: makeManifest({
         providers: [
@@ -323,10 +323,30 @@ describe('generateHtmlReport', () => {
       providerContents: {},
       sources: SOURCES,
     });
-    expect(html).toContain('ungrounded');
+    expect(html).toContain('direct');
     expect(html).not.toContain('0 sources');
     // Other tiers keep their counts.
     expect(html).toContain('25 sources');
+  });
+
+  it('shows source counts for cited llm-tier rows', () => {
+    const html = generateHtmlReport({
+      manifest: makeManifest({
+        providers: [
+          makeReport({
+            id: 'claude',
+            tier: 'llm',
+            citationCount: 2,
+            outputFile: 'claude.md',
+            metaFile: 'claude.meta.json',
+          }),
+        ],
+      }),
+      providerContents: {},
+      sources: SOURCES,
+    });
+    expect(html).toContain('2 sources');
+    expect(html).not.toContain('direct');
   });
 
   it('keeps error/skipped labels for llm-tier rows', () => {
@@ -347,7 +367,7 @@ describe('generateHtmlReport', () => {
       sources: [],
     });
     expect(html).toContain('error');
-    expect(html).not.toContain('ungrounded');
+    expect(html).not.toContain('direct');
   });
 
   it('marks fallback providers in the summary row', () => {

--- a/tests/init-provider-choices.test.ts
+++ b/tests/init-provider-choices.test.ts
@@ -14,7 +14,7 @@ const LLM_PROVIDERS = [
 ] as const;
 
 describe('isLlmTierProvider', () => {
-  it('identifies the four ungrounded llm providers', () => {
+  it('identifies the four opt-in llm providers', () => {
     for (const id of LLM_PROVIDERS) {
       expect(isLlmTierProvider(id)).toBe(true);
     }

--- a/tests/integration/dist-registry.test.ts
+++ b/tests/integration/dist-registry.test.ts
@@ -129,6 +129,7 @@ describe('dist registry sharing (core + node)', () => {
           asyncTimeout: 60,
           asyncPollInterval: 1,
           mode: 'sync',
+          llmWebSearch: true,
         },
         providers: { 'dist-lib-provider': { enabled: true } },
         customProviders: {},

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -18,6 +18,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
     },
     providers: {},
     customProviders: {},
@@ -59,6 +60,55 @@ describe('resolveLlmClients', () => {
     );
     expect(clients[0]?.model).toBe('custom');
     expect(clients[1]?.model).toBe('gemini-2.5-flash');
+  });
+
+  it('resolves configured provider credentials when env vars are absent', () => {
+    const config = makeConfig({
+      providers: {
+        'openai-chat': {
+          enabled: true,
+          apiKey: 'literal-openai-key',
+        },
+      },
+    });
+
+    const clients = resolveLlmClients(undefined, { env: {}, config });
+
+    expect(clients).toEqual([
+      {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        apiKey: 'literal-openai-key',
+      },
+    ]);
+  });
+
+  it('resolves keychain-backed provider credentials', () => {
+    const config = makeConfig({
+      providers: {
+        'gemini-grounded': {
+          enabled: true,
+          apiKey: 'keychain:GEMINI_API_KEY',
+        },
+      },
+    });
+
+    const clients = resolveLlmClients(undefined, {
+      env: {},
+      config,
+      credentials: {
+        resolveCredential: (ref) =>
+          ref === 'keychain:GEMINI_API_KEY' ? 'gemini-keychain-key' : undefined,
+      },
+    });
+
+    expect(clients).toEqual([
+      {
+        provider: 'gemini',
+        model: 'gemini-2.5-flash',
+        apiKey: 'gemini-keychain-key',
+      },
+    ]);
   });
 });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -52,6 +52,7 @@ function makeConfig(overrides: Partial<Config['defaults']> = {}): Config {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
       ...overrides,
     },
     providers: {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { reusableCredentialRef } from '../src/commands/onboarding.js';
+import {
+  firstQueryGuidance,
+  reusableCredentialRef,
+} from '../src/commands/onboarding.js';
 import type { Config, Provider } from '../src/types.js';
 
 function provider(id: string, envVar: string): Provider {
@@ -68,5 +71,18 @@ describe('onboarding credential reuse', () => {
     );
 
     expect(ref).toBeUndefined();
+  });
+});
+
+describe('onboarding first-query guidance', () => {
+  it('shows the guided wizard and a direct first query command', () => {
+    expect(firstQueryGuidance()).toContain('librarium`');
+    expect(firstQueryGuidance()).toContain(
+      'librarium run "compare flutter vs react native"',
+    );
+  });
+
+  it('includes a provider flag when a usable provider is known', () => {
+    expect(firstQueryGuidance('brave-search')).toContain('-p brave-search');
   });
 });

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { reusableCredentialRef } from '../src/commands/onboarding.js';
+import type { Config, Provider } from '../src/types.js';
+
+function provider(id: string, envVar: string): Provider {
+  return {
+    id,
+    displayName: id,
+    tier: 'llm',
+    envVar,
+    execute: async () => ({
+      provider: id,
+      tier: 'llm',
+      content: '',
+      citations: [],
+      durationMs: 0,
+    }),
+  };
+}
+
+function config(): Config {
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel: 6,
+      timeout: 30,
+      asyncTimeout: 1800,
+      asyncPollInterval: 10,
+      mode: 'mixed',
+      llmWebSearch: true,
+    },
+    providers: {
+      'openai-deep': {
+        enabled: true,
+        apiKey: 'keychain:OPENAI_API_KEY',
+      },
+    },
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {},
+  };
+}
+
+describe('onboarding credential reuse', () => {
+  it('reuses keychain-backed credentials across providers that share an env var', () => {
+    const selected = [
+      provider('openai-deep', 'OPENAI_API_KEY'),
+      provider('openai-chat', 'OPENAI_API_KEY'),
+    ];
+
+    const ref = reusableCredentialRef(config(), selected, 'OPENAI_API_KEY', {
+      resolveCredential: (value) =>
+        value === 'keychain:OPENAI_API_KEY' ? 'openai-key' : undefined,
+    });
+
+    expect(ref).toBe('keychain:OPENAI_API_KEY');
+  });
+
+  it('does not invent an env ref when no shared credential is available', () => {
+    const selected = [provider('openai-chat', 'OPENAI_API_KEY')];
+
+    const ref = reusableCredentialRef(
+      { ...config(), providers: {} },
+      selected,
+      'OPENAI_API_KEY',
+      { env: {} },
+    );
+
+    expect(ref).toBeUndefined();
+  });
+});

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -85,4 +85,10 @@ describe('onboarding first-query guidance', () => {
   it('includes a provider flag when a usable provider is known', () => {
     expect(firstQueryGuidance('brave-search')).toContain('-p brave-search');
   });
+
+  it('uses the answer command when synthesis is available', () => {
+    expect(firstQueryGuidance('perplexity-sonar-pro', true)).toContain(
+      'librarium answer "compare flutter vs react native" -p perplexity-sonar-pro',
+    );
+  });
 });

--- a/tests/provider-selection.test.ts
+++ b/tests/provider-selection.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ProviderSelectionError,
+  providerCredentialRef,
+  resolveProviderSelection,
+  usableProviderIds,
+} from '../src/core/provider-selection.js';
+import type { Config, Provider } from '../src/types.js';
+
+function provider(id: string, envVar: string): Provider {
+  return {
+    id,
+    displayName: id,
+    tier: 'raw-search',
+    envVar,
+    execute: async () => ({
+      provider: id,
+      tier: 'raw-search',
+      content: '',
+      citations: [],
+      durationMs: 0,
+    }),
+  };
+}
+
+const providers = [
+  provider('brave-search', 'BRAVE_API_KEY'),
+  provider('exa', 'EXA_API_KEY'),
+];
+
+function config(): Config {
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel: 6,
+      timeout: 30,
+      asyncTimeout: 1800,
+      asyncPollInterval: 10,
+      mode: 'mixed',
+      llmWebSearch: true,
+    },
+    providers: {
+      'brave-search': { enabled: true, apiKey: '$BRAVE_API_KEY' },
+      exa: { enabled: true, apiKey: '$EXA_API_KEY' },
+    },
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {
+      quick: ['brave-search', 'exa'],
+    },
+  };
+}
+
+describe('provider selection', () => {
+  it('uses provider env vars when config has no explicit apiKey', () => {
+    expect(providerCredentialRef(providers[0], undefined)).toBe(
+      '$BRAVE_API_KEY',
+    );
+    expect(providerCredentialRef(providers[0], { apiKey: 'literal' })).toBe(
+      'literal',
+    );
+  });
+
+  it('returns only usable enabled providers', () => {
+    const ids = usableProviderIds(config(), providers, {
+      env: { BRAVE_API_KEY: 'brave-key' },
+    });
+    expect(ids).toEqual(['brave-search']);
+  });
+
+  it('skips missing-key providers for group/default selections', () => {
+    const warnings: string[] = [];
+    const ids = resolveProviderSelection(
+      config(),
+      { group: 'quick' },
+      providers,
+      {
+        requireUsable: true,
+        credentials: { env: { BRAVE_API_KEY: 'brave-key' } },
+        onWarn: (message) => warnings.push(message),
+      },
+    );
+
+    expect(ids).toEqual(['brave-search']);
+    expect(warnings.join('\n')).toContain('exa is missing an API key');
+  });
+
+  it('fails fast when explicit providers are missing keys', () => {
+    expect(() =>
+      resolveProviderSelection(config(), { providers: ['exa'] }, providers, {
+        requireUsable: true,
+        strictExplicitCredentials: true,
+        credentials: { env: {} },
+      }),
+    ).toThrow(ProviderSelectionError);
+  });
+
+  it('allows explicit providers with credentials even when not enabled', () => {
+    const c = config();
+    c.providers.exa.enabled = false;
+
+    const ids = resolveProviderSelection(c, { providers: ['exa'] }, providers, {
+      requireUsable: true,
+      strictExplicitCredentials: true,
+      credentials: { env: { EXA_API_KEY: 'exa-key' } },
+    });
+
+    expect(ids).toEqual(['exa']);
+  });
+
+  it('allows explicit groups to opt into credentialed disabled providers', () => {
+    const c = config();
+    c.providers.exa.enabled = false;
+
+    const ids = resolveProviderSelection(c, { group: 'quick' }, providers, {
+      requireUsable: true,
+      credentials: {
+        env: { BRAVE_API_KEY: 'brave-key', EXA_API_KEY: 'exa-key' },
+      },
+    });
+
+    expect(ids).toEqual(['brave-search', 'exa']);
+  });
+
+  it('keeps default selections limited to enabled providers', () => {
+    const c = config();
+    c.providers.exa.enabled = false;
+
+    const ids = resolveProviderSelection(c, {}, providers, {
+      requireUsable: true,
+      credentials: {
+        env: { BRAVE_API_KEY: 'brave-key', EXA_API_KEY: 'exa-key' },
+      },
+    });
+
+    expect(ids).toEqual(['brave-search']);
+  });
+
+  it('fails when no usable provider remains', () => {
+    expect(() =>
+      resolveProviderSelection(config(), {}, providers, {
+        requireUsable: true,
+        credentials: { env: {} },
+      }),
+    ).toThrow(/No usable providers selected/);
+  });
+});

--- a/tests/refine.test.ts
+++ b/tests/refine.test.ts
@@ -27,6 +27,7 @@ function makeConfig(refine?: Config['refine']): Config {
       asyncTimeout: 1800,
       asyncPollInterval: 10,
       mode: 'mixed',
+      llmWebSearch: true,
     },
     providers: {},
     customProviders: {},

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -187,6 +187,37 @@ describe('registry', () => {
     );
   });
 
+  it('enables llm web search by default and allows global/provider overrides', async () => {
+    await initializeProviders();
+    expect((getProvider('claude') as { webSearch?: boolean }).webSearch).toBe(
+      true,
+    );
+    expect(
+      (getProvider('openai-chat') as { webSearch?: boolean }).webSearch,
+    ).toBe(true);
+
+    await initializeProviders({
+      defaults: {
+        outputDir: './agents/librarium',
+        maxParallel: 6,
+        timeout: 30,
+        asyncTimeout: 1800,
+        asyncPollInterval: 10,
+        mode: 'mixed',
+        llmWebSearch: false,
+      },
+      providers: {
+        'openai-chat': { options: { webSearch: true } },
+      },
+    });
+    expect((getProvider('claude') as { webSearch?: boolean }).webSearch).toBe(
+      false,
+    );
+    expect(
+      (getProvider('openai-chat') as { webSearch?: boolean }).webSearch,
+    ).toBe(true);
+  });
+
   it('initializeProviders applies gemini model config override', async () => {
     await initializeProviders({
       providers: {

--- a/tests/workers/core.test.ts
+++ b/tests/workers/core.test.ts
@@ -21,6 +21,7 @@ function makeConfig(): Config {
       asyncTimeout: 60,
       asyncPollInterval: 1,
       mode: 'sync',
+      llmWebSearch: true,
     },
     providers: {
       'worker-mock': {


### PR DESCRIPTION
## Summary

Improves first-run onboarding and configuration so new users can choose providers, understand tradeoffs, store API keys safely, and reach a usable setup. Bumps Librarium to `1.1.0`.

## Changes

- Add a first-run onboarding wizard for bare `librarium` and no-provider states, with a warmer intro, docs link, recommended providers, and access to the full provider list.
- Add provider catalog metadata, setup URLs, clearer descriptions, alphabetical browsing, and recommended starter providers.
- Add credential storage support for OS keychain, shell env-file storage, and config-file fallback.
- Add `librarium config` menu flows for provider setup and settings, including `defaults.llmWebSearch`.
- Enable LLM providers to use web search/citations by default, while keeping LLMs opt-in for normal grounded runs.
- Fix provider selection so explicit `-p` / `--group` can opt into credentialed providers that are not enabled by default.
- Fix LLM synthesis/refine credential resolution for keychain/config-backed provider keys.
- Update README docs and tests for onboarding, credentials, provider selection, LLM web search, and reports.

## Testing

- [x] Added / updated unit tests (`npm test`)
- [ ] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

Additional validation:

- `npm run typecheck`
- `npm test` (44 files, 522 tests)
- `npm run lint`
- `npm run test:pty`
- `npx vitest run tests/readme-drift.test.ts`
- `/tmp/librarium-onboarding-test-cwd/run-librarium-isolated.sh --version` -> `1.1.0`
- Deep review completed with final GO decisions for goals, security, and code quality after fixing findings from earlier rounds.

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] New providers include an adapter in `src/adapters/` and are registered in `src/adapters/index.ts`
- [x] Config changes are reflected in `src/core/config.ts` and `src/types.ts`
