### PR TITLE
chore: sync v1.4.1 release back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-23
+
 ### Fixed
 
 - **`brave-answers` citations restored** (live-verified against the Answers
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brave-answers` token usage falls back to the final stream chunk's
   OpenAI-style `usage` counts when no inline tag is present; legacy
   `x-request-*` header parsing is retained as a further fallback.
+
 
 ## [1.4.0] - 2026-07-22
 
@@ -255,7 +258,7 @@ The first stable release: the 0.1.x research fan-out core plus a complete intera
 - API keys use environment variable references, never stored in plaintext
 - Response size guard (10MB) on HTTP client
 
-[Unreleased]: https://github.com/jkudish/librarium/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/jkudish/librarium/compare/v1.4.1...HEAD
 [1.1.0]: https://github.com/jkudish/librarium/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/jkudish/librarium/releases/tag/v1.0.0
 [0.2.0]: https://github.com/jkudish/librarium/compare/v0.1.3...v0.2.0
@@ -265,3 +268,4 @@ The first stable release: the 0.1.x research fan-out core plus a complete intera
 [0.1.2]: https://github.com/jkudish/librarium/compare/v0.1.1...v0.1.2
 [1.3.0]: https://github.com/jkudish/librarium/releases/tag/v1.3.0
 [1.4.0]: https://github.com/jkudish/librarium/releases/tag/v1.4.0
+[1.4.1]: https://github.com/jkudish/librarium/releases/tag/v1.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
Automated release-sync PR: brings the v1.4.1 tag's changelog promotion and version bump back to main, following the standard tag→main sync pattern.