### PR TITLE
fix: tighten claim selection and decouple verification from answer.md format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Opt-in claim verification**: `librarium answer --verify` extracts up to eight
+  material factual claims from the synthesized answer, checks them against the
+  fan-out's independent source evidence, runs at most three successful follow-up
+  evidence queries (three provider attempts each, fast tiers only), and revises
+  the answer only after a complete evidence-backed verification. Fails open: any
+  incomplete evidence, budget exhaustion, or provider/LLM failure preserves the
+  original grounded answer. A full audit trail lands in `verification.json`, the
+  run manifest, `results.jsonl` (a `"type":"verification"` line), and
+  `report.html`, with provider and verification-LLM spend accounted separately
+  and unknown costs flagged as explicit lower bounds.
+- `--no-fallback` flag on `librarium run` and `librarium answer`: disables
+  configured provider fallbacks for an exact provider matrix.
+- Repo-local, reproducible provider benchmark under `benchmark/` (not part of
+  the npm package): curated stable and freshness-sensitive corpora, offline
+  fixture replay in CI, pinned synthesis/judge configuration, resumable runs,
+  and interactive confirmation before any paid call.
+
+### Changed
+- HTML report link sanitization hardened: URL-parse-based scheme allowlist,
+  rejecting protocol-relative URLs, control characters, and backslashes.
+- The answer/refine LLM cascade now records normalized token usage and reported
+  cost per attempt.
+- Claim selection treats modal statements with active verbs ("may require X")
+  as checkable claims; only explicit hedges are excluded from verification.
+
 ## [1.1.0] - 2026-06-29
 
 ### Added

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Command } from 'commander';
 import { safeWriteFile } from '../core/fs-utils.js';
@@ -117,23 +116,17 @@ export async function synthesizeAndVerifyAnswer(
   const synthesis = await synthesizeAnswer(context);
   if (!synthesis?.manifestExtra?.answer) return synthesis;
 
-  let originalAnswer: string;
-  try {
-    originalAnswer = readFileSync(
-      join(context.outputDir, 'answer.md'),
-      'utf-8',
-    );
-  } catch (error) {
+  // The raw body comes straight from the synthesis stage rather than being
+  // re-parsed out of answer.md, so verification never depends on the rendered
+  // file format.
+  const answerBody = synthesis.answerText?.trim();
+  if (!answerBody) {
     context.printLine(
-      `  ! answer verification skipped: ${error instanceof Error ? error.message : String(error)}`,
+      '  ! answer verification skipped: synthesized answer body unavailable',
     );
     return synthesis;
   }
 
-  const answerBody = originalAnswer
-    .replace(/^\s*#[^\S\n]+[^\n]*\n+/, '')
-    .replace(/\n#{1,6}[^\S\n]+Sources\b[\s\S]*$/i, '\n')
-    .trim();
   let verification;
   try {
     verification = await verifyAnswer({
@@ -143,6 +136,7 @@ export async function synthesizeAndVerifyAnswer(
       results: context.results,
       reports: context.reports,
       sources: context.sources,
+      warn: (message) => console.error(`[librarium] verify: ${message}`),
     });
   } catch (error) {
     context.printLine('');
@@ -252,6 +246,7 @@ export async function synthesizeAnswer(
     manifestExtra: {
       answer: { provider: synthesis.provider, model: synthesis.model },
     },
+    answerText: synthesis.text,
   };
 }
 

--- a/src/commands/claim-verification.ts
+++ b/src/commands/claim-verification.ts
@@ -69,6 +69,8 @@ export interface VerificationInput {
   results: ProviderDispatchResult[];
   reports: ProviderReport[];
   sources: DeduplicatedSource[];
+  /** Sink for cascade fallback warnings. Defaults to a stderr line. */
+  warn?: (message: string) => void;
 }
 
 export interface VerificationResult {
@@ -204,9 +206,18 @@ function recordLlmAttempt(
   return call;
 }
 
+/**
+ * Bare modals ("may", "could") also appear in checkable factual claims
+ * ("may require SNI", "could negotiate"), so a modal only counts as
+ * uncertainty when followed by be/have/not — the usual epistemic hedge shape.
+ * The model's own explicitUncertainty flag is still honored before this
+ * backstop runs.
+ */
 function isExplicitlyUncertain(claim: string): boolean {
-  return /\b(?:unknown|unclear|uncertain|unconfirmed|not confirmed|may|might|could)\b/i.test(
-    claim,
+  return (
+    /\b(?:unknown|unclear|uncertain|unconfirmed|not (?:yet )?confirmed|possibly|perhaps|reportedly|allegedly|apparently|seemingly|supposedly|purportedly|may or may not)\b/i.test(
+      claim,
+    ) || /\b(?:may|might|could)\s+(?:\w+\s+)?(?:be|have|not)\b/i.test(claim)
   );
 }
 
@@ -222,12 +233,18 @@ function parseJson(text: string): unknown {
   return JSON.parse(fenced?.[1] ?? trimmed);
 }
 
-async function runLlmJson<T>(
-  config: Config,
+interface LlmRunContext {
+  config: Config;
+  warn: (message: string) => void;
+}
+
+async function runLlm<T>(
+  { config, warn }: LlmRunContext,
   stage: VerificationLlmCall['stage'],
   prompt: string,
   budgets: VerificationBudgets,
   calls: VerificationLlmCall[],
+  parse?: (text: string) => T,
 ): Promise<LlmResult<T>> {
   const preference = preferenceFromConfig(config, 'answer', 'refine');
   const clients = resolveLlmClients(preference, {
@@ -244,14 +261,14 @@ async function runLlmJson<T>(
     prompt,
     action: `claim verification ${stage}`,
     timeoutMs: verificationTimeoutMs(config),
-    json: true,
-    parse: (text) => parseJson(text) as T,
+    json: Boolean(parse),
+    parse,
     beforeAttempt: (client) => beforeLlmAttempt(client, config, budgets),
     onAttempt: (attempt) => {
       const call = recordLlmAttempt(stage, attempt, config, budgets, calls);
       if (attempt.status === 'success') successfulCall = call;
     },
-    onWarning: (message) => console.error(`[librarium] verify: ${message}`),
+    onWarning: warn,
   });
   if (!successfulCall) throw new Error(`claim verification ${stage} failed`);
   return {
@@ -260,41 +277,31 @@ async function runLlmJson<T>(
   };
 }
 
-async function runLlmText(
-  config: Config,
+function runLlmJson<T>(
+  context: LlmRunContext,
+  stage: VerificationLlmCall['stage'],
+  prompt: string,
+  budgets: VerificationBudgets,
+  calls: VerificationLlmCall[],
+): Promise<LlmResult<T>> {
+  return runLlm<T>(
+    context,
+    stage,
+    prompt,
+    budgets,
+    calls,
+    (text) => parseJson(text) as T,
+  );
+}
+
+function runLlmText(
+  context: LlmRunContext,
   stage: VerificationLlmCall['stage'],
   prompt: string,
   budgets: VerificationBudgets,
   calls: VerificationLlmCall[],
 ): Promise<LlmResult<string>> {
-  const preference = preferenceFromConfig(config, 'answer', 'refine');
-  const clients = resolveLlmClients(preference, {
-    env: process.env,
-    config,
-    credentials: createNodeCredentialContext(),
-  });
-  if (clients.length === 0) {
-    throw new Error('no verification LLM provider available');
-  }
-  let successfulCall: VerificationLlmCall | undefined;
-  const { result } = await callWithCascade<string>({
-    clients,
-    prompt,
-    action: `claim verification ${stage}`,
-    timeoutMs: verificationTimeoutMs(config),
-    json: false,
-    beforeAttempt: (client) => beforeLlmAttempt(client, config, budgets),
-    onAttempt: (attempt) => {
-      const call = recordLlmAttempt(stage, attempt, config, budgets, calls);
-      if (attempt.status === 'success') successfulCall = call;
-    },
-    onWarning: (message) => console.error(`[librarium] verify: ${message}`),
-  });
-  if (!successfulCall) throw new Error(`claim verification ${stage} failed`);
-  return {
-    value: result,
-    call: successfulCall,
-  };
+  return runLlm<string>(context, stage, prompt, budgets, calls);
 }
 
 function untrusted(value: string): string {
@@ -668,6 +675,12 @@ export async function verifyAnswer(
 ): Promise<VerificationResult> {
   const llm: VerificationLlmCall[] = [];
   const reasons: string[] = [];
+  const llmContext: LlmRunContext = {
+    config: input.config,
+    warn:
+      input.warn ??
+      ((message) => console.error(`[librarium] verify: ${message}`)),
+  };
   const budgets: VerificationBudgets = {
     reported: createBudgetTracker(input.config.defaults.maxCostUsd),
     estimated: createEstimateBudgetTracker(
@@ -704,7 +717,7 @@ export async function verifyAnswer(
   let claims: ClaimSupport[];
   try {
     const extraction = await runLlmJson<{ claims?: unknown }>(
-      input.config,
+      llmContext,
       'claims',
       claimsPrompt(input.answer),
       budgets,
@@ -728,7 +741,7 @@ export async function verifyAnswer(
     // This initial assessment is deliberately before any follow-up provider
     // call; the order is part of the product contract and testable via mocks.
     const assessment = await runLlmJson<{ assessments?: unknown }>(
-      input.config,
+      llmContext,
       'initial-assessment',
       evidencePrompt(claims, initialEvidence(input.results)),
       budgets,
@@ -790,7 +803,7 @@ export async function verifyAnswer(
   ) {
     try {
       const assessment = await runLlmJson<{ assessments?: unknown }>(
-        input.config,
+        llmContext,
         'follow-up-assessment',
         evidencePrompt(claims, evidence),
         budgets,
@@ -826,7 +839,7 @@ export async function verifyAnswer(
 
   try {
     const revision = await runLlmText(
-      input.config,
+      llmContext,
       'revision',
       revisionPrompt(input.answer, matrix),
       budgets,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -111,6 +111,11 @@ export interface PostDispatchContext {
 export interface PostDispatchResult {
   /** Additive fields merged into the run manifest before it is written. */
   manifestExtra?: Partial<RunManifest>;
+  /**
+   * Raw synthesized answer body for downstream hook stages (verification).
+   * Never merged into the manifest or persisted.
+   */
+  answerText?: string;
 }
 
 export interface ExecuteRunHooks {

--- a/tests/claim-verification.test.ts
+++ b/tests/claim-verification.test.ts
@@ -155,6 +155,50 @@ describe('claim verification boundaries', () => {
     );
   });
 
+  it('keeps modal claims with active verbs checkable while excluding hedges', () => {
+    const selected = selectMaterialClaims([
+      {
+        ...CLAIM,
+        claim: 'TLS 1.3 servers may require SNI.',
+        category: 'compatibility',
+      },
+      {
+        ...CLAIM,
+        claim: 'Clients could negotiate the extension since v2.',
+        category: 'compatibility',
+      },
+      {
+        ...CLAIM,
+        claim: 'The maintainers might have merged the fix already.',
+        category: 'date',
+      },
+      {
+        ...CLAIM,
+        claim: 'The date is reportedly 2025-03-01.',
+        category: 'date',
+      },
+      {
+        ...CLAIM,
+        claim: 'The rollout may be postponed.',
+        category: 'date',
+      },
+      {
+        ...CLAIM,
+        claim: 'The launch might well be delayed again.',
+        category: 'date',
+      },
+      {
+        ...CLAIM,
+        claim: 'The cutoff is apparently 2025-06-01.',
+        category: 'date',
+      },
+    ]);
+    expect(selected.map((claim) => claim.claim)).toEqual([
+      'TLS 1.3 servers may require SNI.',
+      'Clients could negotiate the extension since v2.',
+    ]);
+  });
+
   it('assigns deterministic unique ids regardless of duplicate or adversarial model ids', () => {
     const selected = selectMaterialClaims([
       { ...CLAIM, id: 'claim-2' },


### PR DESCRIPTION
## Summary

Follow-up cleanup from the post-merge review of #52 (`answer --verify`). Three targeted changes, no behavioral surface beyond the `--verify` path:

- **Decouple verification from the rendered answer.md format**: `synthesizeAnswer` now hands the raw synthesized answer body to the verify wrapper via a new non-persisted `PostDispatchResult.answerText` field, replacing the read-back + regex strip of the `# title` heading and `## Sources` section. Verification no longer breaks if `renderAnswerMarkdown` changes shape.
- **Tighten the claim uncertainty filter**: bare modals with active verbs ("may require SNI", "could negotiate X") are now checkable claims instead of being auto-excluded; a modal only counts as a hedge in `may/might/could (+ one word) + be/have/not` shape, and explicit hedge markers (possibly, perhaps, reportedly, allegedly, apparently, seemingly, supposedly, purportedly) are covered. Failure direction remains safe: an excluded claim is simply not verified (fail-open).
- **Thread the warning sink and deduplicate**: `VerificationInput.warn` callback (defaults to the previous stderr line, so observable behavior is unchanged); near-identical `runLlmJson`/`runLlmText` collapsed into one `runLlm` helper.

## Testing

- [x] `npm test` — 604 tests, 49 files
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] New regression test for the modal boundary (verified to fail against the old regex), covering both inclusion and exclusion directions including adverb-intervened hedges
- [x] Multi-model review panel: 3 reviewers, unanimous GO, zero critical/high findings; both actionable low findings fixed in this PR

## Notes

- `answerText` is never merged into `run.json` (`executeRun` reads only `manifestExtra`).
- The defensive "answerText unavailable" skip branch is currently unreachable (synthesis throws on empty answers first) and is intentionally left untested.