### PR TITLE
chore: v1.4.0 prep — live-verified Brave error hints, dependency refresh, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **xAI Grok grounded provider** (`grok`, ai-grounded tier): queries xAI's
+  official Responses API with the `web_search` tool, normalizes `url_citation`
+  annotations into citations (inline `[[n]](url)` markers preserved), and
+  reports honest API-reported cost converted from xAI's `cost_in_usd_ticks`.
+  Defaults to `grok-4.5` with a per-provider model override (`grok-4.3` for
+  cost-sensitive runs). Requires `XAI_API_KEY`. Joins the `comprehensive` and
+  `all` groups only — deliberately not `quick`/`fast`, so default-group runs
+  see no cost change. X/social search is intentionally excluded from requests.
+- Benchmark CI guard lockstep test: every provider credential env var must be
+  present in the benchmark secret blocklist.
+
+### Changed
+
+- **`brave-answers` migrated to Brave's Answers API** (the OpenAI-compatible
+  `chat/completions` endpoint) from the deprecated Summarizer Search flow.
+  Citations arrive as inline stream metadata and are normalized/deduplicated;
+  usage comes from Brave's response headers; `usage.costUsd` is set only when
+  Brave reports an explicit dollar figure. Provider id, env var, tier, and
+  group membership are unchanged. Answer content is now the native Answers
+  markdown — the adapter-fabricated `## AI Summary`/`## Web Results` headings
+  are gone.
+- `brave-answers` metering moved from `request_priced` (fixed $0.009 estimate)
+  to `api_unit_priced` (search + token billing, units-only — no fabricated USD
+  pre-dispatch estimate). `PRICING_VERSION` bumped to `2026-07`.
+- Dependency refresh within existing ranges (biome 2.5.5, wrangler 4.113,
+  marked, p-limit, vitest-pool-workers).
+
+### Fixed
+
+- Brave error messages now carry actionable hints keyed to live-verified error
+  codes: an invalid key (`422 SUBSCRIPTION_TOKEN_INVALID`) points at
+  `BRAVE_API_KEY`, and a key without the Answers subscription
+  (`400 OPTION_NOT_IN_PLAN`) points at the plan upgrade. Grok's live-verified
+  bad-key response (HTTP 400) also gets the `XAI_API_KEY` hint.
+- Hardened Brave stream handling: byte-accurate response-size caps for streams
+  and error bodies, JSON-string-aware citation-tag boundary parsing, malformed
+  stream frames skipped instead of discarding the answer, and mid-stream
+  aborts terminating hung streams without hanging on cancellation.
+- README parity with the site docs: the `answer` example reflects the real
+  `quick` group, the `run.json` sample documents the optional `usage`/`metering`
+  fields, and the run-directory anatomy includes `answer.md` and
+  `verification.json`.
+
 ## [1.3.0] - 2026-07-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.5.tgz",
+      "integrity": "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -55,20 +55,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.3",
-        "@biomejs/cli-darwin-x64": "2.5.3",
-        "@biomejs/cli-linux-arm64": "2.5.3",
-        "@biomejs/cli-linux-arm64-musl": "2.5.3",
-        "@biomejs/cli-linux-x64": "2.5.3",
-        "@biomejs/cli-linux-x64-musl": "2.5.3",
-        "@biomejs/cli-win32-arm64": "2.5.3",
-        "@biomejs/cli-win32-x64": "2.5.3"
+        "@biomejs/cli-darwin-arm64": "2.5.5",
+        "@biomejs/cli-darwin-x64": "2.5.5",
+        "@biomejs/cli-linux-arm64": "2.5.5",
+        "@biomejs/cli-linux-arm64-musl": "2.5.5",
+        "@biomejs/cli-linux-x64": "2.5.5",
+        "@biomejs/cli-linux-x64-musl": "2.5.5",
+        "@biomejs/cli-win32-arm64": "2.5.5",
+        "@biomejs/cli-win32-x64": "2.5.5"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.5.tgz",
+      "integrity": "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==",
       "cpu": [
         "arm64"
       ],
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.5.tgz",
+      "integrity": "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==",
       "cpu": [
         "x64"
       ],
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.5.tgz",
+      "integrity": "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.5.tgz",
+      "integrity": "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==",
       "cpu": [
         "arm64"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.5.tgz",
+      "integrity": "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==",
       "cpu": [
         "x64"
       ],
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.5.tgz",
+      "integrity": "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==",
       "cpu": [
         "x64"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.5.tgz",
+      "integrity": "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.5.tgz",
+      "integrity": "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==",
       "cpu": [
         "x64"
       ],
@@ -268,16 +268,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.18.4.tgz",
-      "integrity": "sha512-jOXvyLoR2b8jFvo3tX+mWxXXwcZ+PbId3d7vGFtZsuKakmDjKSeIq4o/sQjkqNv6q3XacIKSCAvfM8TfkPyrEw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.18.7.tgz",
+      "integrity": "sha512-PGYToiFoGpuRV2Uh33S4fI7JcmSkDxk6LQeneYtgfsITEkVi5iGxc3Vms6yW9Jr6uSzVK4Be9XZfdyZDr5GWYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cjs-module-lexer": "1.2.3",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260708.1",
-        "wrangler": "4.110.0",
+        "miniflare": "4.20260721.0",
+        "wrangler": "4.113.0",
         "zod": "3.25.76"
       },
       "peerDependencies": {
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260708.1.tgz",
-      "integrity": "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260721.1.tgz",
+      "integrity": "sha512-VivNMhiEdZIB4JBWxf1RMJGROErv53qmQ+dvhjA1evrCouvqRYW718VqDideU3PSV7Ythl5Df48NqZYWoaEHpQ==",
       "cpu": [
         "x64"
       ],
@@ -304,9 +304,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260708.1.tgz",
-      "integrity": "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-k7oye1ZiuwnnBBA2eTMduconr/ud5ZxFtRNTsYwMdmJeeeislw2+M72otrHxxvybCP7JWPPlJ38uhfajpcyhOA==",
       "cpu": [
         "arm64"
       ],
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260708.1.tgz",
-      "integrity": "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260721.1.tgz",
+      "integrity": "sha512-hon0lW4ZQ4boAVgaw+0ZFTNS8v5MWPWvK0HZnt4tDpKYnDUviLZawtUW3KqvFmCQTipVHl1S34j3J8Eqb93hGQ==",
       "cpu": [
         "x64"
       ],
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260708.1.tgz",
-      "integrity": "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-nAl+HRQqpX5b7xVwWcvLPZmCk8NQ2yjI0yvJTWcHiRswbMEg1ZZckVmjJUAn0PHzZARbCSyIV7v3UjM+SPRmIQ==",
       "cpu": [
         "arm64"
       ],
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260708.1.tgz",
-      "integrity": "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260721.1.tgz",
+      "integrity": "sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ==",
       "cpu": [
         "x64"
       ],
@@ -3865,9 +3865,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
-      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -3944,16 +3944,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260708.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260708.1.tgz",
-      "integrity": "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==",
+      "version": "4.20260721.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260721.0.tgz",
+      "integrity": "sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260708.1",
+        "workerd": "1.20260721.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -4144,9 +4144,9 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.2.1"
@@ -5665,9 +5665,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260708.1.tgz",
-      "integrity": "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260721.1.tgz",
+      "integrity": "sha512-b/DWhpV0jTudzQpLhDovcOgBz233386q+3Hbari7CLCNT9UXxjQziSTZ9yCoKdT2K3TSx5jrwlOisq8hlLWXYg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -5678,17 +5678,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260708.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260708.1",
-        "@cloudflare/workerd-linux-64": "1.20260708.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260708.1",
-        "@cloudflare/workerd-windows-64": "1.20260708.1"
+        "@cloudflare/workerd-darwin-64": "1.20260721.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260721.1",
+        "@cloudflare/workerd-linux-64": "1.20260721.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260721.1",
+        "@cloudflare/workerd-windows-64": "1.20260721.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.110.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.110.0.tgz",
-      "integrity": "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==",
+      "version": "4.113.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.113.0.tgz",
+      "integrity": "sha512-ROGzSloJv0y21It6Oc9LaruNcu1tdiQ/XzL3Jc3YkFjzXEMXzTqVhA8vQaGMTdZHTjFP0PVcwAHNgaw3gXu4wA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -5696,10 +5696,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260708.1",
+        "miniflare": "4.20260721.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260708.1"
+        "workerd": "1.20260721.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -5713,7 +5713,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260708.1"
+        "@cloudflare/workers-types": "^5.20260721.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/src/adapters/brave-answers.ts
+++ b/src/adapters/brave-answers.ts
@@ -443,6 +443,16 @@ export class BraveAnswersProvider extends BaseProvider {
     const detail = this.braveErrorDetail(body);
     const base = `Brave Answers API returned ${status}: ${detail}`;
 
+    // Live-verified: Brave reports an invalid key as 422 and a key whose plan
+    // lacks the Answers option as 400, so route hints by error code first.
+    const code = this.braveErrorCode(body);
+    if (code === 'SUBSCRIPTION_TOKEN_INVALID') {
+      return `${base} — check that ${this.envVar} is a valid Brave Search API key`;
+    }
+    if (code === 'OPTION_NOT_IN_PLAN') {
+      return `${base} — your Brave plan does not include the Answers API; upgrade at https://api-dashboard.search.brave.com`;
+    }
+
     if (status === 401) {
       return `${base} — check that ${this.envVar} is valid and enabled for the Brave Answers plan`;
     }
@@ -465,6 +475,13 @@ export class BraveAnswersProvider extends BaseProvider {
       return `${base} — check the request parameters`;
     }
     return base;
+  }
+
+  private braveErrorCode(body: unknown): string | undefined {
+    if (!this.isRecord(body)) return undefined;
+    const error = body.error;
+    if (!this.isRecord(error)) return undefined;
+    return this.firstString(error.code);
   }
 
   private braveErrorDetail(body: unknown): string {

--- a/tests/adapters/brave-answers.test.ts
+++ b/tests/adapters/brave-answers.test.ts
@@ -174,7 +174,51 @@ describe('Brave Answers provider', () => {
 
     expect(result.error).toContain('401');
     expect(result.error).toContain('Token rejected');
-    expect(result.error).toContain('Answers plan');
+    expect(result.error).toContain('valid Brave Search API key');
+  });
+
+  it('gives the key hint for a live-shaped 422 invalid-token rejection', async () => {
+    // Live-captured envelope: Brave reports an invalid key as 422, not 401.
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      errorResponse(422, {
+        error: {
+          code: 'SUBSCRIPTION_TOKEN_INVALID',
+          detail: 'The provided subscription token is invalid.',
+          meta: { component: 'authentication' },
+          status: 422,
+        },
+        type: 'ErrorResponse',
+      }),
+    );
+
+    const result = await provider().execute('bad key', { timeout: 10 });
+
+    expect(result.error).toContain('422');
+    expect(result.error).toContain('valid Brave Search API key');
+    expect(result.error).not.toContain('shorter query');
+  });
+
+  it('gives the plan-upgrade hint for a live-shaped 400 option-not-in-plan rejection', async () => {
+    // Live-captured envelope: a key without the Answers subscription gets 400.
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      errorResponse(400, {
+        type: 'ErrorResponse',
+        error: {
+          id: 'fe2985f4-23e8-4a71-a2d2-740b1f5dcc9e',
+          status: 400,
+          detail: 'The option is not subscribed in the plan.',
+          meta: { component: 'authentication' },
+          code: 'OPTION_NOT_IN_PLAN',
+        },
+        time: 1784763543,
+      }),
+    );
+
+    const result = await provider().execute('no plan', { timeout: 10 });
+
+    expect(result.error).toContain('400');
+    expect(result.error).toContain('not subscribed');
+    expect(result.error).toContain('does not include the Answers API');
   });
 
   it('normalizes 402 errors from the top-level Brave error envelope', async () => {

--- a/tests/adapters/grok.test.ts
+++ b/tests/adapters/grok.test.ts
@@ -334,26 +334,26 @@ describe('GrokProvider — live-verified edge cases', () => {
 
   // NaN cannot appear on the JSON wire (it serializes to null), so null is
   // the realistic degenerate value alongside a negative number.
-  it.each([
-    [-1],
-    [null],
-  ])('omits costUsd when cost_in_usd_ticks is %s', async (ticks) => {
-    globalThis.fetch = vi.fn().mockResolvedValueOnce(
-      jsonResponse(200, {
-        ...outputResponse(),
-        usage: {
-          input_tokens: 10,
-          output_tokens: 5,
-          cost_in_usd_ticks: ticks,
-        },
-      }),
-    );
+  it.each([[-1], [null]])(
+    'omits costUsd when cost_in_usd_ticks is %s',
+    async (ticks) => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(
+        jsonResponse(200, {
+          ...outputResponse(),
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cost_in_usd_ticks: ticks,
+          },
+        }),
+      );
 
-    const result = await provider().execute('q', { timeout: 10 });
+      const result = await provider().execute('q', { timeout: 10 });
 
-    expect(result.error).toBeUndefined();
-    expect(result.usage?.costUsd).toBeUndefined();
-  });
+      expect(result.error).toBeUndefined();
+      expect(result.usage?.costUsd).toBeUndefined();
+    },
+  );
 
   it('drops url_citation annotations that lack a url', async () => {
     globalThis.fetch = vi.fn().mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
Release preparation for v1.4.0:

- **Brave error hints keyed to live-verified error codes** (captured via authorized rejected-request smoke calls, no spend): an invalid key is actually `422 SUBSCRIPTION_TOKEN_INVALID` (now gets the `BRAVE_API_KEY` hint instead of the misleading "shorter query" advice) and a key without the Answers subscription is `400 OPTION_NOT_IN_PLAN` (now gets a plan-upgrade hint). Tests use the exact live-captured envelopes, which also confirmed the real error shape (`type: ErrorResponse` + nested `error.code/detail/meta`) is handled by the existing parser.
- **Dependency refresh within existing ranges**: biome 2.5.5 (aligns the lockfile with current, resolving the formatter version drift that broke CI formatting checks), wrangler 4.113, marked 18.0.7, p-limit 7.3.1, vitest-pool-workers 0.18.7.
- **CHANGELOG for v1.4.0** covering the Grok provider, Brave Answers migration, metering changes, and hardening.

## Test evidence
- 646 tests / 51 files pass, workers suite, build, `benchmark:validate` (25 providers), changelog validation script passes with unreleased content.

## Notes
- The live smoke also established that the current `BRAVE_API_KEY` does **not** include the Answers subscription — full success-path verification of the Answers endpoint (SSE citations, usage headers, length limits) remains blocked until the Brave plan is upgraded. This is a prerequisite for using brave-answers in paid flows.