### PR TITLE
Release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
## Summary

- Sync the release workflow's generated v1.2.0 package version bump back into main.
- The release is already published at https://github.com/jkudish/librarium/releases/tag/v1.2.0 and npm reports librarium@1.2.0.

## Testing

- Release workflow completed successfully: https://github.com/jkudish/librarium/actions/runs/28966776788
- npm publish, binary uploads, Homebrew update, and smoke-test install jobs passed.