### PR TITLE
feat: provider metering capability registry (#1609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Provider metering capability registry** (`librarium/core`): every provider now declares a `metering_kind` (`native_cost`, `native_tokens`, `request_priced`, `credit_priced`, `api_unit_priced`, or `manual_unmetered`), visible in `librarium ls` and `ls --json`. A network-free `estimateMetering()` returns a pre-dispatch estimate (`estimatedCostUsd`, `billableUnits`, `unit`, `pricingVersion`, `costConfidence`) without any API call, and `buildProviderMetering()` is the single normalization path used across sync dispatch, fallback, and async retrieval. New `getMeteringKind()`, `estimateMetering()`, `buildProviderMetering()`, and `createEstimateBudgetTracker()` exports.
+- **`--max-estimated-cost <usd>` flag** (and `defaults.maxEstimatedCostUsd`) on `run` and `answer`: a pre-dispatch *reservation* ceiling that reserves each provider's estimated cost before it launches and skips launches once the estimate crosses the ceiling. Independent of the reported-only `--max-cost` (the two never reconcile); providers with no estimable cost reserve `0`.
+- Metering is exposed through dispatch results, `run.json`, per-provider `.meta.json` (CLI run, MCP `research`, and both async-retrieval paths: `status --retrieve` and the MCP `check_async` tool), `results.jsonl`, MCP shaping, and the `usage` command (a separate `est. cost` lane).
+
+### Notes
+- Honesty preserved: `usage.costUsd` remains provider-reported only. Estimates live under `metering.estimate` and never become facts; plan-dependent credit/API-unit providers emit unit metadata without a fabricated USD figure until pricing is configured via provider `options`. Actual-cost provenance is recorded under `metering.actual.source`.
+
 ## [1.0.0] - 2026-06-12
 
 The first stable release: the 0.1.x research fan-out core plus a complete interactive and agent-integration layer shipped in one release -- live per-provider results table, interactive wizard, results browser with a fullscreen reader, HTML and JSONL reports, grounded `answer` synthesis, an MCP server, an `llm` provider tier, spend guardrails, true async deep research on Perplexity and Gemini, and committed PTY test coverage.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ librarium run <query> [options]
 | `--parallel <n>` | Max parallel requests |
 | `--timeout <n>` | Timeout per provider in seconds |
 | `--max-cost <usd>` | Stop launching providers once API-reported cost crosses this budget (see [Spend guardrails](#spend-guardrails)) |
+| `--max-estimated-cost <usd>` | Reserve each provider's pre-dispatch *estimated* cost and skip launches once the estimate crosses this ceiling (see [Spend guardrails](#spend-guardrails)) |
 | `-y, --yes` | Skip the deep-research pre-flight confirm |
 | `--json` | Output `run.json` to stdout |
 | `--refine` | Rewrite the query into tier-tuned variants with one LLM call before dispatch |
@@ -305,7 +306,7 @@ $ librarium answer "what changed in postgres 17 logical replication"
   ▸ ~/research/agents/librarium/1781136000-what-changed-in-postgres-17/
 ```
 
-The synthesis call uses the first available of OpenAI (`gpt-5-mini`), Gemini (`gemini-2.5-flash`), or Perplexity (`sonar`), overridable via an `answer: { provider, model }` config key that falls back to the `refine` config and then to those defaults. Synthesis fails open: if every client fails (quota, auth, timeout), a detailed warning prints and the run summary and output directory still appear, so the research is never lost. The exit code reflects the run, not the synthesis. `answer` accepts the same run flags, including `--max-cost`, `--html`, and `--jsonl`. When the run directory contains `answer.md`, both `report.html` (an Answer section leading the report) and `results.jsonl` (an `"type":"answer"` line) pick it up automatically on generation and regeneration. The interactive wizard also offers grounded synthesis after its refine prompt when an LLM client key is configured.
+The synthesis call uses the first available of OpenAI (`gpt-5-mini`), Gemini (`gemini-2.5-flash`), or Perplexity (`sonar`), overridable via an `answer: { provider, model }` config key that falls back to the `refine` config and then to those defaults. Synthesis fails open: if every client fails (quota, auth, timeout), a detailed warning prints and the run summary and output directory still appear, so the research is never lost. The exit code reflects the run, not the synthesis. `answer` accepts the same run flags, including `--max-cost`, `--max-estimated-cost`, `--html`, and `--jsonl`. When the run directory contains `answer.md`, both `report.html` (an Answer section leading the report) and `results.jsonl` (an `"type":"answer"` line) pick it up automatically on generation and regeneration. The interactive wizard also offers grounded synthesis after its refine prompt when an LLM client key is configured.
 ### Spend guardrails
 
 Two opt-in guardrails help avoid surprise spend on large fan-outs.
@@ -326,6 +327,31 @@ The budget is honest, not predictive. Only costs an API actually reports count t
 - Deep-research costs land at *retrieval* (when you run `librarium status --wait`), long after the dispatch that submitted them has returned. Those async costs cannot be pre-metered and so cannot be enforced by `--max-cost` at submit time.
 
 Use `--max-cost` as a backstop against runaway synchronous fan-outs, not as a hard billing cap.
+
+#### Metering registry and the estimated budget
+
+`--max-cost` is deliberately reported-only: it never guesses. The gap it leaves — providers that report no cost (most raw-search APIs) run "for free" as far as the breaker is concerned — is filled by a separate, opt-in **estimated** lane.
+
+Every provider declares a **metering kind** in a built-in registry, visible in `librarium ls` (and its `--json`):
+
+| Kind | Meaning | Examples |
+|---|---|---|
+| `native_cost` | API returns a real per-call cost | Perplexity, Exa, OpenRouter |
+| `native_tokens` | API returns token counts but no cost | Claude, OpenAI, Gemini |
+| `request_priced` | Deterministic/plan price per request | SerpAPI, SearchAPI, Brave, Kagi |
+| `credit_priced` | Priced in account credits per request | Tavily, Firecrawl, You.com |
+| `api_unit_priced` | Priced per API unit/token, size known only after the call | Jina |
+| `manual_unmetered` | No reliable per-call metering | custom providers |
+
+For request- and credit-priced providers, librarium can produce a **network-free estimate** *before* a call runs. Estimates are guesses, never facts: they live under each result's `metering.estimate` (never in `usage.costUsd`), carry a `costConfidence` (`estimated` from a built-in default snapshot, `configured` when you supply pricing, `unknown` when there's no basis) and a `pricingVersion`. Plan-dependent credit providers emit unit metadata (`billableUnits`, `unit`) **without** an invented dollar figure until you configure a price via provider `options` (`perRequestUsd`, or `creditUsd` + `creditsPerRequest`).
+
+**Estimated budget (`--max-estimated-cost <usd>` or `defaults.maxEstimatedCostUsd`).** A pre-dispatch *reservation* ceiling, independent of `--max-cost` (the two never reconcile into one number). Before each provider launches, its estimated cost is reserved; once the reservation crosses the ceiling, not-yet-started providers are skipped with an estimated-budget reason. Providers with no estimable cost reserve `0`, so the reserved total is an honest lower bound. This gives products pre-call budget reservation that `--max-cost` (which only learns cost *after* a call) cannot. When it trips, the summary adds a line like:
+
+```
+  ▸ estimated budget reached: ~$0.05 reserved of $0.05 budget, skipped 2 providers
+```
+
+The actual-cost provenance of a reported figure is recorded as `metering.actual.source` (`provider_reported` today; reserved values like `computed_from_tokens`/`computed_from_credits` are defined for future computed lanes).
 
 ### Interactive wizard
 
@@ -457,20 +483,22 @@ librarium usage [options]
 | `--json` | Output JSON |
 | `-o, --output <dir>` | Output base directory |
 
-`usage` walks the `run.json` manifests under the output base directory and totals up cost and tokens per provider, plus a run count and date range. As with the run summary, only API-reported costs are counted (providers that report nothing contribute `0`), so figures are honest lower bounds, never pricing-table estimates. The output notes how many runs had no reported usage.
+`usage` walks the `run.json` manifests under the output base directory and totals up cost and tokens per provider, plus a run count and date range. As with the run summary, only API-reported costs are counted in the `cost` column (providers that report nothing contribute `0`), so figures are honest lower bounds, never pricing-table estimates. A separate `est. cost` column sums any pre-dispatch estimates from the [metering registry](#metering-registry-and-the-estimated-budget) — a guess, never billed, never mixed with reported cost. The output notes how many runs had no reported usage.
 
 ```
 $ librarium usage --days 30
 
 Usage (last 30 days):
 
-  provider       cost  tokens  runs
-  -----------  ------  ------  ----
-  openai-deep   $0.50    5.0k     1
-  exa          $0.020    1.5k     1
+  provider       cost  est. cost  tokens  runs
+  -----------  ------  ---------  ------  ----
+  openai-deep   $0.50          -    5.0k     1
+  exa          $0.020          -    1.5k     1
+  serpapi           -    ~$0.015       -     1
 
   runs: 2
   total reported cost: $0.52
+  total estimated cost: ~$0.015 (pre-dispatch estimate, not billed)
   date range: 2026-01-14 15:58 to 2026-01-14 16:00
   1 of 2 runs had no reported usage
 ```
@@ -699,7 +727,7 @@ Each layer overrides the previous:
 - `trustedProviderIds`: union + dedupe across global and project
 - `groups`: project overrides global group names on conflict
 
-The optional `defaults.maxCostUsd` key sets a default cost budget for runs (the runtime circuit breaker described in [Spend guardrails](#spend-guardrails)). The `--max-cost` flag wins over it. Omit it for no limit.
+The optional `defaults.maxCostUsd` key sets a default cost budget for runs (the runtime circuit breaker described in [Spend guardrails](#spend-guardrails)). The `--max-cost` flag wins over it. Omit it for no limit. The optional `defaults.maxEstimatedCostUsd` key sets a default pre-dispatch reservation ceiling (the estimated budget); the `--max-estimated-cost` flag wins over it.
 
 ### Global Config Example
 
@@ -713,7 +741,8 @@ The optional `defaults.maxCostUsd` key sets a default cost budget for runs (the 
     "asyncTimeout": 1800,
     "asyncPollInterval": 10,
     "mode": "mixed",
-    "maxCostUsd": 0.5
+    "maxCostUsd": 0.5,
+    "maxEstimatedCostUsd": 0.25
   },
   "providers": {
     "perplexity-sonar-pro": {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,6 +1,7 @@
 import { resolveProviderId } from '../constants.js';
 import type { CredentialContext } from '../core/credentials.js';
 import { hasCredential } from '../core/credentials.js';
+import { getMeteringKind } from '../core/metering.js';
 import type { Config, Provider, ProviderMeta, ProviderTier } from '../types.js';
 import { BaseProvider } from './base.js';
 import { BraveAnswersProvider } from './brave-answers.js';
@@ -90,6 +91,7 @@ export function getProviderMeta(
       source: p.source ?? 'builtin',
       enabled: providerConfig?.enabled ?? false,
       configured: providerConfig !== undefined,
+      meteringKind: getMeteringKind(p.id),
       hasApiKey: requiresApiKey
         ? providerConfig
           ? hasCredential(providerConfig.apiKey, credentials)

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -59,6 +59,11 @@ export function registerAnswerCommand(program: Command): void {
       'Stop launching providers once API-reported cost crosses this budget (USD)',
       parseMaxCost,
     )
+    .option(
+      '--max-estimated-cost <usd>',
+      'Reserve each provider’s pre-dispatch estimated cost; skip launches once the estimate crosses this ceiling (USD)',
+      parseMaxCost,
+    )
     .option('-y, --yes', 'Skip the deep-research pre-flight confirm')
     .option('--json', 'Output run.json to stdout')
     .option(

--- a/src/commands/jsonl-report.ts
+++ b/src/commands/jsonl-report.ts
@@ -60,6 +60,7 @@ interface ResultLine {
   durationMs: number;
   citationCount: number;
   usage?: Record<string, unknown>;
+  metering?: Record<string, unknown>;
   error?: string;
   fallbackFor?: string;
   content: string | null;
@@ -144,6 +145,9 @@ export function generateJsonlReport(input: JsonlReportInput): string {
     };
     if (report.usage !== undefined) {
       line.usage = report.usage as unknown as Record<string, unknown>;
+    }
+    if (report.metering !== undefined) {
+      line.metering = report.metering as unknown as Record<string, unknown>;
     }
     if (report.error !== undefined) line.error = report.error;
     if (report.fallbackFor !== undefined) line.fallbackFor = report.fallbackFor;

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -48,6 +48,10 @@ export function registerLsCommand(program: Command): void {
           'Tier'.length,
           ...meta.map((p) => p.tier.length),
         );
+        const meteringWidth = Math.max(
+          'Metering'.length,
+          ...meta.map((p) => (p.meteringKind ?? '').length),
+        );
         const sourceWidth = Math.max(
           'Source'.length,
           ...meta.map((p) => p.source.length),
@@ -61,6 +65,7 @@ export function registerLsCommand(program: Command): void {
           'ID'.padEnd(idWidth),
           'Name'.padEnd(nameWidth),
           'Tier'.padEnd(tierWidth),
+          'Metering'.padEnd(meteringWidth),
           'Source'.padEnd(sourceWidth),
           'Enabled'.padEnd(enabledWidth),
           'API Key'.padEnd(apiKeyWidth),
@@ -83,6 +88,7 @@ export function registerLsCommand(program: Command): void {
             p.id.padEnd(idWidth),
             p.displayName.padEnd(nameWidth),
             p.tier.padEnd(tierWidth),
+            (p.meteringKind ?? '').padEnd(meteringWidth),
             p.source.padEnd(sourceWidth),
             enabled.padEnd(enabledWidth),
             apiKey.padEnd(apiKeyWidth),

--- a/src/commands/run-format.ts
+++ b/src/commands/run-format.ts
@@ -322,6 +322,20 @@ export interface RunSummaryInput {
    * that crossed it, the budget ceiling, and how many providers were skipped.
    */
   budgetReached?: { reportedUsd: number; budgetUsd: number; skipped: number };
+  /**
+   * Pre-dispatch estimated cost across providers that produced a USD estimate.
+   * A separate lane from reportedCost — estimates are guesses, never facts.
+   */
+  estimatedCost?: { totalUsd: number; estimating: number; providers: number };
+  /**
+   * Present only when the estimated-cost reservation ceiling was reached: the
+   * reserved total that crossed it, the ceiling, and how many were skipped.
+   */
+  estimatedBudgetReached?: {
+    reservedUsd: number;
+    budgetUsd: number;
+    skipped: number;
+  };
 }
 
 /** End-of-run summary block (returned as individual lines). */
@@ -353,11 +367,30 @@ export function formatRunSummary(input: RunSummaryInput): string[] {
       `  ▸ reported cost: ${formatCost(input.reportedCost.totalUsd)} (${input.reportedCost.reporting} of ${input.reportedCost.providers} providers)`,
     );
   }
+  if (input.estimatedCost && input.estimatedCost.estimating > 0) {
+    lines.push(
+      paint(
+        `  ▸ estimated cost: ~${formatCost(input.estimatedCost.totalUsd)} (${input.estimatedCost.estimating} of ${input.estimatedCost.providers} providers, pre-dispatch estimate)`,
+        ANSI.dim,
+        input.color,
+      ),
+    );
+  }
   if (input.budgetReached) {
     const { reportedUsd, budgetUsd, skipped } = input.budgetReached;
     lines.push(
       paint(
         `  ▸ budget reached: ${formatCost(reportedUsd)} reported of ${formatCost(budgetUsd)} budget, skipped ${skipped} ${skipped === 1 ? 'provider' : 'providers'}`,
+        ANSI.yellow,
+        input.color,
+      ),
+    );
+  }
+  if (input.estimatedBudgetReached) {
+    const { reservedUsd, budgetUsd, skipped } = input.estimatedBudgetReached;
+    lines.push(
+      paint(
+        `  ▸ estimated budget reached: ~${formatCost(reservedUsd)} reserved of ${formatCost(budgetUsd)} budget, skipped ${skipped} ${skipped === 1 ? 'provider' : 'providers'}`,
         ANSI.yellow,
         input.color,
       ),

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,7 +10,12 @@ import {
 } from '../adapters/node-registry.js';
 import { resolveProviderIds, resolveProviderTokens } from '../constants.js';
 import { saveAsyncTasks } from '../core/async-manager.js';
-import { BUDGET_SKIP_REASON, createBudgetTracker } from '../core/budget.js';
+import {
+  BUDGET_SKIP_REASON,
+  createBudgetTracker,
+  createEstimateBudgetTracker,
+  ESTIMATE_BUDGET_SKIP_REASON,
+} from '../core/budget.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import { dispatch } from '../core/dispatcher.js';
 import { safeWriteFile } from '../core/fs-utils.js';
@@ -60,6 +65,7 @@ export interface RunOptions {
   parallel?: number;
   timeout?: number;
   maxCost?: number;
+  maxEstimatedCost?: number;
   json?: boolean;
   open?: boolean;
   html?: boolean;
@@ -144,6 +150,11 @@ export function registerRunCommand(program: Command): void {
       'Stop launching providers once API-reported cost crosses this budget (USD)',
       parseMaxCost,
     )
+    .option(
+      '--max-estimated-cost <usd>',
+      'Reserve each provider’s pre-dispatch estimated cost; skip launches once the estimate crosses this ceiling (USD)',
+      parseMaxCost,
+    )
     .option('-y, --yes', 'Skip the deep-research pre-flight confirm')
     .option('--json', 'Output run.json to stdout')
     .option(
@@ -200,6 +211,9 @@ export async function executeRun(
       if (opts.mode) cliFlags.mode = opts.mode;
       // Flag wins over defaults.maxCostUsd from config.
       if (opts.maxCost !== undefined) cliFlags.maxCostUsd = opts.maxCost;
+      if (opts.maxEstimatedCost !== undefined) {
+        cliFlags.maxEstimatedCostUsd = opts.maxEstimatedCost;
+      }
 
       const config = mergeConfigs(globalConfig, projectConfig, cliFlags);
       const credentials = { env: process.env };
@@ -417,6 +431,11 @@ export async function executeRun(
       // providers that report nothing contribute 0. Undefined budget means no
       // limit, in which case the tracker never trips.
       const budget = createBudgetTracker(config.defaults.maxCostUsd);
+      // Separate pre-dispatch reservation ceiling (estimated cost). Kept fully
+      // independent of the reported-cost budget above; the two never reconcile.
+      const estimatedBudget = createEstimateBudgetTracker(
+        config.defaults.maxEstimatedCostUsd,
+      );
 
       const dispatchStartedAt = Date.now();
       const { reports, results, asyncTasks } = await dispatch({
@@ -427,6 +446,7 @@ export async function executeRun(
         mode: config.defaults.mode,
         credentials,
         budget,
+        estimatedBudget,
         onProgress: (event) => {
           if (live) {
             switch (event.event) {
@@ -628,6 +648,39 @@ export async function executeRun(
             }
           : undefined;
 
+      // Pre-dispatch estimated cost across providers that produced a USD
+      // estimate (separate lane from reported cost; never mixed).
+      const estimateReports = reports.filter(
+        (r) =>
+          typeof r.metering?.estimate?.estimatedCostUsd === 'number' &&
+          Number.isFinite(r.metering.estimate.estimatedCostUsd),
+      );
+      const estimatedCost =
+        estimateReports.length > 0
+          ? {
+              totalUsd: estimateReports.reduce(
+                (sum, r) => sum + (r.metering?.estimate?.estimatedCostUsd ?? 0),
+                0,
+              ),
+              estimating: estimateReports.length,
+              providers: reports.length,
+            }
+          : undefined;
+
+      // Surface the estimated-cost reservation breaker when it tripped.
+      const estimateSkipped = effectiveReports.filter(
+        (r) =>
+          r.status === 'skipped' && r.error === ESTIMATE_BUDGET_SKIP_REASON,
+      ).length;
+      const estimatedBudgetReached =
+        estimatedBudget.limitUsd !== undefined && estimateSkipped > 0
+          ? {
+              reservedUsd: estimatedBudget.reservedUsd,
+              budgetUsd: estimatedBudget.limitUsd,
+              skipped: estimateSkipped,
+            }
+          : undefined;
+
       for (const line of formatRunSummary({
         succeeded: successful.length,
         failed: failed.length,
@@ -639,6 +692,8 @@ export async function executeRun(
         totalDurationMs,
         reportedCost,
         budgetReached,
+        estimatedCost,
+        estimatedBudgetReached,
       })) {
         printLine(line);
       }
@@ -733,6 +788,7 @@ function writeProviderOutputs(
           citationCount: result.citations.length,
           tokenUsage: result.tokenUsage,
           usage: result.usage,
+          metering: result.metering,
           citations: result.citations,
         },
         null,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -648,10 +648,12 @@ export async function executeRun(
             }
           : undefined;
 
-      // Pre-dispatch estimated cost across providers that produced a USD
-      // estimate (separate lane from reported cost; never mixed).
+      // Pre-dispatch estimated cost across providers that actually launched and
+      // produced a USD estimate (separate lane from reported cost; never mixed).
+      // Skipped providers never ran, so their estimate is not counted.
       const estimateReports = reports.filter(
         (r) =>
+          r.status !== 'skipped' &&
           typeof r.metering?.estimate?.estimatedCostUsd === 'number' &&
           Number.isFinite(r.metering.estimate.estimatedCostUsd),
       );

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -13,6 +13,7 @@ import {
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import { normalizeUsage } from '../core/dispatcher.js';
 import { safeWriteFile } from '../core/fs-utils.js';
+import { buildProviderMetering } from '../core/metering.js';
 import { deduplicateSources } from '../core/normalizer.js';
 import type {
   AsyncTaskHandle,
@@ -84,6 +85,7 @@ async function retrieveTask(
         citationCount: 0,
         outputFile: '',
         metaFile: '',
+        metering: buildProviderMetering(task.provider),
         error: result.error,
       };
       const wasSpinning = spinner.isSpinning;
@@ -98,6 +100,10 @@ async function retrieveTask(
     const outputFile = `${safeId}.md`;
     const metaFile = `${safeId}.meta.json`;
     const usage = normalizeUsage(result);
+    // Same metering normalization path as sync dispatch, so retrieved
+    // async deep-research results carry metering (and provider_reported cost)
+    // just like their sync counterparts.
+    const metering = buildProviderMetering(task.provider, undefined, usage);
 
     safeWriteFile(join(dir, outputFile), result.content);
     safeWriteFile(
@@ -111,6 +117,7 @@ async function retrieveTask(
           citationCount: result.citations.length,
           tokenUsage: result.tokenUsage,
           usage,
+          metering,
           citations: result.citations,
         },
         null,
@@ -131,6 +138,7 @@ async function retrieveTask(
       outputFile,
       metaFile,
       usage,
+      metering,
     };
 
     // Fold the retrieved result back into run.json and sources.json so JSON
@@ -346,6 +354,7 @@ export function registerStatusCommand(program: Command): void {
                       citationCount: 0,
                       outputFile: '',
                       metaFile: '',
+                      metering: buildProviderMetering(task.provider),
                       error: result.message ?? 'task failed',
                     };
                     spinner.stop();

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -18,6 +18,7 @@ import { deduplicateSources } from '../core/normalizer.js';
 import type {
   AsyncTaskHandle,
   Citation,
+  ProviderConfig,
   ProviderReport,
   RunManifest,
 } from '../types.js';
@@ -61,6 +62,7 @@ async function retrieveTask(
   widths: LineWidths,
   color: boolean,
   print: (line: string) => void,
+  providerConfig?: ProviderConfig,
 ): Promise<boolean> {
   const provider = getProvider(task.provider);
   if (!provider?.retrieve) {
@@ -102,8 +104,12 @@ async function retrieveTask(
     const usage = normalizeUsage(result);
     // Same metering normalization path as sync dispatch, so retrieved
     // async deep-research results carry metering (and provider_reported cost)
-    // just like their sync counterparts.
-    const metering = buildProviderMetering(task.provider, undefined, usage);
+    // just like their sync counterparts, including any configured pricing.
+    const metering = buildProviderMetering(
+      task.provider,
+      providerConfig,
+      usage,
+    );
 
     safeWriteFile(join(dir, outputFile), result.content);
     safeWriteFile(
@@ -411,6 +417,7 @@ export function registerStatusCommand(program: Command): void {
                 widths,
                 color,
                 pretty,
+                config.providers[task.provider],
               );
               if (ok) retrieved++;
             }
@@ -451,6 +458,7 @@ export function registerStatusCommand(program: Command): void {
               widths,
               color,
               pretty,
+              config.providers[task.provider],
             );
             if (ok) retrieved++;
           }

--- a/src/commands/usage-data.ts
+++ b/src/commands/usage-data.ts
@@ -114,9 +114,12 @@ export function aggregateUsage(
           usage.outputTokens !== undefined ||
           usage.totalTokens !== undefined);
       // Pre-dispatch estimate (a guess) — a separate lane from reported usage.
+      // Skipped providers never launched, so their estimate is not counted.
       const estimateUsd = report.metering?.estimate?.estimatedCostUsd;
       const hasEstimate =
-        typeof estimateUsd === 'number' && Number.isFinite(estimateUsd);
+        report.status !== 'skipped' &&
+        typeof estimateUsd === 'number' &&
+        Number.isFinite(estimateUsd);
       if (!hasCost && !hasTokens && !hasEstimate) continue;
 
       // "Usage" here means actual reported usage; an estimate alone does not

--- a/src/commands/usage-data.ts
+++ b/src/commands/usage-data.ts
@@ -22,6 +22,10 @@ export interface ProviderUsageTotals {
   runCount: number;
   /** Whether any run reported a cost for this provider. */
   reportedCost: boolean;
+  /** Summed pre-dispatch estimated cost (a guess, kept separate from costUsd). */
+  estimatedCostUsd: number;
+  /** Whether any run carried a USD estimate for this provider. */
+  hasEstimate: boolean;
 }
 
 export interface UsageAggregate {
@@ -31,6 +35,8 @@ export interface UsageAggregate {
   totalCostUsd: number;
   /** Number of runs that reported at least one cost figure. */
   runsWithCost: number;
+  /** Summed pre-dispatch estimated cost across all runs (separate lane). */
+  totalEstimatedCostUsd: number;
   providers: ProviderUsageTotals[];
   /** Earliest and latest manifest timestamps (unix seconds), or null when empty. */
   range: { fromSeconds: number; toSeconds: number } | null;
@@ -57,6 +63,7 @@ export function aggregateUsage(
     runsWithoutUsage: 0,
     totalCostUsd: 0,
     runsWithCost: 0,
+    totalEstimatedCostUsd: 0,
     providers: [],
     range: null,
   };
@@ -73,6 +80,7 @@ export function aggregateUsage(
   let runsWithoutUsage = 0;
   let totalCostUsd = 0;
   let runsWithCost = 0;
+  let totalEstimatedCostUsd = 0;
   let fromSeconds = Number.POSITIVE_INFINITY;
   let toSeconds = Number.NEGATIVE_INFINITY;
 
@@ -99,15 +107,21 @@ export function aggregateUsage(
 
     for (const report of manifest.providers) {
       const usage = report.usage;
-      if (!usage) continue;
-      const hasCost = typeof usage.costUsd === 'number';
+      const hasCost = typeof usage?.costUsd === 'number';
       const hasTokens =
-        usage.inputTokens !== undefined ||
-        usage.outputTokens !== undefined ||
-        usage.totalTokens !== undefined;
-      if (!hasCost && !hasTokens) continue;
+        usage !== undefined &&
+        (usage.inputTokens !== undefined ||
+          usage.outputTokens !== undefined ||
+          usage.totalTokens !== undefined);
+      // Pre-dispatch estimate (a guess) — a separate lane from reported usage.
+      const estimateUsd = report.metering?.estimate?.estimatedCostUsd;
+      const hasEstimate =
+        typeof estimateUsd === 'number' && Number.isFinite(estimateUsd);
+      if (!hasCost && !hasTokens && !hasEstimate) continue;
 
-      runHadUsage = true;
+      // "Usage" here means actual reported usage; an estimate alone does not
+      // count a run as having usage (it never made a measured call).
+      if (hasCost || hasTokens) runHadUsage = true;
       const totals = byProvider.get(report.id) ?? {
         provider: report.id,
         costUsd: 0,
@@ -116,21 +130,28 @@ export function aggregateUsage(
         totalTokens: 0,
         runCount: 0,
         reportedCost: false,
+        estimatedCostUsd: 0,
+        hasEstimate: false,
       };
       totals.runCount += 1;
       if (hasCost) {
-        const cost = usage.costUsd ?? 0;
+        const cost = usage?.costUsd ?? 0;
         totals.costUsd += cost;
         totals.reportedCost = true;
         totalCostUsd += cost;
         runHadCost = true;
       }
-      const input = usage.inputTokens ?? 0;
-      const output = usage.outputTokens ?? 0;
+      if (hasEstimate) {
+        totals.estimatedCostUsd += estimateUsd;
+        totals.hasEstimate = true;
+        totalEstimatedCostUsd += estimateUsd;
+      }
+      const input = usage?.inputTokens ?? 0;
+      const output = usage?.outputTokens ?? 0;
       totals.inputTokens += input;
       totals.outputTokens += output;
       // Prefer a reported total; otherwise sum input+output.
-      totals.totalTokens += usage.totalTokens ?? input + output;
+      totals.totalTokens += usage?.totalTokens ?? input + output;
       byProvider.set(report.id, totals);
     }
 
@@ -147,6 +168,7 @@ export function aggregateUsage(
     runsWithoutUsage,
     totalCostUsd,
     runsWithCost,
+    totalEstimatedCostUsd,
     providers,
     range: runCount > 0 ? { fromSeconds, toSeconds } : null,
   };

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -72,11 +72,13 @@ export function formatUsageReport(
   lines.push(`Usage (${scope}):`);
   lines.push('');
 
-  // Provider table.
-  const header = ['provider', 'cost', 'tokens', 'runs'];
+  // Provider table. "est. cost" is a separate, pre-dispatch estimate lane —
+  // a guess, never mixed with reported cost.
+  const header = ['provider', 'cost', 'est. cost', 'tokens', 'runs'];
   const rows = aggregate.providers.map((p) => [
     p.provider,
     p.reportedCost ? formatCost(p.costUsd) : '-',
+    p.hasEstimate ? `~${formatCost(p.estimatedCostUsd)}` : '-',
     p.totalTokens > 0 ? formatTokens(p.totalTokens) : '-',
     String(p.runCount),
   ]);
@@ -96,6 +98,11 @@ export function formatUsageReport(
   lines.push('');
   lines.push(`  runs: ${aggregate.runCount}`);
   lines.push(`  total reported cost: ${formatCost(aggregate.totalCostUsd)}`);
+  if (aggregate.totalEstimatedCostUsd > 0) {
+    lines.push(
+      `  total estimated cost: ~${formatCost(aggregate.totalEstimatedCostUsd)} (pre-dispatch estimate, not billed)`,
+    );
+  }
   if (aggregate.range) {
     lines.push(
       `  date range: ${formatRunDate(aggregate.range.fromSeconds)} to ${formatRunDate(aggregate.range.toSeconds)}`,

--- a/src/core-entry.ts
+++ b/src/core-entry.ts
@@ -31,6 +31,7 @@ export * from './core/budget.js';
 export * from './core/credentials.js';
 export * from './core/dispatcher.js';
 export * from './core/http-client.js';
+export * from './core/metering.js';
 export * from './core/normalizer.js';
 export * from './core/prompt-builder.js';
 export * from './types.js';

--- a/src/core/budget.ts
+++ b/src/core/budget.ts
@@ -1,4 +1,4 @@
-import type { ProviderUsage } from '../types.js';
+import type { MeteringEstimate, ProviderUsage } from '../types.js';
 
 /**
  * Runtime spend circuit breaker for a dispatch.
@@ -64,3 +64,72 @@ export function createBudgetTracker(
 
 /** Reason string recorded on providers skipped because the budget was reached. */
 export const BUDGET_SKIP_REASON = 'skipped: cost budget reached';
+
+/**
+ * Pre-dispatch reservation circuit breaker for a dispatch.
+ *
+ * Unlike the reported budget (which folds in API-reported cost AFTER a provider
+ * returns), this tracker RESERVES each provider's network-free estimated cost at
+ * the moment it is about to launch. Once the accumulated reservation crosses the
+ * ceiling, not-yet-started providers are skipped before they ever run — giving
+ * products pre-call budget reservation.
+ *
+ * Honest, lower-bound semantics: a provider whose estimate has no USD figure
+ * (plan-dependent credits, unmetered providers) reserves 0, so the reserved
+ * total is a lower bound on estimated spend — never an inflated guess. Estimated
+ * and reported budgets are independent and never reconcile into one number.
+ */
+export interface EstimateBudgetTracker {
+  /** Reservation ceiling in USD, or undefined when no limit is set. */
+  readonly limitUsd: number | undefined;
+  /** Accumulated reserved estimated cost so far, in USD. */
+  readonly reservedUsd: number;
+  /**
+   * Reserve a provider's estimated cost against the ceiling. Estimates without
+   * a finite positive estimatedCostUsd reserve nothing. Returns the new total.
+   */
+  reserve(estimate: MeteringEstimate | undefined): number;
+  /**
+   * True once the accumulated reservation has crossed the ceiling. Always false
+   * when no limit is configured.
+   */
+  exceeded(): boolean;
+}
+
+/**
+ * Create an estimate-reservation tracker. A non-positive or undefined limit
+ * yields a tracker that never trips, so callers can construct one
+ * unconditionally and let `exceeded()` gate behavior.
+ */
+export function createEstimateBudgetTracker(
+  limitUsd: number | undefined,
+): EstimateBudgetTracker {
+  const limit =
+    typeof limitUsd === 'number' && Number.isFinite(limitUsd) && limitUsd > 0
+      ? limitUsd
+      : undefined;
+  let reserved = 0;
+
+  return {
+    get limitUsd() {
+      return limit;
+    },
+    get reservedUsd() {
+      return reserved;
+    },
+    reserve(estimate) {
+      const cost = estimate?.estimatedCostUsd;
+      if (typeof cost === 'number' && Number.isFinite(cost) && cost > 0) {
+        reserved += cost;
+      }
+      return reserved;
+    },
+    exceeded() {
+      return limit !== undefined && reserved >= limit;
+    },
+  };
+}
+
+/** Reason recorded on providers skipped because the estimated budget was reached. */
+export const ESTIMATE_BUDGET_SKIP_REASON =
+  'skipped: estimated cost budget reached';

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -174,8 +174,9 @@ export async function dispatch(
       );
       return null;
     }
-    // A fallback is its own billable launch: reserve its estimate first, and
-    // skip it if the estimated budget is already spent.
+    // A fallback is its own billable launch: skip it if the estimated budget is
+    // already spent. (The reservation itself happens only once we've committed
+    // to launching, below, so a fallback we bail on never reserves.)
     if (estimatedBudget?.exceeded()) {
       recordBudgetSkip(
         fallbackId,
@@ -185,7 +186,6 @@ export async function dispatch(
       );
       return null;
     }
-    estimatedBudget?.reserve(meteringFor(fallbackId).estimate);
 
     // Don't use a fallback that's already running as a primary in this dispatch
     if (providerIds.includes(fallbackId)) return null;
@@ -195,6 +195,11 @@ export async function dispatch(
     // same fallback target.
     if (usedFallbacks.has(fallbackId)) return null;
     usedFallbacks.add(fallbackId);
+
+    // Committed to launching this fallback now: reserve its estimate against the
+    // estimated budget. Reserving only after the claim guards means a fallback
+    // we bail on above never leaves a phantom reservation behind.
+    estimatedBudget?.reserve(meteringFor(fallbackId).estimate);
 
     // Note: enabled is intentionally not checked here — fallback providers may
     // be configured with enabled: false so they only activate as backups.

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -6,14 +6,22 @@ import type {
   Config,
   ProgressEvent,
   Provider,
+  ProviderConfig,
   ProviderDispatchResult,
+  ProviderMetering,
   ProviderReport,
   ProviderResult,
   ProviderUsage,
 } from '../types.js';
-import { BUDGET_SKIP_REASON, type BudgetTracker } from './budget.js';
+import {
+  BUDGET_SKIP_REASON,
+  type BudgetTracker,
+  ESTIMATE_BUDGET_SKIP_REASON,
+  type EstimateBudgetTracker,
+} from './budget.js';
 import type { CredentialContext } from './credentials.js';
 import { hasCredential } from './credentials.js';
+import { buildProviderMetering } from './metering.js';
 
 export interface DispatchOptions {
   config: Config;
@@ -37,6 +45,14 @@ export interface DispatchOptions {
    * dispatch behaves exactly as before.
    */
   budget?: BudgetTracker;
+  /**
+   * Optional pre-dispatch reservation circuit breaker. When supplied, each
+   * provider's network-free estimated cost is reserved just before it launches;
+   * once the accumulated reservation crosses the ceiling, not-yet-started
+   * providers are skipped with an estimated-budget reason. Independent of
+   * `budget` (reported cost): the two never reconcile. Additive and edge-safe.
+   */
+  estimatedBudget?: EstimateBudgetTracker;
 }
 
 export interface DispatchResult {
@@ -48,10 +64,23 @@ export interface DispatchResult {
 export async function dispatch(
   options: DispatchOptions,
 ): Promise<DispatchResult> {
-  const { config, providerIds, query, mode, credentials, onProgress, budget } =
-    options;
+  const {
+    config,
+    providerIds,
+    query,
+    mode,
+    credentials,
+    onProgress,
+    budget,
+    estimatedBudget,
+  } = options;
   const queryForTier = (tier: Provider['tier']): string =>
     options.tierQueries?.[tier] ?? query;
+  // Single metering normalization path: static kind + network-free estimate +
+  // (when a result is in hand) the actual-cost lane, using each provider's
+  // configured pricing overrides.
+  const meteringFor = (id: string, usage?: ProviderUsage): ProviderMetering =>
+    buildProviderMetering(id, config.providers[id], usage);
   const limit = pLimit(config.defaults.maxParallel);
   const reports: ProviderReport[] = [];
   const results: ProviderDispatchResult[] = [];
@@ -81,6 +110,7 @@ export async function dispatch(
         fallbackId,
         fallbackProvider.tier,
         result,
+        config.providers[fallbackId],
         originalId,
       );
       results.push(structured);
@@ -88,6 +118,7 @@ export async function dispatch(
       return createReport(fallbackId, fallbackProvider.tier, structured);
     } catch (e) {
       const error = e instanceof Error ? e.message : String(e);
+      const metering = meteringFor(fallbackId);
       results.push({
         provider: fallbackId,
         tier: fallbackProvider.tier,
@@ -96,6 +127,7 @@ export async function dispatch(
         sourceUrls: [],
         citations: [],
         durationMs: 0,
+        metering,
         error,
         fallbackFor: originalId,
       });
@@ -108,6 +140,7 @@ export async function dispatch(
         citationCount: 0,
         outputFile: '',
         metaFile: '',
+        metering,
         error,
         fallbackFor: originalId,
       };
@@ -133,9 +166,26 @@ export async function dispatch(
     // Fallbacks are API calls too: once the cost budget is exhausted, a
     // failed primary must not launch its backup.
     if (budget?.exceeded()) {
-      recordBudgetSkip(fallbackId, fallbackProvider.tier, id);
+      recordBudgetSkip(
+        fallbackId,
+        fallbackProvider.tier,
+        BUDGET_SKIP_REASON,
+        id,
+      );
       return null;
     }
+    // A fallback is its own billable launch: reserve its estimate first, and
+    // skip it if the estimated budget is already spent.
+    if (estimatedBudget?.exceeded()) {
+      recordBudgetSkip(
+        fallbackId,
+        fallbackProvider.tier,
+        ESTIMATE_BUDGET_SKIP_REASON,
+        id,
+      );
+      return null;
+    }
+    estimatedBudget?.reserve(meteringFor(fallbackId).estimate);
 
     // Don't use a fallback that's already running as a primary in this dispatch
     if (providerIds.includes(fallbackId)) return null;
@@ -165,12 +215,16 @@ export async function dispatch(
   }
 
   // Emit a budget-skipped report+result for a provider whose start was
-  // suppressed because the accumulated cost crossed the budget.
+  // suppressed because a budget (reported or estimated) was crossed. Metering
+  // is still attached so consumers see the provider's capability even when it
+  // never ran.
   function recordBudgetSkip(
     id: string,
     tier: Provider['tier'],
+    reason: string,
     fallbackFor?: string,
   ): void {
+    const metering = meteringFor(id);
     results.push({
       provider: id,
       tier,
@@ -179,7 +233,8 @@ export async function dispatch(
       sourceUrls: [],
       citations: [],
       durationMs: 0,
-      error: BUDGET_SKIP_REASON,
+      metering,
+      error: reason,
       ...(fallbackFor ? { fallbackFor } : {}),
     });
     const report: ProviderReport = {
@@ -191,7 +246,8 @@ export async function dispatch(
       citationCount: 0,
       outputFile: '',
       metaFile: '',
-      error: BUDGET_SKIP_REASON,
+      metering,
+      error: reason,
       ...(fallbackFor ? { fallbackFor } : {}),
     };
     reports.push(report);
@@ -204,6 +260,7 @@ export async function dispatch(
     limit(async (): Promise<void> => {
       const provider = getProvider(id);
       if (!provider) {
+        const metering = meteringFor(id);
         results.push({
           provider: id,
           tier: 'raw-search',
@@ -212,6 +269,7 @@ export async function dispatch(
           sourceUrls: [],
           citations: [],
           durationMs: 0,
+          metering,
           error: `Provider "${id}" not found`,
         });
         reports.push({
@@ -223,6 +281,7 @@ export async function dispatch(
           citationCount: 0,
           outputFile: '',
           metaFile: '',
+          metering,
           error: `Provider "${id}" not found`,
         });
         return;
@@ -230,6 +289,7 @@ export async function dispatch(
 
       const providerConfig = config.providers[id];
       if (!providerConfig?.enabled) {
+        const metering = meteringFor(id);
         results.push({
           provider: id,
           tier: provider.tier,
@@ -238,6 +298,7 @@ export async function dispatch(
           sourceUrls: [],
           citations: [],
           durationMs: 0,
+          metering,
           error: 'Provider not enabled',
         });
         reports.push({
@@ -249,6 +310,7 @@ export async function dispatch(
           citationCount: 0,
           outputFile: '',
           metaFile: '',
+          metering,
           error: 'Provider not enabled',
         });
         return;
@@ -260,9 +322,19 @@ export async function dispatch(
       // results have been recorded), so not-yet-started providers are skipped
       // while in-flight requests are left to finish.
       if (budget?.exceeded()) {
-        recordBudgetSkip(id, provider.tier);
+        recordBudgetSkip(id, provider.tier, BUDGET_SKIP_REASON);
         return;
       }
+
+      // Estimated-cost reservation: skip if the estimate ceiling is already
+      // spent, otherwise reserve this provider's network-free estimate before
+      // it launches. Reserving only at launch means skipped providers never
+      // leave a phantom reservation behind.
+      if (estimatedBudget?.exceeded()) {
+        recordBudgetSkip(id, provider.tier, ESTIMATE_BUDGET_SKIP_REASON);
+        return;
+      }
+      estimatedBudget?.reserve(meteringFor(id).estimate);
 
       onProgress?.({ providerId: id, event: 'started' });
 
@@ -284,7 +356,12 @@ export async function dispatch(
             provider.retrieve
           ) {
             const result = await provider.retrieve(handle);
-            const structured = createDispatchResult(id, provider.tier, result);
+            const structured = createDispatchResult(
+              id,
+              provider.tier,
+              result,
+              providerConfig,
+            );
             results.push(structured);
             const report = createReport(id, provider.tier, structured);
             reports.push(report);
@@ -321,6 +398,7 @@ export async function dispatch(
           // since there is no synchronous result to evaluate. Fallback only fires
           // when a provider completes immediately with an error (handled above).
           asyncTasks.push(handle);
+          const pendingMetering = meteringFor(id);
           results.push({
             provider: id,
             tier: provider.tier,
@@ -329,6 +407,7 @@ export async function dispatch(
             sourceUrls: [],
             citations: [],
             durationMs: 0,
+            metering: pendingMetering,
           });
           const pendingReport: ProviderReport = {
             id,
@@ -339,6 +418,7 @@ export async function dispatch(
             citationCount: 0,
             outputFile: '',
             metaFile: '',
+            metering: pendingMetering,
           };
           reports.push(pendingReport);
           onProgress?.({
@@ -362,7 +442,12 @@ export async function dispatch(
               ? config.defaults.asyncTimeout
               : config.defaults.timeout,
         });
-        const structured = createDispatchResult(id, provider.tier, result);
+        const structured = createDispatchResult(
+          id,
+          provider.tier,
+          result,
+          providerConfig,
+        );
         results.push(structured);
         const report = createReport(id, provider.tier, structured);
 
@@ -395,6 +480,7 @@ export async function dispatch(
         }
       } catch (e) {
         const error = e instanceof Error ? e.message : String(e);
+        const metering = meteringFor(id);
         results.push({
           provider: id,
           tier: provider.tier,
@@ -403,6 +489,7 @@ export async function dispatch(
           sourceUrls: [],
           citations: [],
           durationMs: 0,
+          metering,
           error,
         });
         const errorReport: ProviderReport = {
@@ -414,6 +501,7 @@ export async function dispatch(
           citationCount: 0,
           outputFile: '',
           metaFile: '',
+          metering,
           error,
         };
         reports.push(errorReport);
@@ -486,8 +574,10 @@ function createDispatchResult(
   providerId: string,
   tier: Provider['tier'],
   result: ProviderResult,
+  providerConfig: ProviderConfig | undefined,
   fallbackFor?: string,
 ): ProviderDispatchResult {
+  const usage = normalizeUsage(result);
   return {
     provider: providerId,
     tier,
@@ -500,7 +590,8 @@ function createDispatchResult(
     durationMs: result.durationMs,
     model: result.model,
     tokenUsage: result.tokenUsage,
-    usage: normalizeUsage(result),
+    usage,
+    metering: buildProviderMetering(providerId, providerConfig, usage),
     error: result.error,
     fallbackFor,
   };
@@ -528,6 +619,7 @@ function createReport(
         ? `${safeId}.meta.json`
         : '',
     usage: result.usage,
+    metering: result.metering,
     error: result.error,
     fallbackFor: result.fallbackFor,
   };

--- a/src/core/metering.ts
+++ b/src/core/metering.ts
@@ -1,0 +1,269 @@
+import { resolveProviderId } from '../constants.js';
+import type {
+  CostConfidence,
+  MeteringActual,
+  MeteringEstimate,
+  MeteringKind,
+  ProviderMetering,
+  ProviderUsage,
+} from '../types.js';
+
+/**
+ * Provider metering capability registry.
+ *
+ * A single source of truth for HOW each provider is priced, so consumers can
+ * tell — before a call runs and without any network request — whether a
+ * provider reports native cost, reports tokens only, is priced per request, per
+ * credit, per API unit, or is simply unmetered.
+ *
+ * Honesty contract (mirrors src/types.ts ProviderUsage):
+ *  - Estimates here are NEVER facts. They are stamped with a `costConfidence`
+ *    of 'estimated' (built-in default snapshot) or 'configured' (user-supplied
+ *    pricing in provider options) and a `pricingVersion`, and they never touch
+ *    ProviderUsage.costUsd.
+ *  - Plan-dependent providers (credits, API units) do NOT emit a default USD
+ *    figure — only unit metadata — so we never invent precision the user's plan
+ *    doesn't support. A USD estimate appears only once the user configures a
+ *    price.
+ */
+
+/** Pricing snapshot tag for the built-in default estimates below. */
+export const PRICING_VERSION = '2026-06';
+
+interface MeteringCapability {
+  kind: MeteringKind;
+  /**
+   * Built-in deterministic per-request price (USD) for request_priced
+   * providers with a published flat rate. Plan-dependent rates are omitted so
+   * the estimate carries unit metadata without a misleading dollar figure.
+   */
+  defaultPerRequestUsd?: number;
+  /** Default billable units consumed per request (credit_priced/api_unit). */
+  defaultUnitsPerRequest?: number;
+  /** Unit the estimate is denominated in: 'request' | 'credit' | 'token'. */
+  unit?: string;
+}
+
+/**
+ * Per-provider capability table. Keys are canonical provider ids.
+ *
+ * Default USD figures are deliberately conservative estimates of common
+ * lower-volume plan pricing as of PRICING_VERSION; they are starting points,
+ * not contractual rates. Users on other plans should override via provider
+ * `options` (see readPricingOverride).
+ */
+const REGISTRY: Record<string, MeteringCapability> = {
+  // Deep research — Perplexity returns native cost in the usage block.
+  'perplexity-sonar-deep': { kind: 'native_cost' },
+  'perplexity-deep-research': { kind: 'native_cost' },
+  'perplexity-advanced-deep': { kind: 'native_cost' },
+  // Token-metered deep research (no cost in the API response).
+  'openai-deep': { kind: 'native_tokens' },
+  'openai-deep-o3': { kind: 'native_tokens' },
+  'gemini-deep': { kind: 'native_tokens' },
+
+  // AI-grounded.
+  'perplexity-sonar-pro': { kind: 'native_cost' },
+  'gemini-grounded': { kind: 'native_tokens' },
+  'openrouter-online': { kind: 'native_cost' },
+  exa: { kind: 'native_cost' },
+  // Brave AI answers — request-priced (Data-for-AI plan), deterministic-ish.
+  'brave-answers': {
+    kind: 'request_priced',
+    defaultPerRequestUsd: 0.009,
+    unit: 'request',
+  },
+  // You.com — priced per query, plan-dependent: units only, no default USD.
+  'you-research': {
+    kind: 'credit_priced',
+    defaultUnitsPerRequest: 1,
+    unit: 'query',
+  },
+  // Kagi FastGPT — published flat $0.015 per call.
+  'kagi-fastgpt': {
+    kind: 'request_priced',
+    defaultPerRequestUsd: 0.015,
+    unit: 'request',
+  },
+
+  // Raw search.
+  // Perplexity search — request-priced but plan-dependent: no default USD.
+  'perplexity-search': { kind: 'request_priced', unit: 'request' },
+  'brave-search': {
+    kind: 'request_priced',
+    defaultPerRequestUsd: 0.005,
+    unit: 'request',
+  },
+  // Jina — token/API-unit priced; billable size known only post-call.
+  'jina-search': { kind: 'api_unit_priced', unit: 'token' },
+  // Firecrawl — credit-priced, plan-dependent: units only, no default USD.
+  'firecrawl-search': {
+    kind: 'credit_priced',
+    defaultUnitsPerRequest: 1,
+    unit: 'credit',
+  },
+  searchapi: {
+    kind: 'request_priced',
+    defaultPerRequestUsd: 0.004,
+    unit: 'request',
+  },
+  serpapi: {
+    kind: 'request_priced',
+    defaultPerRequestUsd: 0.015,
+    unit: 'request',
+  },
+  // Tavily — credit-priced; advanced search consumes 2 credits.
+  tavily: { kind: 'credit_priced', defaultUnitsPerRequest: 2, unit: 'credit' },
+
+  // Ungrounded LLMs — token-metered, no cost in the response.
+  claude: { kind: 'native_tokens' },
+  'openai-chat': { kind: 'native_tokens' },
+  'gemini-chat': { kind: 'native_tokens' },
+  // OpenRouter returns native cost in its usage block.
+  'openrouter-chat': { kind: 'native_cost' },
+};
+
+/** Capability for unregistered/custom providers: no reliable per-call metering. */
+const UNMETERED: MeteringCapability = { kind: 'manual_unmetered' };
+
+/** Look up a provider's static metering capability (kind + pricing shape). */
+function getCapability(providerId: string): MeteringCapability {
+  return REGISTRY[resolveProviderId(providerId)] ?? UNMETERED;
+}
+
+/** Public: the metering kind for a provider id (manual_unmetered if unknown). */
+export function getMeteringKind(providerId: string): MeteringKind {
+  return getCapability(providerId).kind;
+}
+
+/** Canonical provider ids that have a registry entry. */
+export function meteredProviderIds(): string[] {
+  return Object.keys(REGISTRY);
+}
+
+/** Coerce an unknown options value to a finite positive number, else undefined. */
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+interface ProviderPricingConfig {
+  options?: Record<string, unknown>;
+}
+
+/**
+ * User-supplied pricing overrides from provider config `options`:
+ *  - perRequestUsd: flat USD per request (request_priced)
+ *  - creditUsd + (creditsPerRequest | capability default): USD per credit
+ */
+function readPricingOverride(config?: ProviderPricingConfig): {
+  perRequestUsd?: number;
+  creditUsd?: number;
+  unitsPerRequest?: number;
+} {
+  const options = config?.options ?? {};
+  return {
+    perRequestUsd: positiveNumber(options.perRequestUsd),
+    creditUsd: positiveNumber(options.creditUsd),
+    unitsPerRequest: positiveNumber(options.creditsPerRequest),
+  };
+}
+
+/**
+ * Network-free pre-dispatch cost estimate for a provider. Returns undefined for
+ * kinds whose cost is only known from the API response (native_cost,
+ * native_tokens) and for manual_unmetered providers.
+ */
+export function estimateMetering(
+  providerId: string,
+  config?: ProviderPricingConfig,
+): MeteringEstimate | undefined {
+  const cap = getCapability(providerId);
+  const override = readPricingOverride(config);
+
+  if (cap.kind === 'request_priced') {
+    const perRequest = override.perRequestUsd ?? cap.defaultPerRequestUsd;
+    const confidence: CostConfidence =
+      override.perRequestUsd !== undefined ? 'configured' : 'estimated';
+    const estimate: MeteringEstimate = {
+      billableUnits: 1,
+      unit: cap.unit ?? 'request',
+      costConfidence: perRequest !== undefined ? confidence : 'unknown',
+      pricingVersion: PRICING_VERSION,
+    };
+    if (perRequest !== undefined) estimate.estimatedCostUsd = perRequest;
+    return estimate;
+  }
+
+  if (cap.kind === 'credit_priced') {
+    const units = override.unitsPerRequest ?? cap.defaultUnitsPerRequest;
+    const estimate: MeteringEstimate = {
+      unit: cap.unit ?? 'credit',
+      costConfidence: 'estimated',
+      pricingVersion: PRICING_VERSION,
+    };
+    if (units !== undefined) estimate.billableUnits = units;
+    // A USD figure appears only when the user configures a per-credit price;
+    // plan-dependent credits never get an invented default dollar amount.
+    if (override.creditUsd !== undefined && units !== undefined) {
+      estimate.estimatedCostUsd = override.creditUsd * units;
+      estimate.costConfidence = 'configured';
+    }
+    return estimate;
+  }
+
+  if (cap.kind === 'api_unit_priced') {
+    // Billable size (tokens/rows) is unknown before the call. Surface the unit
+    // and confidence without a fabricated dollar amount.
+    const perUnit = positiveNumber(config?.options?.perUnitUsd);
+    const estimate: MeteringEstimate = {
+      unit: cap.unit ?? 'unit',
+      costConfidence: perUnit !== undefined ? 'configured' : 'estimated',
+      pricingVersion: PRICING_VERSION,
+    };
+    return estimate;
+  }
+
+  // native_cost, native_tokens, manual_unmetered: no pre-dispatch estimate.
+  return undefined;
+}
+
+/**
+ * Build the actual-cost lane from reported usage. usage.costUsd is only ever set
+ * by an adapter from a real API figure, so its presence means provider_reported.
+ */
+function actualFromUsage(usage?: ProviderUsage): MeteringActual | undefined {
+  if (
+    usage?.costUsd !== undefined &&
+    Number.isFinite(usage.costUsd) &&
+    usage.costUsd >= 0
+  ) {
+    return { costUsd: usage.costUsd, source: 'provider_reported' };
+  }
+  return undefined;
+}
+
+/**
+ * Assemble the full ProviderMetering for a provider: static kind, a network-free
+ * estimate, and (when a result is in hand) the actual cost lane. This is the
+ * single normalization path shared by sync dispatch, fallback, and async
+ * retrieval so every surface attaches metering identically.
+ */
+export function buildProviderMetering(
+  providerId: string,
+  config?: ProviderPricingConfig,
+  usage?: ProviderUsage,
+): ProviderMetering {
+  const cap = getCapability(providerId);
+  const metering: ProviderMetering = { kind: cap.kind };
+  const estimate = estimateMetering(providerId, config);
+  if (estimate) {
+    metering.estimate = estimate;
+    if (estimate.pricingVersion)
+      metering.pricingVersion = estimate.pricingVersion;
+  }
+  const actual = actualFromUsage(usage);
+  if (actual) metering.actual = actual;
+  return metering;
+}

--- a/src/mcp/async.ts
+++ b/src/mcp/async.ts
@@ -9,6 +9,7 @@ import {
 } from '../core/async-manager.js';
 import { normalizeUsage } from '../core/dispatcher.js';
 import { safeWriteFile } from '../core/fs-utils.js';
+import { buildProviderMetering } from '../core/metering.js';
 import { deduplicateSources } from '../core/normalizer.js';
 import type {
   AsyncTaskHandle,
@@ -107,6 +108,9 @@ async function retrieveTaskSilent(
     const outputFile = `${safeId}.md`;
     const metaFile = `${safeId}.meta.json`;
     const usage = normalizeUsage(result);
+    // Same metering normalization path as sync dispatch and `status --retrieve`,
+    // so MCP-retrieved async results carry metering on run.json/.meta.json too.
+    const metering = buildProviderMetering(task.provider, undefined, usage);
 
     safeWriteFile(join(dir, outputFile), result.content);
     safeWriteFile(
@@ -120,6 +124,7 @@ async function retrieveTaskSilent(
           citationCount: result.citations.length,
           tokenUsage: result.tokenUsage,
           usage,
+          metering,
           citations: result.citations,
         },
         null,
@@ -137,6 +142,7 @@ async function retrieveTaskSilent(
       outputFile,
       metaFile,
       usage,
+      metering,
     };
     updateManifestAfterRetrieve(dir, report);
 

--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -188,6 +188,7 @@ function writeProviderOutputs(
           citationCount: result.citations.length,
           tokenUsage: result.tokenUsage,
           usage: result.usage,
+          metering: result.metering,
           citations: result.citations,
         },
         null,

--- a/src/mcp/shaping.ts
+++ b/src/mcp/shaping.ts
@@ -5,6 +5,7 @@ import { loadAsyncTasks } from '../core/async-manager.js';
 import type {
   AsyncTaskHandle,
   DeduplicatedSource,
+  ProviderMetering,
   ProviderReport,
   ProviderUsage,
   RunManifest,
@@ -74,6 +75,7 @@ export interface ShapedProvider {
   citationCount: number;
   wordCount: number;
   usage?: ProviderUsage;
+  metering?: ProviderMetering;
   error?: string;
   fallbackFor?: string;
 }
@@ -117,6 +119,7 @@ function shapeProviders(reports: ProviderReport[]): ShapedProvider[] {
     citationCount: r.citationCount,
     wordCount: r.wordCount,
     ...(r.usage ? { usage: r.usage } : {}),
+    ...(r.metering ? { metering: r.metering } : {}),
     ...(r.error ? { error: r.error } : {}),
     ...(r.fallbackFor ? { fallbackFor: r.fallbackFor } : {}),
   }));
@@ -344,6 +347,7 @@ export function readRunResults(
         citationCount: r.citationCount,
         wordCount: r.wordCount,
         ...(r.usage ? { usage: r.usage } : {}),
+        ...(r.metering ? { metering: r.metering } : {}),
         ...(r.error ? { error: r.error } : {}),
         ...(r.fallbackFor ? { fallbackFor: r.fallbackFor } : {}),
       })),

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,13 +24,86 @@ export interface ProviderOptions {
 
 // Normalized usage/cost as reported by a provider's API. Honest data only:
 // fields are set when (and only when) the API itself reported them. costUsd
-// is never estimated from a pricing table.
+// is never estimated from a pricing table — estimates live under
+// ProviderMetering.estimate, never here.
 export interface ProviderUsage {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
   costUsd?: number;
   raw?: unknown;
+}
+
+// How a provider is metered/priced. Declared statically per provider in the
+// metering registry (src/core/metering.ts); network-free.
+//   native_cost      — the API returns a real per-call cost (e.g. Perplexity, Exa)
+//   native_tokens    — the API returns token counts but no cost (e.g. Claude, OpenAI)
+//   request_priced   — a deterministic/plan price per request (e.g. SerpAPI, Brave)
+//   credit_priced    — priced in account credits per request (e.g. Tavily, Firecrawl)
+//   api_unit_priced  — priced per API unit/row/token, size known only post-call (e.g. Jina)
+//   manual_unmetered — no reliable per-call metering available
+export type MeteringKind =
+  | 'native_cost'
+  | 'native_tokens'
+  | 'request_priced'
+  | 'credit_priced'
+  | 'api_unit_priced'
+  | 'manual_unmetered';
+
+// Confidence in a cost figure.
+//   reported   — taken straight from the provider API (a fact)
+//   configured — computed from user-supplied pricing in provider options
+//   estimated  — computed from a built-in default pricing snapshot (a guess)
+//   unknown    — no basis to estimate
+export type CostConfidence =
+  | 'reported'
+  | 'configured'
+  | 'estimated'
+  | 'unknown';
+
+// Provenance of an actual (non-estimated) cost figure on normalized output.
+export type ActualCostSource =
+  | 'provider_reported'
+  | 'computed_from_tokens'
+  | 'computed_from_request'
+  | 'computed_from_credits'
+  | 'account_usage_delta'
+  | 'unknown';
+
+// Pre-dispatch cost estimate. Produced WITHOUT any network call so budgets can
+// be reserved before a provider runs. Never folded into ProviderUsage.costUsd.
+export interface MeteringEstimate {
+  /** Estimated USD cost. Omitted when the price is plan-dependent/unknown. */
+  estimatedCostUsd?: number;
+  /** Number of billable units this call is expected to consume. */
+  billableUnits?: number;
+  /** Unit the estimate is denominated in: 'request' | 'credit' | 'token' | ... */
+  unit?: string;
+  /** Version tag for the pricing snapshot behind estimatedCostUsd. */
+  pricingVersion?: string;
+  /** How much to trust estimatedCostUsd (estimated/configured/unknown here). */
+  costConfidence: CostConfidence;
+}
+
+// An actual (post-dispatch) cost figure with its provenance. Kept separate from
+// ProviderUsage so usage.costUsd stays strictly provider-reported.
+export interface MeteringActual {
+  costUsd?: number;
+  source: ActualCostSource;
+  billableUnits?: number;
+}
+
+// Per-provider metering metadata attached to dispatch results/reports. Carries
+// the static capability (kind), a pre-dispatch estimate, and — once a result is
+// in hand — the actual cost lane. Additive: omit it and nothing else changes.
+export interface ProviderMetering {
+  kind: MeteringKind;
+  /** Pricing snapshot version for this provider's defaults, when applicable. */
+  pricingVersion?: string;
+  /** Network-free pre-dispatch estimate (absent for native/unmetered kinds). */
+  estimate?: MeteringEstimate;
+  /** Actual cost lane, populated only when a real figure is known. */
+  actual?: MeteringActual;
 }
 
 // Normalized citation from any provider
@@ -51,6 +124,7 @@ export interface ProviderResult {
   model?: string;
   tokenUsage?: { input?: number; output?: number };
   usage?: ProviderUsage;
+  metering?: ProviderMetering;
   error?: string;
 }
 
@@ -66,6 +140,7 @@ export interface ProviderDispatchResult {
   model?: string;
   tokenUsage?: { input?: number; output?: number };
   usage?: ProviderUsage;
+  metering?: ProviderMetering;
   error?: string;
   fallbackFor?: string;
 }
@@ -121,6 +196,8 @@ export interface ProviderMeta {
   hasApiKey: boolean;
   /** False when the provider has no entry in config (e.g. added after init). */
   configured?: boolean;
+  /** How this provider is metered/priced (from the metering registry). */
+  meteringKind?: MeteringKind;
 }
 
 // Config for a single provider
@@ -177,6 +254,10 @@ export const DefaultsSchema = z.object({
   // Optional runtime spend circuit breaker. Honest budget: only API-reported
   // costs count toward it (see src/core/budget.ts). Unset means no limit.
   maxCostUsd: z.number().optional(),
+  // Optional pre-dispatch reservation ceiling. Reserves each provider's
+  // network-free estimated cost BEFORE it runs (see src/core/budget.ts);
+  // providers with no estimable cost reserve 0. Unset means no limit.
+  maxEstimatedCostUsd: z.number().optional(),
 });
 export type Defaults = z.infer<typeof DefaultsSchema>;
 
@@ -219,6 +300,7 @@ export const ProjectConfigSchema = z.object({
       asyncPollInterval: z.number().optional(),
       mode: z.enum(['sync', 'async', 'mixed']).optional(),
       maxCostUsd: z.number().optional(),
+      maxEstimatedCostUsd: z.number().optional(),
     })
     .optional(),
   providers: z.record(ProjectProviderConfigSchema).optional(),
@@ -262,6 +344,7 @@ export interface ProviderReport {
   outputFile: string;
   metaFile: string;
   usage?: ProviderUsage;
+  metering?: ProviderMetering;
   error?: string;
   fallbackFor?: string;
 }

--- a/tests/dispatcher-metering.test.ts
+++ b/tests/dispatcher-metering.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ESTIMATE_BUDGET_SKIP_REASON } from '../src/core/budget.js';
+import type {
+  Config,
+  Provider,
+  ProviderOptions,
+  ProviderResult,
+} from '../src/types.js';
+
+let registerProvider: typeof import('../src/adapters/index.js').registerProvider;
+let createEstimateBudgetTracker: typeof import('../src/core/budget.js').createEstimateBudgetTracker;
+let dispatch: typeof import('../src/core/dispatcher.js').dispatch;
+
+function makeConfig(
+  providers: Record<
+    string,
+    { apiKey: string; enabled: boolean; options?: Record<string, unknown> }
+  >,
+  maxParallel = 1,
+): Config {
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel,
+      timeout: 30,
+      asyncTimeout: 1800,
+      asyncPollInterval: 10,
+      mode: 'sync',
+    },
+    providers,
+    groups: {},
+  };
+}
+
+/** A raw-search provider (real registry id) that reports no usage. */
+function searchProvider(id: string): Provider {
+  return {
+    id,
+    displayName: `Mock ${id}`,
+    tier: 'raw-search',
+    envVar: `MOCK_${id.toUpperCase().replace(/-/g, '_')}_KEY`,
+    execute: async (
+      _query: string,
+      _options: ProviderOptions,
+    ): Promise<ProviderResult> => ({
+      provider: id,
+      tier: 'raw-search',
+      content: `result from ${id}`,
+      citations: [],
+      durationMs: 1,
+    }),
+  };
+}
+
+describe('dispatcher: metering attachment', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const adapters = await import('../src/adapters/index.js');
+    registerProvider = adapters.registerProvider;
+    const budgetMod = await import('../src/core/budget.js');
+    createEstimateBudgetTracker = budgetMod.createEstimateBudgetTracker;
+    const dispatcherMod = await import('../src/core/dispatcher.js');
+    dispatch = dispatcherMod.dispatch;
+    process.env.MOCK_SERPAPI_KEY = 'k';
+    process.env.MOCK_BRAVE_SEARCH_KEY = 'k';
+    process.env.MOCK_TAVILY_KEY = 'k';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.MOCK_SERPAPI_KEY;
+    delete process.env.MOCK_BRAVE_SEARCH_KEY;
+    delete process.env.MOCK_TAVILY_KEY;
+  });
+
+  it('attaches metering (kind + estimate) to every report and result', async () => {
+    registerProvider(searchProvider('serpapi'));
+    const { reports, results } = await dispatch({
+      config: makeConfig({
+        serpapi: { apiKey: '$MOCK_SERPAPI_KEY', enabled: true },
+      }),
+      providerIds: ['serpapi'],
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: process.env },
+    });
+
+    const report = reports.find((r) => r.id === 'serpapi');
+    expect(report?.metering?.kind).toBe('request_priced');
+    expect(report?.metering?.estimate?.estimatedCostUsd).toBe(0.015);
+    expect(report?.metering?.estimate?.costConfidence).toBe('estimated');
+    // The same metering rides on the structured dispatch result.
+    const result = results.find((r) => r.provider === 'serpapi');
+    expect(result?.metering?.kind).toBe('request_priced');
+  });
+
+  it('honors configured pricing overrides from provider options', async () => {
+    registerProvider(searchProvider('serpapi'));
+    const { reports } = await dispatch({
+      config: makeConfig({
+        serpapi: {
+          apiKey: '$MOCK_SERPAPI_KEY',
+          enabled: true,
+          options: { perRequestUsd: 0.03 },
+        },
+      }),
+      providerIds: ['serpapi'],
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: process.env },
+    });
+    const est = reports.find((r) => r.id === 'serpapi')?.metering?.estimate;
+    expect(est?.estimatedCostUsd).toBe(0.03);
+    expect(est?.costConfidence).toBe('configured');
+  });
+});
+
+describe('dispatcher: estimated budget reservation', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const adapters = await import('../src/adapters/index.js');
+    registerProvider = adapters.registerProvider;
+    const budgetMod = await import('../src/core/budget.js');
+    createEstimateBudgetTracker = budgetMod.createEstimateBudgetTracker;
+    const dispatcherMod = await import('../src/core/dispatcher.js');
+    dispatch = dispatcherMod.dispatch;
+    process.env.MOCK_SERPAPI_KEY = 'k';
+    process.env.MOCK_BRAVE_SEARCH_KEY = 'k';
+    process.env.MOCK_SEARCHAPI_KEY = 'k';
+    process.env.MOCK_TAVILY_KEY = 'k';
+    process.env.MOCK_FIRECRAWL_SEARCH_KEY = 'k';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const k of [
+      'MOCK_SERPAPI_KEY',
+      'MOCK_BRAVE_SEARCH_KEY',
+      'MOCK_SEARCHAPI_KEY',
+      'MOCK_TAVILY_KEY',
+      'MOCK_FIRECRAWL_SEARCH_KEY',
+    ]) {
+      delete process.env[k];
+    }
+  });
+
+  it('skips not-yet-started providers once the reservation crosses the ceiling', async () => {
+    registerProvider(searchProvider('serpapi')); // estimate 0.015
+    registerProvider(searchProvider('searchapi')); // estimate 0.004
+    registerProvider(searchProvider('brave-search')); // estimate 0.005
+
+    const estimatedBudget = createEstimateBudgetTracker(0.015);
+    const { reports } = await dispatch({
+      config: makeConfig({
+        serpapi: { apiKey: '$MOCK_SERPAPI_KEY', enabled: true },
+        searchapi: { apiKey: '$MOCK_SEARCHAPI_KEY', enabled: true },
+        'brave-search': { apiKey: '$MOCK_BRAVE_SEARCH_KEY', enabled: true },
+      }),
+      providerIds: ['serpapi', 'searchapi', 'brave-search'],
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: process.env },
+      estimatedBudget,
+    });
+
+    const byId = new Map(reports.map((r) => [r.id, r]));
+    // serpapi reserves 0.015 -> reaches the ceiling -> the rest are skipped.
+    expect(byId.get('serpapi')?.status).toBe('success');
+    expect(byId.get('searchapi')?.status).toBe('skipped');
+    expect(byId.get('searchapi')?.error).toBe(ESTIMATE_BUDGET_SKIP_REASON);
+    expect(byId.get('brave-search')?.status).toBe('skipped');
+    expect(estimatedBudget.reservedUsd).toBeCloseTo(0.015);
+  });
+
+  it('never skips providers whose estimate has no USD figure (reserve 0)', async () => {
+    // tavily/firecrawl are credit-priced with no configured price: each reserves
+    // 0, so even a tiny ceiling lets them all run.
+    registerProvider(searchProvider('tavily'));
+    registerProvider(searchProvider('firecrawl-search'));
+
+    const estimatedBudget = createEstimateBudgetTracker(0.001);
+    const { reports } = await dispatch({
+      config: makeConfig({
+        tavily: { apiKey: '$MOCK_TAVILY_KEY', enabled: true },
+        'firecrawl-search': {
+          apiKey: '$MOCK_FIRECRAWL_SEARCH_KEY',
+          enabled: true,
+        },
+      }),
+      providerIds: ['tavily', 'firecrawl-search'],
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: process.env },
+      estimatedBudget,
+    });
+
+    expect(reports.every((r) => r.status === 'success')).toBe(true);
+    expect(estimatedBudget.reservedUsd).toBe(0);
+  });
+
+  it('does not reserve or skip anything when no estimated budget is supplied', async () => {
+    registerProvider(searchProvider('serpapi'));
+    registerProvider(searchProvider('searchapi'));
+    const { reports } = await dispatch({
+      config: makeConfig({
+        serpapi: { apiKey: '$MOCK_SERPAPI_KEY', enabled: true },
+        searchapi: { apiKey: '$MOCK_SEARCHAPI_KEY', enabled: true },
+      }),
+      providerIds: ['serpapi', 'searchapi'],
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: process.env },
+    });
+    expect(reports.every((r) => r.status === 'success')).toBe(true);
+  });
+});

--- a/tests/dispatcher-metering.test.ts
+++ b/tests/dispatcher-metering.test.ts
@@ -199,6 +199,51 @@ describe('dispatcher: estimated budget reservation', () => {
     expect(estimatedBudget.reservedUsd).toBe(0);
   });
 
+  it('does not reserve a fallback that never launches (no phantom reservation)', async () => {
+    // serpapi fails and is configured to fall back to brave-search — but
+    // brave-search is already a primary in this dispatch, so the fallback bails
+    // out without launching. Its estimate must NOT be reserved twice.
+    const failing: Provider = {
+      id: 'serpapi',
+      displayName: 'Mock serpapi',
+      tier: 'raw-search',
+      envVar: 'MOCK_SERPAPI_KEY',
+      execute: async (): Promise<ProviderResult> => ({
+        provider: 'serpapi',
+        tier: 'raw-search',
+        content: '',
+        citations: [],
+        durationMs: 1,
+        error: 'boom',
+      }),
+    };
+    registerProvider(failing);
+    registerProvider(searchProvider('brave-search'));
+
+    const config = makeConfig({
+      serpapi: { apiKey: '$MOCK_SERPAPI_KEY', enabled: true },
+      'brave-search': { apiKey: '$MOCK_BRAVE_SEARCH_KEY', enabled: true },
+    });
+    config.providers.serpapi = {
+      ...config.providers.serpapi,
+      fallback: 'brave-search',
+    } as never;
+
+    const estimatedBudget = createEstimateBudgetTracker(1);
+    await dispatch({
+      config,
+      providerIds: ['serpapi', 'brave-search'],
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: process.env },
+      estimatedBudget,
+    });
+
+    // serpapi (0.015) + brave-search-as-primary (0.005) = 0.02. The bailed
+    // fallback must not add another 0.005.
+    expect(estimatedBudget.reservedUsd).toBeCloseTo(0.02);
+  });
+
   it('does not reserve or skip anything when no estimated budget is supplied', async () => {
     registerProvider(searchProvider('serpapi'));
     registerProvider(searchProvider('searchapi'));

--- a/tests/jsonl-report.test.ts
+++ b/tests/jsonl-report.test.ts
@@ -272,6 +272,37 @@ describe('generateJsonlReport -- each line parses independently', () => {
     expect(resultLine?.usage).toEqual({ costUsd: 0.012, inputTokens: 500 });
   });
 
+  it('includes metering when present on result line', () => {
+    const manifest = makeManifest({
+      providers: [
+        makeReport({
+          metering: {
+            kind: 'request_priced',
+            pricingVersion: '2026-06',
+            estimate: {
+              estimatedCostUsd: 0.015,
+              billableUnits: 1,
+              unit: 'request',
+              costConfidence: 'estimated',
+            },
+          },
+        }),
+      ],
+    });
+    const jsonl = generateJsonlReport({
+      manifest,
+      providerContents: {},
+      sources: [],
+    });
+    const lines = parseLines(jsonl) as Array<{
+      type: string;
+      metering?: { kind?: string; estimate?: { estimatedCostUsd?: number } };
+    }>;
+    const resultLine = lines.find((l) => l.type === 'result');
+    expect(resultLine?.metering?.kind).toBe('request_priced');
+    expect(resultLine?.metering?.estimate?.estimatedCostUsd).toBe(0.015);
+  });
+
   it('emits source lines with correct fields', () => {
     const jsonl = generateJsonlReport({
       manifest: makeManifest(),

--- a/tests/mcp-async-metering.test.ts
+++ b/tests/mcp-async-metering.test.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AsyncTaskHandle,
+  Provider,
+  ProviderResult,
+  RunManifest,
+} from '../src/types.js';
+
+let registerProvider: typeof import('../src/adapters/index.js').registerProvider;
+let checkAsyncTasks: typeof import('../src/mcp/async.js').checkAsyncTasks;
+let saveAsyncTasks: typeof import('../src/core/async-manager.js').saveAsyncTasks;
+
+/**
+ * Regression for the MCP `check_async` retrieval path: a completed async result
+ * retrieved via the MCP tool must persist metering on run.json and .meta.json,
+ * matching the CLI `status --retrieve` path. (deep-review #1609 finding.)
+ */
+describe('MCP check_async retrieval persists metering', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    registerProvider = (await import('../src/adapters/index.js'))
+      .registerProvider;
+    checkAsyncTasks = (await import('../src/mcp/async.js')).checkAsyncTasks;
+    saveAsyncTasks = (await import('../src/core/async-manager.js'))
+      .saveAsyncTasks;
+    dir = join(tmpdir(), `librarium-mcp-async-${randomUUID().slice(0, 8)}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes metering (kind + provider_reported actual) on retrieval', async () => {
+    // perplexity-sonar-deep is native_cost: retrieval reports costUsd, which the
+    // metering normalization turns into a provider_reported actual lane.
+    const provider: Provider = {
+      id: 'perplexity-sonar-deep',
+      displayName: 'Mock deep',
+      tier: 'deep-research',
+      envVar: 'MOCK_PPLX_KEY',
+      execute: async (): Promise<ProviderResult> => ({
+        provider: 'perplexity-sonar-deep',
+        tier: 'deep-research',
+        content: 'final',
+        citations: [],
+        durationMs: 1,
+      }),
+      retrieve: async (): Promise<ProviderResult> => ({
+        provider: 'perplexity-sonar-deep',
+        tier: 'deep-research',
+        content: 'retrieved body',
+        citations: [],
+        durationMs: 10,
+        usage: { costUsd: 0.42, totalTokens: 100 },
+      }),
+    };
+    registerProvider(provider);
+
+    const manifest: RunManifest = {
+      version: 1,
+      timestamp: 1_781_136_000,
+      slug: 'async-meter',
+      query: 'q',
+      mode: 'async',
+      outputDir: dir,
+      providers: [
+        {
+          id: 'perplexity-sonar-deep',
+          tier: 'deep-research',
+          status: 'async-pending',
+          durationMs: 0,
+          wordCount: 0,
+          citationCount: 0,
+          outputFile: '',
+          metaFile: '',
+        },
+      ],
+      sources: { total: 0, unique: 0, file: 'sources.json' },
+      asyncTasks: [],
+      exitCode: 0,
+    };
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+
+    const task: AsyncTaskHandle = {
+      provider: 'perplexity-sonar-deep',
+      taskId: 'task-1',
+      query: 'q',
+      submittedAt: 1,
+      status: 'completed',
+      outputDir: dir,
+    };
+    saveAsyncTasks(dir, [task]);
+
+    const result = await checkAsyncTasks(dir, true);
+    expect(result.retrieved).toBe(1);
+
+    // .meta.json carries metering.
+    const meta = JSON.parse(
+      readFileSync(join(dir, 'perplexity-sonar-deep.meta.json'), 'utf-8'),
+    );
+    expect(meta.metering.kind).toBe('native_cost');
+    expect(meta.metering.actual).toEqual({
+      costUsd: 0.42,
+      source: 'provider_reported',
+    });
+
+    // run.json's folded-in provider report carries metering too.
+    const updated = JSON.parse(
+      readFileSync(join(dir, 'run.json'), 'utf-8'),
+    ) as RunManifest;
+    const report = updated.providers.find(
+      (p) => p.id === 'perplexity-sonar-deep',
+    );
+    expect(report?.status).toBe('success');
+    expect(report?.metering?.kind).toBe('native_cost');
+    expect(report?.metering?.actual?.source).toBe('provider_reported');
+  });
+});

--- a/tests/metering.test.ts
+++ b/tests/metering.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { getAllProviders, initializeProviders } from '../src/adapters/index.js';
+import {
+  createEstimateBudgetTracker,
+  ESTIMATE_BUDGET_SKIP_REASON,
+} from '../src/core/budget.js';
+import {
+  buildProviderMetering,
+  estimateMetering,
+  getMeteringKind,
+  meteredProviderIds,
+  PRICING_VERSION,
+} from '../src/core/metering.js';
+
+describe('metering registry: kinds', () => {
+  it('classifies known providers by metering kind', () => {
+    expect(getMeteringKind('perplexity-sonar-pro')).toBe('native_cost');
+    expect(getMeteringKind('exa')).toBe('native_cost');
+    expect(getMeteringKind('openrouter-chat')).toBe('native_cost');
+    expect(getMeteringKind('claude')).toBe('native_tokens');
+    expect(getMeteringKind('gemini-deep')).toBe('native_tokens');
+    expect(getMeteringKind('serpapi')).toBe('request_priced');
+    expect(getMeteringKind('brave-search')).toBe('request_priced');
+    expect(getMeteringKind('kagi-fastgpt')).toBe('request_priced');
+    expect(getMeteringKind('tavily')).toBe('credit_priced');
+    expect(getMeteringKind('firecrawl-search')).toBe('credit_priced');
+    expect(getMeteringKind('jina-search')).toBe('api_unit_priced');
+  });
+
+  it('resolves legacy aliases to the canonical kind', () => {
+    // perplexity-sonar -> perplexity-sonar-pro (native_cost)
+    expect(getMeteringKind('perplexity-sonar')).toBe('native_cost');
+  });
+
+  it('defaults unknown/custom providers to manual_unmetered', () => {
+    expect(getMeteringKind('totally-made-up')).toBe('manual_unmetered');
+  });
+
+  it('lockstep: every built-in provider has a registry entry', async () => {
+    await initializeProviders();
+    const registered = new Set(meteredProviderIds());
+    const missing = getAllProviders()
+      .map((p) => p.id)
+      .filter((id) => !registered.has(id));
+    expect(
+      missing,
+      `built-in providers missing a metering registry entry: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('metering registry: estimates', () => {
+  it('emits a default USD estimate for flat request-priced providers', () => {
+    const est = estimateMetering('serpapi');
+    expect(est).toBeDefined();
+    expect(est?.estimatedCostUsd).toBe(0.015);
+    expect(est?.billableUnits).toBe(1);
+    expect(est?.unit).toBe('request');
+    expect(est?.costConfidence).toBe('estimated');
+    expect(est?.pricingVersion).toBe(PRICING_VERSION);
+  });
+
+  it('honors a configured per-request override (confidence: configured)', () => {
+    const est = estimateMetering('serpapi', {
+      options: { perRequestUsd: 0.02 },
+    });
+    expect(est?.estimatedCostUsd).toBe(0.02);
+    expect(est?.costConfidence).toBe('configured');
+  });
+
+  it('emits units WITHOUT a default USD figure for credit-priced providers', () => {
+    const est = estimateMetering('tavily');
+    expect(est).toBeDefined();
+    expect(est?.unit).toBe('credit');
+    expect(est?.billableUnits).toBe(2);
+    expect(est?.estimatedCostUsd).toBeUndefined();
+    expect(est?.costConfidence).toBe('estimated');
+  });
+
+  it('computes a USD estimate for credit providers only once a price is configured', () => {
+    const est = estimateMetering('tavily', { options: { creditUsd: 0.008 } });
+    expect(est?.estimatedCostUsd).toBeCloseTo(0.016);
+    expect(est?.costConfidence).toBe('configured');
+  });
+
+  it('emits unit metadata without USD for api_unit_priced providers', () => {
+    const est = estimateMetering('jina-search');
+    expect(est?.unit).toBe('token');
+    expect(est?.estimatedCostUsd).toBeUndefined();
+  });
+
+  it('produces no estimate for native or unmetered providers', () => {
+    expect(estimateMetering('claude')).toBeUndefined();
+    expect(estimateMetering('perplexity-sonar-pro')).toBeUndefined();
+    expect(estimateMetering('totally-made-up')).toBeUndefined();
+  });
+
+  it('pins the pricing snapshot version (bump deliberately)', () => {
+    // Tripwire: changing default prices should bump PRICING_VERSION.
+    expect(PRICING_VERSION).toBe('2026-06');
+  });
+});
+
+describe('buildProviderMetering: estimate vs actual separation', () => {
+  it('attaches an estimate but no actual when no usage is in hand', () => {
+    const metering = buildProviderMetering('serpapi');
+    expect(metering.kind).toBe('request_priced');
+    expect(metering.estimate?.estimatedCostUsd).toBe(0.015);
+    expect(metering.actual).toBeUndefined();
+  });
+
+  it('derives a provider_reported actual lane from reported costUsd', () => {
+    const metering = buildProviderMetering('perplexity-sonar-pro', undefined, {
+      costUsd: 0.0086,
+      totalTokens: 180,
+    });
+    expect(metering.kind).toBe('native_cost');
+    expect(metering.actual).toEqual({
+      costUsd: 0.0086,
+      source: 'provider_reported',
+    });
+    // native_cost has no pre-dispatch estimate, and the actual never leaks into
+    // an estimate field.
+    expect(metering.estimate).toBeUndefined();
+  });
+
+  it('never invents an actual lane from tokens-only usage', () => {
+    const metering = buildProviderMetering('claude', undefined, {
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+    });
+    expect(metering.kind).toBe('native_tokens');
+    expect(metering.actual).toBeUndefined();
+  });
+
+  it('defaults unknown providers to manual_unmetered with no estimate/actual', () => {
+    const metering = buildProviderMetering('totally-made-up');
+    expect(metering).toEqual({ kind: 'manual_unmetered' });
+  });
+});
+
+describe('createEstimateBudgetTracker', () => {
+  it('never trips when no limit is set', () => {
+    const tracker = createEstimateBudgetTracker(undefined);
+    tracker.reserve({ estimatedCostUsd: 100, costConfidence: 'estimated' });
+    expect(tracker.limitUsd).toBeUndefined();
+    expect(tracker.reservedUsd).toBe(100);
+    expect(tracker.exceeded()).toBe(false);
+  });
+
+  it('reserves only a finite positive estimatedCostUsd', () => {
+    const tracker = createEstimateBudgetTracker(1);
+    tracker.reserve(undefined);
+    tracker.reserve({ costConfidence: 'estimated' }); // no USD figure
+    tracker.reserve({
+      billableUnits: 2,
+      unit: 'credit',
+      costConfidence: 'estimated',
+    });
+    tracker.reserve({ estimatedCostUsd: -1, costConfidence: 'estimated' });
+    expect(tracker.reservedUsd).toBe(0);
+    expect(tracker.exceeded()).toBe(false);
+  });
+
+  it('trips once the reservation reaches the ceiling (inclusive)', () => {
+    const tracker = createEstimateBudgetTracker(0.03);
+    tracker.reserve({ estimatedCostUsd: 0.015, costConfidence: 'estimated' });
+    expect(tracker.exceeded()).toBe(false);
+    tracker.reserve({ estimatedCostUsd: 0.015, costConfidence: 'estimated' });
+    expect(tracker.reservedUsd).toBeCloseTo(0.03);
+    expect(tracker.exceeded()).toBe(true);
+  });
+
+  it('treats a non-positive limit as no limit', () => {
+    expect(createEstimateBudgetTracker(0).limitUsd).toBeUndefined();
+    expect(createEstimateBudgetTracker(-2).limitUsd).toBeUndefined();
+  });
+
+  it('exposes a stable, distinct skip reason', () => {
+    expect(ESTIMATE_BUDGET_SKIP_REASON).toContain('estimated');
+    expect(ESTIMATE_BUDGET_SKIP_REASON).not.toBe(
+      'skipped: cost budget reached',
+    );
+  });
+});

--- a/tests/usage-data.test.ts
+++ b/tests/usage-data.test.ts
@@ -183,4 +183,32 @@ describe('aggregateUsage', () => {
     // An estimate alone does not count the run as having measured usage.
     expect(agg.runsWithoutUsage).toBe(0); // exa reported real usage this run
   });
+
+  it('excludes skipped providers from estimated cost (never launched)', () => {
+    const skipped: ProviderReport = {
+      id: 'serpapi',
+      tier: 'raw-search',
+      status: 'skipped',
+      durationMs: 0,
+      wordCount: 0,
+      citationCount: 0,
+      outputFile: '',
+      metaFile: '',
+      error: 'skipped: estimated cost budget reached',
+      metering: {
+        kind: 'request_priced',
+        estimate: {
+          estimatedCostUsd: 0.015,
+          billableUnits: 1,
+          unit: 'request',
+          costConfidence: 'estimated',
+        },
+      },
+    };
+    writeManifest(baseDir, nowSec, [report('exa', { costUsd: 0.02 }), skipped]);
+
+    const agg = aggregateUsage(baseDir);
+    expect(agg.totalEstimatedCostUsd).toBe(0);
+    expect(agg.providers.find((p) => p.provider === 'serpapi')).toBeUndefined();
+  });
 });

--- a/tests/usage-data.test.ts
+++ b/tests/usage-data.test.ts
@@ -67,6 +67,7 @@ describe('aggregateUsage', () => {
       runsWithoutUsage: 0,
       totalCostUsd: 0,
       runsWithCost: 0,
+      totalEstimatedCostUsd: 0,
       providers: [],
       range: null,
     });
@@ -141,5 +142,45 @@ describe('aggregateUsage', () => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, 'run.json'), '{ not valid json');
     expect(aggregateUsage(baseDir).runCount).toBe(0);
+  });
+
+  it('aggregates estimated cost separately from reported cost', () => {
+    const reported = report('exa', { costUsd: 0.02 });
+    // A report with only a pre-dispatch estimate and no reported usage.
+    const estimated: ProviderReport = {
+      id: 'serpapi',
+      tier: 'raw-search',
+      status: 'success',
+      durationMs: 50,
+      wordCount: 10,
+      citationCount: 1,
+      outputFile: 'serpapi.md',
+      metaFile: 'serpapi.meta.json',
+      metering: {
+        kind: 'request_priced',
+        estimate: {
+          estimatedCostUsd: 0.015,
+          billableUnits: 1,
+          unit: 'request',
+          costConfidence: 'estimated',
+        },
+      },
+    };
+    writeManifest(baseDir, nowSec, [reported, estimated]);
+
+    const agg = aggregateUsage(baseDir);
+    expect(agg.totalCostUsd).toBeCloseTo(0.02);
+    expect(agg.totalEstimatedCostUsd).toBeCloseTo(0.015);
+    // The estimate-only provider appears with an estimate but no reported cost.
+    const serp = agg.providers.find((p) => p.provider === 'serpapi');
+    expect(serp?.reportedCost).toBe(false);
+    expect(serp?.hasEstimate).toBe(true);
+    expect(serp?.estimatedCostUsd).toBeCloseTo(0.015);
+    // The reported-cost provider carries no estimate.
+    const exa = agg.providers.find((p) => p.provider === 'exa');
+    expect(exa?.reportedCost).toBe(true);
+    expect(exa?.hasEstimate).toBe(false);
+    // An estimate alone does not count the run as having measured usage.
+    expect(agg.runsWithoutUsage).toBe(0); // exa reported real usage this run
   });
 });

--- a/tests/workers/core.test.ts
+++ b/tests/workers/core.test.ts
@@ -98,6 +98,7 @@ describe('librarium/core in workerd', () => {
         durationMs: 5,
         model: 'mock-model',
         tokenUsage: undefined,
+        metering: { kind: 'manual_unmetered' },
         error: undefined,
         fallbackFor: undefined,
       },


### PR DESCRIPTION
## Summary

Adds a network-free **provider metering capability registry** so consumers (e.g. Accelerator) can know *how* each provider is priced — and reserve budget against pre-dispatch estimates — before a call ever runs. Implements PlanMode task #1609.

Librarium's existing `--max-cost` budget is intentionally honest: it counts only provider-reported `costUsd`, a lower bound. That's right for research fan-out but not enough for products that need pre-call budget reservation against request/credit/API-unit-priced APIs. This change adds the estimate lane **without** compromising the honest-reported contract.

## What's new

- **`metering_kind` per provider** (`src/core/metering.ts`): `native_cost`, `native_tokens`, `request_priced`, `credit_priced`, `api_unit_priced`, `manual_unmetered`. Visible in `librarium ls` / `ls --json`.
- **Network-free estimate hooks** — `estimateMetering()` returns `estimatedCostUsd`, `billableUnits`, `unit`, `pricingVersion`, `costConfidence` with no API call. Flat request-priced providers (SerpAPI, SearchAPI, Brave, Kagi) carry a default estimate marked `'estimated'`; **plan-dependent** credit/api-unit providers (Tavily, Firecrawl, You.com, Jina) emit unit metadata **without** a fabricated USD figure until you configure a price via provider `options`.
- **Estimate ≠ fact** — `usage.costUsd` stays provider-reported only. Estimates live under `metering.estimate`; the actual-cost provenance lives under `metering.actual.source` (`provider_reported` today).
- **`--max-estimated-cost` flag** (+ `defaults.maxEstimatedCostUsd`) on `run`/`answer` — a pre-dispatch *reservation* ceiling, fully independent of the reported-only `--max-cost` (the two never reconcile). Reserves only at launch, so skipped/bailed providers leave no phantom reservation.
- **Exposed everywhere** — dispatch results, `run.json`, per-provider `.meta.json` (CLI run, MCP, and async retrieval via both `status --retrieve` and the MCP `check_async` tool), `results.jsonl`, MCP shaping, and the `usage` command (separate `est. cost` lane).

## Design notes

Built after a multi-agent plan review (Codex/Claude/Amp): a **separate** top-level `metering` field keeps the honest-reported vs estimated boundary clean; credit-priced providers deliberately omit default dollars to avoid fake precision; a single `buildProviderMetering()` normalization path covers sync dispatch, fallback, and all async-retrieval surfaces.

## Testing

- New `tests/metering.test.ts`, `tests/dispatcher-metering.test.ts`, `tests/mcp-async-metering.test.ts` + extended usage/jsonl tests: registry kinds + provider↔registry lockstep, estimate-vs-actual separation, reservation/skip semantics (incl. fallback no-double-reserve), serialization, and usage aggregation.
- `tsc --noEmit` clean, `vitest run` 533 passing, `biome check` clean.

Cross-model verification (Sonnet + Codex) and a 3-reviewer Solo deep-review panel (Codex/Claude/Amp) ran on the diff; all findings (notably an MCP async-retrieval metering gap) are fixed and covered by tests.

Implements PlanMode #1609.