### PR TITLE
Refresh npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "librarium": "dist/cli.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.5.3",
-        "@cloudflare/vitest-pool-workers": "^0.18.4",
+        "@biomejs/biome": "^2.5.4",
+        "@cloudflare/vitest-pool-workers": "^0.18.6",
         "@types/node": "^22.20.1",
         "esbuild": "^0.28.1",
         "node-pty": "^1.1.0",
@@ -32,7 +32,7 @@
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10",
-        "wrangler": "^4.110.0"
+        "wrangler": "^4.112.0"
       },
       "engines": {
         "node": ">=20.12"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.3",
-    "@cloudflare/vitest-pool-workers": "^0.18.4",
+    "@biomejs/biome": "^2.5.4",
+    "@cloudflare/vitest-pool-workers": "^0.18.6",
     "@types/node": "^22.20.1",
     "esbuild": "^0.28.1",
     "node-pty": "^1.1.0",
@@ -59,7 +59,7 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10",
-    "wrangler": "^4.110.0"
+    "wrangler": "^4.112.0"
   },
   "overrides": {
     "tsup": {


### PR DESCRIPTION
## Summary

- Refresh eligible npm dev tooling: `@biomejs/biome`, `@cloudflare/vitest-pool-workers`, and `wrangler`.
- Apply eligible transitive advisory fixes for `hono`, `fast-uri`, and `body-parser`.
- Keep the worker stack on release-age-eligible `miniflare@4.20260714.0` / `workerd@1.20260714.1`.

## Holdbacks

- 48-hour release-age rule: `@biomejs/biome@2.5.5`, `@cloudflare/vitest-pool-workers@0.18.7`, `wrangler@4.113.0`, `marked@18.0.7`, and `p-limit@7.3.1`.
- Compatibility: `@inquirer/prompts@8.5.2`, `commander@15.0.0`, `@types/node@26.1.1`, `typescript@7.0.2`, and `zod@4.4.3`.

## Audit

- `npm audit --json` now reports 6 remaining advisories: 2 moderate and 4 high.
- Remaining MCP SDK advisory has no newer direct SDK update; npm suggests a downgrade to `@modelcontextprotocol/sdk@1.24.3`.
- Remaining Cloudflare worker-tooling advisories require downgrades or July 21 releases that violate the release-age rule.

## Verification

- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test`
- `npm run test:integration`
- `npm run test:workers`
- `npm run test:pty`
- `npx -y -p node@20 -p npm@11 npm run typecheck`
- `npx -y -p node@20 -p npm@11 npm run build`
- `npx -y -p node@22 node scripts/build-sea.mjs`
- `./dist/librarium-macos-arm64 --version`

Deep review completed as a degraded local review because the Solo transport and independent reviewer fallback seats were unavailable; no actionable findings were found.
