### PR TITLE
refactor: harden provider and HTTP contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking library API:** custom and hand-written providers must now declare
+  `execution: "inline"` or `execution: "background"`. Background providers
+  must implement the complete `execute`/`submit`/`poll`/`retrieve` lifecycle;
+  partial lifecycle hooks are rejected at registration. Script-provider
+  `describe` responses must declare the same execution contract and explicitly
+  advertise `execute`.
+- **Breaking HTTP API:** `HttpRequestOptions.maxRetries` is replaced by the
+  explicit `retry` policy. GET requests use bounded safe retries by default;
+  non-GET requests do not retry unless configured with `mode: "idempotent"`
+  and an idempotency key.
 - Claude now defaults to `claude-sonnet-5` with a 16,000-token output ceiling,
   adaptive thinking, and `medium` effort. `maxTokens`, `thinking`, and `effort`
   are configurable; automatic thinking/effort defaults apply only to the

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ You can also add **custom providers** (npm modules or local scripts) via config.
 
 ## Provider Tiers
 
-Providers are categorized into four tiers based on their capabilities, latency, and depth:
+Providers are categorized into four tiers based on their capabilities, latency, and depth. Their execution contract is separate: an `inline` provider finishes in `execute()`, while a `background` provider also provides complete `submit`/`poll`/`retrieve` lifecycle hooks.
 
 - **deep-research** -- Async deep research providers that take minutes to complete but produce comprehensive, multi-source reports. These providers may use a submit/poll/retrieve pattern. Best for thorough research on important topics.
 
@@ -1092,9 +1092,11 @@ Error response:
   "data": {
     "displayName": "My Script Provider",
     "tier": "deep-research",
+    "execution": "background",
     "envVar": "MY_PROVIDER_API_KEY",
     "requiresApiKey": true,
     "capabilities": {
+      "execute": true,
       "submit": true,
       "poll": true,
       "retrieve": true,
@@ -1343,7 +1345,7 @@ const handles: AsyncTaskHandle[] = await loadHandles();
 
 for (const handle of handles) {
   const provider = getProvider(handle.provider);
-  if (!provider?.poll || !provider.retrieve) continue; // not an async provider
+  if (provider?.execution !== 'background') continue;
 
   // 3. Poll for status. AsyncPollResult.status is the AsyncTaskStatus enum:
   //    'pending' | 'running' | 'completed' | 'failed' | 'cancelled'

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -54,13 +54,19 @@ Your provider must match librarium's `Provider` shape:
   - `id` (must equal the config key)
   - `displayName`
   - `tier` (`deep-research`, `ai-grounded`, `raw-search`)
-  - `envVar` (string, may be empty only when `requiresApiKey` is `false`)
-  - `execute(query, options)`
-- Optional methods:
-  - `submit(query, options)`
-  - `poll(handle)`
-  - `retrieve(handle)`
-  - `test()`
+- `envVar` (string, may be empty only when `requiresApiKey` is `false`)
+- `execution`: either `inline` or `background`
+- `execute(query, options)`
+- `test()` is optional
+
+Execution contracts are discriminated:
+
+- `execution: "inline"` completes work in `execute()` and must not expose
+  task lifecycle hooks.
+- `execution: "background"` still implements `execute()` for synchronous
+  callers, and must also implement all of `submit(query, options)`,
+  `poll(handle)`, and `retrieve(handle)`. Librarium never accepts a partial
+  background lifecycle.
 - Optional metadata:
   - `requiresApiKey` (defaults to `true`)
 
@@ -167,6 +173,7 @@ Failure:
     "id": "my-provider",
     "displayName": "My Provider",
     "tier": "raw-search",
+    "execution": "inline",
     "envVar": "MY_PROVIDER_API_KEY",
     "requiresApiKey": true,
     "capabilities": {
@@ -183,7 +190,10 @@ Failure:
 Rules:
 
 - `displayName` and `tier` are required
-- `execute` is expected; if `capabilities.execute` is explicitly `false`, load fails
+- `execution` must be either `inline` or `background`
+- `capabilities.execute` must be `true`
+- Background scripts must declare `submit`, `poll`, and `retrieve` as `true`;
+  inline scripts must not declare those hooks
 - If `id` is returned, it must match the configured provider ID
 
 ### Operation Data Shapes
@@ -221,7 +231,7 @@ A built-in adapter declares its pricing model in the central registry. The meter
 
 Built-in adapters live in core and must stay runtime-portable (fetch-only HTTP, no `node:*`, no direct `process.env`; a workerd CI suite enforces this). To add one, update **all** of these in lockstep -- several are guarded by tests, so a partial change fails CI:
 
-1. **Adapter** -- `src/adapters/<id>.ts`, extending `BaseProvider` and implementing `execute` (plus `submit`/`poll`/`retrieve` for async deep research). Return `usage` when the API reports cost/tokens.
+1. **Adapter** -- `src/adapters/<id>.ts`, extending `BaseProvider` for inline execution or `BackgroundBaseProvider` for a complete remote-task lifecycle. Implement `execute` in both cases; background adapters also implement `submit`/`poll`/`retrieve`. Return `usage` when the API reports cost/tokens.
 2. **Registration** -- add an instance to the `builtIns` array in `src/adapters/index.ts` (`initializeProviders`).
 3. **Constants** (`src/constants.ts`) -- `PROVIDER_ENV_VARS`, `PROVIDER_DISPLAY_NAMES`, and at least one entry in `DEFAULT_GROUPS` (and `all`).
 4. **Metering registry** (`src/core/metering.ts`) -- add a `REGISTRY` entry with the provider's `kind` (and, for priced kinds, `defaultPerRequestUsd` / `defaultUnitsPerRequest` / `unit`). **Required:** the lockstep test in `tests/metering.test.ts` asserts every built-in has a registry entry, so a missing entry fails CI.
@@ -249,4 +259,3 @@ Run `npm run test` (it includes the metering lockstep and README-drift guards) a
 | `returned invalid JSON` | Script wrote non-JSON to stdout | Write only one JSON envelope to stdout |
 | `returned invalid ... payload` | Shape mismatch for operation data | Return correct schema for that operation |
 | `timed out` | Operation exceeded timeout | Optimize provider or raise timeout for execute/submit |
-

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -54,9 +54,9 @@ Your provider must match librarium's `Provider` shape:
   - `id` (must equal the config key)
   - `displayName`
   - `tier` (`deep-research`, `ai-grounded`, `raw-search`)
-- `envVar` (string, may be empty only when `requiresApiKey` is `false`)
-- `execution`: either `inline` or `background`
-- `execute(query, options)`
+  - `envVar` (string, may be empty only when `requiresApiKey` is `false`)
+  - `execution`: either `inline` or `background`
+  - `execute(query, options)`
 - `test()` is optional
 
 Execution contracts are discriminated:

--- a/scripts/custom-providers/wikipedia-provider.mjs
+++ b/scripts/custom-providers/wikipedia-provider.mjs
@@ -86,6 +86,7 @@ async function main() {
       id: providerId,
       displayName: 'Wikipedia Script Provider',
       tier: 'raw-search',
+      execution: 'inline',
       envVar: '',
       requiresApiKey: false,
       capabilities: {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -31,7 +31,7 @@ export interface BaseProviderOptions {
  * Inline is the default execution contract, so the synchronous adapters need
  * no per-class boilerplate. Background adapters extend BackgroundBaseProvider.
  */
-abstract class ProviderBase {
+export abstract class ProviderBase {
   abstract readonly id: string;
   abstract readonly tier: ProviderTier;
   source?: Provider['source'];

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -9,6 +9,10 @@ import {
   httpRequest,
 } from '../core/http-client.js';
 import type {
+  AsyncPollResult,
+  AsyncTaskHandle,
+  BackgroundProvider,
+  InlineProvider,
   Provider,
   ProviderOptions,
   ProviderResult,
@@ -24,11 +28,10 @@ export interface BaseProviderOptions {
  * Base class for all provider adapters.
  * Handles common concerns: API key resolution, HTTP client, display info.
  *
- * Note: submit/poll/retrieve are NOT declared here. Only deep-research
- * subclasses that need async capabilities implement them directly,
- * satisfying the Provider interface's optional methods.
+ * Inline is the default execution contract, so the synchronous adapters need
+ * no per-class boilerplate. Background adapters extend BackgroundBaseProvider.
  */
-export abstract class BaseProvider implements Provider {
+abstract class ProviderBase {
   abstract readonly id: string;
   abstract readonly tier: ProviderTier;
   source?: Provider['source'];
@@ -119,4 +122,28 @@ export abstract class BaseProvider implements Provider {
     query: string,
     options: ProviderOptions,
   ): Promise<ProviderResult>;
+}
+
+export abstract class BaseProvider
+  extends ProviderBase
+  implements InlineProvider
+{
+  readonly execution = 'inline' as const;
+}
+
+/** Base for adapters that implement the complete persisted-task lifecycle. */
+export abstract class BackgroundBaseProvider
+  extends ProviderBase
+  implements BackgroundProvider
+{
+  readonly execution = 'background' as const;
+
+  abstract submit(
+    query: string,
+    options: ProviderOptions,
+  ): Promise<AsyncTaskHandle>;
+
+  abstract poll(handle: AsyncTaskHandle): Promise<AsyncPollResult>;
+
+  abstract retrieve(handle: AsyncTaskHandle): Promise<ProviderResult>;
 }

--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -348,45 +348,53 @@ async function loadScriptProvider(
     : undefined;
 
   if (describe.execution === 'inline') {
-    return { ...base, execution: 'inline', ...(test ? { test } : {}) };
+    return normalizeAndValidateProvider(
+      { ...base, execution: 'inline', ...(test ? { test } : {}) },
+      providerId,
+      'script',
+    );
   }
 
-  return {
-    ...base,
-    execution: 'background',
-    submit: async (query: string, options: ProviderOptions) =>
-      callScriptOperation({
-        providerId,
-        source,
-        providerConfig,
-        operation: 'submit',
-        query,
-        options,
-        timeoutSeconds: getOperationTimeoutSeconds('submit', options),
-        schema: ASYNC_TASK_HANDLE_SCHEMA,
-      }),
-    poll: async (handle: AsyncTaskHandle) =>
-      callScriptOperation({
-        providerId,
-        source,
-        providerConfig,
-        operation: 'poll',
-        handle,
-        timeoutSeconds: getOperationTimeoutSeconds('poll'),
-        schema: ASYNC_POLL_RESULT_SCHEMA,
-      }),
-    retrieve: async (handle: AsyncTaskHandle) =>
-      callScriptOperation({
-        providerId,
-        source,
-        providerConfig,
-        operation: 'retrieve',
-        handle,
-        timeoutSeconds: getOperationTimeoutSeconds('retrieve'),
-        schema: PROVIDER_RESULT_SCHEMA,
-      }),
-    ...(test ? { test } : {}),
-  };
+  return normalizeAndValidateProvider(
+    {
+      ...base,
+      execution: 'background',
+      submit: async (query: string, options: ProviderOptions) =>
+        callScriptOperation({
+          providerId,
+          source,
+          providerConfig,
+          operation: 'submit',
+          query,
+          options,
+          timeoutSeconds: getOperationTimeoutSeconds('submit', options),
+          schema: ASYNC_TASK_HANDLE_SCHEMA,
+        }),
+      poll: async (handle: AsyncTaskHandle) =>
+        callScriptOperation({
+          providerId,
+          source,
+          providerConfig,
+          operation: 'poll',
+          handle,
+          timeoutSeconds: getOperationTimeoutSeconds('poll'),
+          schema: ASYNC_POLL_RESULT_SCHEMA,
+        }),
+      retrieve: async (handle: AsyncTaskHandle) =>
+        callScriptOperation({
+          providerId,
+          source,
+          providerConfig,
+          operation: 'retrieve',
+          handle,
+          timeoutSeconds: getOperationTimeoutSeconds('retrieve'),
+          schema: PROVIDER_RESULT_SCHEMA,
+        }),
+      ...(test ? { test } : {}),
+    },
+    providerId,
+    'script',
+  );
 }
 
 function getOperationTimeoutSeconds(

--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -81,11 +81,12 @@ const SCRIPT_DESCRIBE_SCHEMA = z.object({
   id: z.string().optional(),
   displayName: z.string().min(1),
   tier: PROVIDER_TIER_SCHEMA,
+  execution: z.enum(['inline', 'background']),
   envVar: z.string().optional(),
   requiresApiKey: z.boolean().optional(),
   capabilities: z
     .object({
-      execute: z.boolean().optional(),
+      execute: z.boolean(),
       submit: z.boolean().optional(),
       poll: z.boolean().optional(),
       retrieve: z.boolean().optional(),
@@ -289,21 +290,39 @@ async function loadScriptProvider(
     );
   }
 
-  const capabilities = describe.capabilities ?? {};
-  if (capabilities.execute === false) {
+  const capabilities = describe.capabilities;
+  if (!capabilities?.execute) {
     throw new Error(
       'Script provider describe.capabilities.execute must be true',
     );
   }
 
-  const provider: Provider = {
+  if (
+    describe.execution === 'background' &&
+    (!capabilities.submit || !capabilities.poll || !capabilities.retrieve)
+  ) {
+    throw new Error(
+      'Background script providers must declare submit, poll, and retrieve capabilities as true',
+    );
+  }
+
+  if (
+    describe.execution === 'inline' &&
+    (capabilities.submit || capabilities.poll || capabilities.retrieve)
+  ) {
+    throw new Error(
+      'Inline script providers cannot declare submit, poll, or retrieve capabilities',
+    );
+  }
+
+  const base = {
     id: providerId,
     displayName: describe.displayName,
     tier: describe.tier,
     envVar: describe.envVar ?? '',
-    source: 'script',
+    source: 'script' as const,
     requiresApiKey: describe.requiresApiKey ?? true,
-    execute: async (query, options) =>
+    execute: async (query: string, options: ProviderOptions) =>
       callScriptOperation({
         providerId,
         source,
@@ -316,8 +335,26 @@ async function loadScriptProvider(
       }),
   };
 
-  if (capabilities.submit) {
-    provider.submit = async (query, options) =>
+  const test = capabilities.test
+    ? async () =>
+        callScriptOperation({
+          providerId,
+          source,
+          providerConfig,
+          operation: 'test',
+          timeoutSeconds: getOperationTimeoutSeconds('test'),
+          schema: SCRIPT_TEST_SCHEMA,
+        })
+    : undefined;
+
+  if (describe.execution === 'inline') {
+    return { ...base, execution: 'inline', ...(test ? { test } : {}) };
+  }
+
+  return {
+    ...base,
+    execution: 'background',
+    submit: async (query: string, options: ProviderOptions) =>
       callScriptOperation({
         providerId,
         source,
@@ -327,11 +364,8 @@ async function loadScriptProvider(
         options,
         timeoutSeconds: getOperationTimeoutSeconds('submit', options),
         schema: ASYNC_TASK_HANDLE_SCHEMA,
-      });
-  }
-
-  if (capabilities.poll) {
-    provider.poll = async (handle) =>
+      }),
+    poll: async (handle: AsyncTaskHandle) =>
       callScriptOperation({
         providerId,
         source,
@@ -340,11 +374,8 @@ async function loadScriptProvider(
         handle,
         timeoutSeconds: getOperationTimeoutSeconds('poll'),
         schema: ASYNC_POLL_RESULT_SCHEMA,
-      });
-  }
-
-  if (capabilities.retrieve) {
-    provider.retrieve = async (handle) =>
+      }),
+    retrieve: async (handle: AsyncTaskHandle) =>
       callScriptOperation({
         providerId,
         source,
@@ -353,22 +384,9 @@ async function loadScriptProvider(
         handle,
         timeoutSeconds: getOperationTimeoutSeconds('retrieve'),
         schema: PROVIDER_RESULT_SCHEMA,
-      });
-  }
-
-  if (capabilities.test) {
-    provider.test = async () =>
-      callScriptOperation({
-        providerId,
-        source,
-        providerConfig,
-        operation: 'test',
-        timeoutSeconds: getOperationTimeoutSeconds('test'),
-        schema: SCRIPT_TEST_SCHEMA,
-      });
-  }
-
-  return provider;
+      }),
+    ...(test ? { test } : {}),
+  };
 }
 
 function getOperationTimeoutSeconds(
@@ -535,7 +553,13 @@ function normalizeAndValidateProvider(
     throw new Error('Provider module did not return a provider object');
   }
 
-  const provider = candidate as Partial<Provider>;
+  const provider = candidate as Partial<Provider> & {
+    execution?: unknown;
+    submit?: unknown;
+    poll?: unknown;
+    retrieve?: unknown;
+    test?: unknown;
+  };
 
   if (provider.id !== providerId) {
     throw new Error(
@@ -554,11 +578,36 @@ function normalizeAndValidateProvider(
   if (typeof provider.execute !== 'function') {
     throw new Error('Provider must define an execute(query, options) function');
   }
+  if (provider.execution !== 'inline' && provider.execution !== 'background') {
+    throw new Error(
+      'Provider must declare execution as "inline" or "background"',
+    );
+  }
   for (const method of ['submit', 'poll', 'retrieve', 'test'] as const) {
     const value = provider[method];
     if (value !== undefined && typeof value !== 'function') {
       throw new Error(`Provider method "${method}" must be a function`);
     }
+  }
+  if (
+    provider.execution === 'background' &&
+    (typeof provider.submit !== 'function' ||
+      typeof provider.poll !== 'function' ||
+      typeof provider.retrieve !== 'function')
+  ) {
+    throw new Error(
+      'Background providers must define submit(query, options), poll(handle), and retrieve(handle)',
+    );
+  }
+  if (
+    provider.execution === 'inline' &&
+    (provider.submit !== undefined ||
+      provider.poll !== undefined ||
+      provider.retrieve !== undefined)
+  ) {
+    throw new Error(
+      'Inline providers cannot define submit, poll, or retrieve; declare execution: "background" instead',
+    );
   }
 
   provider.source = source;

--- a/src/adapters/gemini-deep.ts
+++ b/src/adapters/gemini-deep.ts
@@ -9,7 +9,7 @@ import type {
   ProviderTier,
   ProviderUsage,
 } from '../types.js';
-import { BaseProvider } from './base.js';
+import { BackgroundBaseProvider } from './base.js';
 
 /**
  * Citation annotation attached to a TextContent block.
@@ -100,7 +100,7 @@ const STATUS_MAP: Record<string, AsyncTaskStatus> = {
  * server-side for minutes; results are polled and retrieved by interaction id.
  * Tier: deep-research (true async).
  */
-export class GeminiDeepProvider extends BaseProvider {
+export class GeminiDeepProvider extends BackgroundBaseProvider {
   readonly id = 'gemini-deep';
   readonly tier: ProviderTier = 'deep-research';
   readonly model: string;
@@ -222,7 +222,6 @@ export class GeminiDeepProvider extends BaseProvider {
         },
         timeout: 30000,
         signal: options.signal,
-        maxRetries: 0,
       });
     } catch (error) {
       throw new UnsafeToRetrySubmissionError(

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -9,7 +9,7 @@ import {
   providerHasCredential,
 } from '../core/provider-selection.js';
 import type { Config, Provider, ProviderMeta, ProviderTier } from '../types.js';
-import { BaseProvider } from './base.js';
+import { ProviderBase } from './base.js';
 import { BraveAnswersProvider } from './brave-answers.js';
 import { BraveSearchProvider } from './brave-search.js';
 import { ClaudeProvider } from './claude.js';
@@ -65,6 +65,7 @@ export function registerProvider(provider: Provider): void {
 function assertProviderExecutionContract(provider: Provider): void {
   const candidate = provider as Provider & {
     execution?: unknown;
+    execute?: unknown;
     submit?: unknown;
     poll?: unknown;
     retrieve?: unknown;
@@ -76,6 +77,9 @@ function assertProviderExecutionContract(provider: Provider): void {
     throw new TypeError(
       `Provider "${provider.id}" must declare execution as "inline" or "background"`,
     );
+  }
+  if (typeof candidate.execute !== 'function') {
+    throw new TypeError(`Provider "${provider.id}" must define execute`);
   }
   const lifecycle = [candidate.submit, candidate.poll, candidate.retrieve];
   if (
@@ -238,7 +242,7 @@ export async function initializeProviders(
   ];
 
   for (const provider of builtIns) {
-    if (provider instanceof BaseProvider) {
+    if (provider instanceof ProviderBase) {
       provider.configure({
         apiKey: providerConfig[provider.id]?.apiKey,
         credentials,

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -56,9 +56,44 @@ export interface ProviderInitResult {
  * Register a provider in the registry
  */
 export function registerProvider(provider: Provider): void {
+  assertProviderExecutionContract(provider);
   provider.source ??= 'builtin';
   provider.requiresApiKey ??= true;
   providers.set(provider.id, provider);
+}
+
+function assertProviderExecutionContract(provider: Provider): void {
+  const candidate = provider as Provider & {
+    execution?: unknown;
+    submit?: unknown;
+    poll?: unknown;
+    retrieve?: unknown;
+  };
+  if (
+    candidate.execution !== 'inline' &&
+    candidate.execution !== 'background'
+  ) {
+    throw new TypeError(
+      `Provider "${provider.id}" must declare execution as "inline" or "background"`,
+    );
+  }
+  const lifecycle = [candidate.submit, candidate.poll, candidate.retrieve];
+  if (
+    candidate.execution === 'background' &&
+    lifecycle.some((method) => typeof method !== 'function')
+  ) {
+    throw new TypeError(
+      `Background provider "${provider.id}" must define submit, poll, and retrieve`,
+    );
+  }
+  if (
+    candidate.execution === 'inline' &&
+    lifecycle.some((method) => method !== undefined)
+  ) {
+    throw new TypeError(
+      `Inline provider "${provider.id}" cannot define submit, poll, or retrieve`,
+    );
+  }
 }
 
 /**

--- a/src/adapters/openai-research.ts
+++ b/src/adapters/openai-research.ts
@@ -9,7 +9,7 @@ import type {
   ProviderTier,
   ProviderUsage,
 } from '../types.js';
-import { BaseProvider, type BaseProviderOptions } from './base.js';
+import { BackgroundBaseProvider, type BaseProviderOptions } from './base.js';
 
 interface OpenAIAnnotation {
   type: string;
@@ -113,7 +113,7 @@ function parseReturnTokenBudget(value: unknown): ReturnTokenBudget {
  * exactly the configured model: a rejected model is an actionable API error,
  * never an opportunity to silently substitute a retired research model.
  */
-export class OpenAIResearchProvider extends BaseProvider {
+export class OpenAIResearchProvider extends BackgroundBaseProvider {
   readonly id = 'openai-research';
   readonly tier: ProviderTier = 'deep-research';
   readonly model: string;
@@ -219,7 +219,6 @@ export class OpenAIResearchProvider extends BaseProvider {
           },
           timeout: 30000,
           signal: options.signal,
-          maxRetries: 0,
         },
       );
     } catch (error) {

--- a/src/adapters/perplexity-agent-base.ts
+++ b/src/adapters/perplexity-agent-base.ts
@@ -6,7 +6,7 @@ import type {
   ProviderResult,
   ProviderUsage,
 } from '../types.js';
-import { BaseProvider } from './base.js';
+import { BackgroundBaseProvider } from './base.js';
 
 interface AgentAnnotation {
   type: string;
@@ -56,7 +56,7 @@ const AGENT_API_URL = 'https://api.perplexity.ai/v1/agent';
  * Shared base for Perplexity Agent API providers (preset-based).
  * Subclasses only need to declare id, tier, and preset.
  */
-export abstract class PerplexityAgentBaseProvider extends BaseProvider {
+export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider {
   abstract readonly preset: string;
 
   private storedResults = new Map<string, ProviderResult>();

--- a/src/adapters/perplexity-sonar-deep.ts
+++ b/src/adapters/perplexity-sonar-deep.ts
@@ -8,7 +8,7 @@ import type {
   ProviderTier,
   ProviderUsage,
 } from '../types.js';
-import { BaseProvider } from './base.js';
+import { BackgroundBaseProvider } from './base.js';
 
 interface PerplexityMessage {
   role: string;
@@ -77,7 +77,7 @@ const ASYNC_STATUS_MAP: Record<string, AsyncTaskHandle['status']> = {
  * Uses the sonar-deep-research model via the Chat Completions API for comprehensive research queries.
  * Tier: deep-research (async capable)
  */
-export class PerplexitySonarDeepProvider extends BaseProvider {
+export class PerplexitySonarDeepProvider extends BackgroundBaseProvider {
   readonly id = 'perplexity-sonar-deep';
   readonly tier: ProviderTier = 'deep-research';
 
@@ -171,7 +171,6 @@ export class PerplexitySonarDeepProvider extends BaseProvider {
         },
         timeout: 30000,
         signal: options.signal,
-        maxRetries: 0,
       });
     } catch (error) {
       throw new UnsafeToRetrySubmissionError(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -74,7 +74,7 @@ async function retrieveTask(
   providerConfig?: ProviderConfig,
 ): Promise<boolean> {
   const provider = getExactProvider(task.provider);
-  if (!provider?.retrieve) {
+  if (provider?.execution !== 'background') {
     spinner.text = `Provider ${task.provider} does not support retrieval`;
     return false;
   }
@@ -212,7 +212,7 @@ export async function reconcilePendingTasksOnce(
 ): Promise<void> {
   for (const task of tasks) {
     const provider = getExactProvider(task.provider);
-    if (!provider?.poll || !task.outputDir) {
+    if (provider?.execution !== 'background' || !task.outputDir) {
       if (task.outputDir) {
         updateAsyncTask(
           task.outputDir,
@@ -362,7 +362,7 @@ export function registerStatusCommand(program: Command): void {
           while (remaining.length > 0) {
             for (const task of remaining) {
               const provider = getExactProvider(task.provider);
-              if (!provider?.poll) {
+              if (provider?.execution !== 'background') {
                 spinner.text = `Provider ${task.provider} does not support polling`;
                 if (task.outputDir) {
                   updateAsyncTask(

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -360,33 +360,19 @@ export async function dispatch(
 
       onProgress?.({ providerId: id, event: 'started' });
 
-      // For deep-research providers in async/mixed mode, use submit
-      if (
-        provider.tier === 'deep-research' &&
-        mode !== 'sync' &&
-        provider.submit
-      ) {
+      // Background providers expose a complete persisted-task lifecycle.
+      if (provider.execution === 'background' && mode !== 'sync') {
         try {
           const handle = await provider.submit(queryForTier(provider.tier), {
             timeout: config.defaults.asyncTimeout,
           });
 
-          if (
-            handle.status === 'cancelled' ||
-            ((handle.status === 'completed' || handle.status === 'failed') &&
-              !provider.retrieve)
-          ) {
+          if (handle.status === 'cancelled') {
             const terminalError =
               handle.lastPollError ??
-              (handle.status === 'cancelled'
-                ? handle.providerStatus
-                  ? `Task was cancelled (${handle.providerStatus})`
-                  : 'Task was cancelled'
-                : handle.status === 'failed'
-                  ? handle.providerStatus
-                    ? `Task failed (${handle.providerStatus})`
-                    : 'Task failed during submission'
-                  : 'Task completed, but the provider does not support retrieval');
+              (handle.providerStatus
+                ? `Task was cancelled (${handle.providerStatus})`
+                : 'Task was cancelled');
             const structured = createDispatchResult(
               id,
               provider.tier,
@@ -421,10 +407,7 @@ export async function dispatch(
 
           // If submit is already terminal, retrieve immediately and treat it
           // as a synchronous result.
-          if (
-            (handle.status === 'completed' || handle.status === 'failed') &&
-            provider.retrieve
-          ) {
+          if (handle.status === 'completed' || handle.status === 'failed') {
             const result = await provider.retrieve(handle);
             const structured = createDispatchResult(
               id,

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -481,28 +481,30 @@ export async function dispatch(
           });
           return;
         } catch (error) {
-          if (error instanceof UnsafeToRetrySubmissionError) {
-            const structured = createDispatchResult(
-              id,
-              provider.tier,
-              {
-                provider: id,
-                tier: provider.tier,
-                content: '',
-                citations: [],
-                durationMs: 0,
-                error: error.message,
-              },
-              providerConfig,
-            );
-            results.push(structured);
-            const report = createReport(id, provider.tier, structured);
-            reports.push(report);
-            recordBudget(report);
-            onProgress?.({ providerId: id, event: 'error', report });
-            return;
-          }
-          // Fall through to sync execution
+          const detail = error instanceof Error ? error.message : String(error);
+          const message =
+            error instanceof UnsafeToRetrySubmissionError
+              ? detail
+              : `Background submission failed and was not retried because the remote task may have been accepted: ${detail}`;
+          const structured = createDispatchResult(
+            id,
+            provider.tier,
+            {
+              provider: id,
+              tier: provider.tier,
+              content: '',
+              citations: [],
+              durationMs: 0,
+              error: message,
+            },
+            providerConfig,
+          );
+          results.push(structured);
+          const report = createReport(id, provider.tier, structured);
+          reports.push(report);
+          recordBudget(report);
+          onProgress?.({ providerId: id, event: 'error', report });
+          return;
         }
       }
 

--- a/src/core/http-client.ts
+++ b/src/core/http-client.ts
@@ -4,14 +4,35 @@ import {
   MAX_RETRIES,
 } from '../constants.js';
 
+const DEFAULT_MAX_RETRY_DELAY_MS = 30_000;
+
+interface RetrySettings {
+  /** Total attempts, including the initial request. */
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export type HttpRetryPolicy =
+  | { mode: 'never' }
+  | ({ mode: 'safe' } & RetrySettings)
+  | ({
+      mode: 'idempotent';
+      idempotencyKey: string;
+      idempotencyHeader?: string;
+    } & RetrySettings);
+
 export interface HttpRequestOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   headers?: Record<string, string>;
   body?: unknown;
   timeout?: number; // ms
   signal?: AbortSignal;
-  /** Override retries for requests that are unsafe to repeat. */
-  maxRetries?: number;
+  /**
+   * GET requests retry transient failures by default. Mutating requests do not
+   * retry unless their idempotency is declared explicitly.
+   */
+  retry?: HttpRetryPolicy;
 }
 
 export interface HttpResponse<T = unknown> {
@@ -22,8 +43,41 @@ export interface HttpResponse<T = unknown> {
   durationMs: number;
 }
 
+export class HttpRequestAbortedError extends Error {
+  constructor() {
+    super('Request aborted');
+    this.name = 'HttpRequestAbortedError';
+  }
+}
+
+export class HttpRequestTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = 'HttpRequestTimeoutError';
+  }
+}
+
+export class HttpResponseTooLargeError extends Error {
+  readonly limitBytes: number;
+
+  constructor(limitBytes: number) {
+    super(`Response exceeds ${limitBytes} bytes`);
+    this.name = 'HttpResponseTooLargeError';
+    this.limitBytes = limitBytes;
+  }
+}
+
+interface ResolvedRetryPolicy {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  idempotencyHeader?: string;
+  idempotencyKey?: string;
+}
+
 /**
- * Thin fetch wrapper with retry, timeout, and duration tracking.
+ * Thin fetch wrapper with bounded response reads, explicit retry safety,
+ * timeout/abort handling, and duration tracking.
  */
 export async function httpRequest<T = unknown>(
   url: string,
@@ -35,40 +89,44 @@ export async function httpRequest<T = unknown>(
     body,
     timeout = 30000,
     signal,
-    maxRetries = MAX_RETRIES,
   } = options;
-
+  const retry = resolveRetryPolicy(method, options.retry);
   let lastError: Error | undefined;
+  let retryDelayMs = 0;
 
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (attempt > 0) {
-      const delay = INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1);
-      await sleep(delay);
+  for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
+    if (attempt > 1) {
+      await abortableSleep(retryDelayMs, signal);
     }
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    let timedOut = false;
+    const onExternalAbort = (): void => controller.abort();
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeout);
 
-    // Link external signal
-    if (signal) {
-      if (signal.aborted) {
-        clearTimeout(timeoutId);
-        throw new Error('Request aborted');
-      }
-      signal.addEventListener('abort', () => controller.abort(), {
-        once: true,
-      });
+    if (signal?.aborted) {
+      clearTimeout(timeoutId);
+      throw new HttpRequestAbortedError();
     }
+    signal?.addEventListener('abort', onExternalAbort, { once: true });
 
     const start = performance.now();
 
     try {
+      const requestHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...headers,
+      };
+      if (retry.idempotencyHeader && retry.idempotencyKey) {
+        requestHeaders[retry.idempotencyHeader] = retry.idempotencyKey;
+      }
+
       const fetchOptions: RequestInit = {
         method,
-        headers: {
-          'Content-Type': 'application/json',
-          ...headers,
-        },
+        headers: requestHeaders,
         signal: controller.signal,
       };
 
@@ -77,47 +135,16 @@ export async function httpRequest<T = unknown>(
       }
 
       const response = await fetch(url, fetchOptions);
-      clearTimeout(timeoutId);
-
       const durationMs = Math.round(performance.now() - start);
+      const retryableStatus = response.status === 429 || response.status >= 500;
 
-      // Don't retry client errors (4xx) except 429 (rate limit)
-      if (
-        response.status >= 400 &&
-        response.status < 500 &&
-        response.status !== 429
-      ) {
-        const text = await response.text();
-        let data: T;
-        try {
-          data = JSON.parse(text) as T;
-        } catch {
-          data = text as T;
-        }
-        return {
-          status: response.status,
-          statusText: response.statusText,
-          data,
-          headers: Object.fromEntries(response.headers.entries()),
-          durationMs,
-        };
+      if (retryableStatus && attempt < retry.maxAttempts) {
+        retryDelayMs = retryDelayForResponse(response, attempt, retry);
+        await cancelResponseBody(response);
+        continue;
       }
 
-      // Retry on 5xx and 429
-      if (response.status >= 500 || response.status === 429) {
-        if (attempt < maxRetries) {
-          lastError = new Error(
-            `HTTP ${response.status}: ${response.statusText}`,
-          );
-          continue;
-        }
-      }
-
-      const text = await response.text();
-      if (text.length > MAX_RESPONSE_SIZE) {
-        throw new Error(`Response exceeds ${MAX_RESPONSE_SIZE} bytes`);
-      }
-
+      const text = await readBoundedBody(response, MAX_RESPONSE_SIZE);
       let data: T;
       try {
         data = JSON.parse(text) as T;
@@ -132,24 +159,188 @@ export async function httpRequest<T = unknown>(
         headers: Object.fromEntries(response.headers.entries()),
         durationMs,
       };
-    } catch (e) {
-      clearTimeout(timeoutId);
-      if (e instanceof Error && e.name === 'AbortError') {
-        if (signal?.aborted) {
-          throw new Error('Request aborted');
-        }
-        lastError = new Error(`Request timed out after ${timeout}ms`);
+    } catch (error) {
+      if (error instanceof HttpResponseTooLargeError) {
+        throw error;
+      }
+      if (signal?.aborted) {
+        throw new HttpRequestAbortedError();
+      }
+      if (isAbortError(error)) {
+        lastError = timedOut
+          ? new HttpRequestTimeoutError(timeout)
+          : new HttpRequestAbortedError();
       } else {
-        lastError = e instanceof Error ? e : new Error(String(e));
+        lastError = error instanceof Error ? error : new Error(String(error));
       }
 
-      if (attempt >= maxRetries) break;
+      if (
+        lastError instanceof HttpRequestAbortedError ||
+        attempt >= retry.maxAttempts
+      ) {
+        break;
+      }
+      retryDelayMs = jitteredBackoff(attempt, retry);
+    } finally {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener('abort', onExternalAbort);
     }
   }
 
   throw lastError ?? new Error('Request failed after retries');
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function resolveRetryPolicy(
+  method: NonNullable<HttpRequestOptions['method']>,
+  policy: HttpRetryPolicy | undefined,
+): ResolvedRetryPolicy {
+  const resolved =
+    policy ?? (method === 'GET' ? { mode: 'safe' } : { mode: 'never' });
+
+  if (resolved.mode === 'never') {
+    return {
+      maxAttempts: 1,
+      baseDelayMs: INITIAL_RETRY_DELAY_MS,
+      maxDelayMs: DEFAULT_MAX_RETRY_DELAY_MS,
+    };
+  }
+  if (resolved.mode === 'safe' && method !== 'GET') {
+    throw new TypeError(`Safe retry policy cannot be used with ${method}`);
+  }
+
+  const maxAttempts = resolved.maxAttempts ?? MAX_RETRIES + 1;
+  const baseDelayMs = resolved.baseDelayMs ?? INITIAL_RETRY_DELAY_MS;
+  const maxDelayMs = resolved.maxDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new TypeError('Retry maxAttempts must be a positive integer');
+  }
+  if (!Number.isFinite(baseDelayMs) || baseDelayMs < 0) {
+    throw new TypeError('Retry baseDelayMs must be a non-negative number');
+  }
+  if (!Number.isFinite(maxDelayMs) || maxDelayMs < 0) {
+    throw new TypeError('Retry maxDelayMs must be a non-negative number');
+  }
+
+  if (resolved.mode === 'idempotent') {
+    if (!resolved.idempotencyKey.trim()) {
+      throw new TypeError('Idempotent retry policy requires a key');
+    }
+    const idempotencyHeader = resolved.idempotencyHeader ?? 'Idempotency-Key';
+    if (!idempotencyHeader.trim()) {
+      throw new TypeError('Idempotency header must not be empty');
+    }
+    return {
+      maxAttempts,
+      baseDelayMs,
+      maxDelayMs,
+      idempotencyHeader,
+      idempotencyKey: resolved.idempotencyKey,
+    };
+  }
+
+  return { maxAttempts, baseDelayMs, maxDelayMs };
+}
+
+function retryDelayForResponse(
+  response: Response,
+  attempt: number,
+  retry: ResolvedRetryPolicy,
+): number {
+  const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+  return retryAfter === undefined
+    ? jitteredBackoff(attempt, retry)
+    : Math.min(retryAfter, retry.maxDelayMs);
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  const date = Date.parse(trimmed);
+  return Number.isNaN(date) ? undefined : Math.max(0, date - Date.now());
+}
+
+function jitteredBackoff(
+  attempt: number,
+  retry: Pick<ResolvedRetryPolicy, 'baseDelayMs' | 'maxDelayMs'>,
+): number {
+  const cap = Math.min(
+    retry.maxDelayMs,
+    retry.baseDelayMs * 2 ** Math.max(0, attempt - 1),
+  );
+  return Math.floor(cap / 2 + Math.random() * (cap / 2));
+}
+
+async function readBoundedBody(
+  response: Response,
+  limitBytes: number,
+): Promise<string> {
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > limitBytes) {
+    await cancelResponseBody(response);
+    throw new HttpResponseTooLargeError(limitBytes);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > limitBytes) {
+      throw new HttpResponseTooLargeError(limitBytes);
+    }
+    return text;
+  }
+
+  const decoder = new TextDecoder();
+  const parts: string[] = [];
+  let bytesRead = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > limitBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Preserve the deterministic size error if stream cleanup fails.
+        }
+        throw new HttpResponseTooLargeError(limitBytes);
+      }
+      parts.push(decoder.decode(value, { stream: true }));
+    }
+    parts.push(decoder.decode());
+    return parts.join('');
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The next attempt must not be hidden by best-effort connection cleanup.
+  }
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(new HttpRequestAbortedError());
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener('abort', onAbort);
+      reject(new HttpRequestAbortedError());
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }

--- a/src/core/http-client.ts
+++ b/src/core/http-client.ts
@@ -121,6 +121,10 @@ export async function httpRequest<T = unknown>(
         ...headers,
       };
       if (retry.idempotencyHeader && retry.idempotencyKey) {
+        const normalized = retry.idempotencyHeader.toLowerCase();
+        for (const name of Object.keys(requestHeaders)) {
+          if (name.toLowerCase() === normalized) delete requestHeaders[name];
+        }
         requestHeaders[retry.idempotencyHeader] = retry.idempotencyKey;
       }
 

--- a/src/mcp/async.ts
+++ b/src/mcp/async.ts
@@ -52,7 +52,7 @@ async function retrieveTaskSilent(
   state: TaskState,
 ): Promise<boolean> {
   const provider = getExactProvider(task.provider);
-  if (!provider?.retrieve) {
+  if (provider?.execution !== 'background') {
     state.retrieveError = `Provider ${task.provider} does not support retrieval`;
     return false;
   }
@@ -146,7 +146,7 @@ export async function checkAsyncTasks(
 
     if (task.status === 'pending' || task.status === 'running') {
       const provider = getExactProvider(task.provider);
-      if (provider?.poll) {
+      if (provider?.execution === 'background') {
         polled++;
         try {
           const poll = await provider.poll(task);

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,8 +170,8 @@ export interface AsyncPollResult {
   rawStatus?: string;
 }
 
-// Provider interface — each adapter implements this
-export interface Provider {
+// Fields shared by every provider implementation.
+export interface ProviderCommon {
   id: string;
   displayName: string;
   tier: ProviderTier;
@@ -179,17 +179,35 @@ export interface Provider {
   source?: ProviderSource;
   requiresApiKey?: boolean;
 
-  // Sync execution (all providers)
+  // All providers support direct execution. Background providers use this for
+  // synchronous callers that choose to wait for their remote task.
   execute(query: string, options: ProviderOptions): Promise<ProviderResult>;
-
-  // Async (deep-research only)
-  submit?(query: string, options: ProviderOptions): Promise<AsyncTaskHandle>;
-  poll?(handle: AsyncTaskHandle): Promise<AsyncPollResult>;
-  retrieve?(handle: AsyncTaskHandle): Promise<ProviderResult>;
 
   // Health check
   test?(): Promise<{ ok: boolean; error?: string }>;
 }
+
+/** A provider whose work is complete when execute() resolves. */
+export interface InlineProvider extends ProviderCommon {
+  execution: 'inline';
+}
+
+/**
+ * A provider that can submit work to a remote background service.
+ *
+ * All lifecycle hooks are required together: a task handle without polling or
+ * retrieval support cannot be safely persisted or resumed.
+ */
+export interface BackgroundProvider extends ProviderCommon {
+  execution: 'background';
+
+  submit(query: string, options: ProviderOptions): Promise<AsyncTaskHandle>;
+  poll(handle: AsyncTaskHandle): Promise<AsyncPollResult>;
+  retrieve(handle: AsyncTaskHandle): Promise<ProviderResult>;
+}
+
+// Provider interface — each adapter implements one execution contract.
+export type Provider = InlineProvider | BackgroundProvider;
 
 // Provider meta for ls/display
 export interface ProviderMeta {

--- a/tests/adapters/openai-research.test.ts
+++ b/tests/adapters/openai-research.test.ts
@@ -202,11 +202,12 @@ describe('OpenAIResearchProvider', () => {
     expect(result.asyncTasks).toEqual([]);
   });
 
-  it('reports an immediately cancelled submission without queuing it', async () => {
+  it('reports an immediately cancelled background submission without queuing it', async () => {
     const cancelledProvider: Provider = {
       id: 'cancelled-submit-test',
       displayName: 'Cancelled submit test',
       tier: 'deep-research',
+      execution: 'background',
       envVar: '',
       execute: vi.fn(),
       submit: async (query) => ({
@@ -215,6 +216,15 @@ describe('OpenAIResearchProvider', () => {
         query,
         submittedAt: Date.now(),
         status: 'cancelled',
+      }),
+      poll: async () => ({ status: 'cancelled' }),
+      retrieve: async () => ({
+        provider: 'cancelled-submit-test',
+        tier: 'deep-research',
+        content: '',
+        citations: [],
+        durationMs: 0,
+        error: 'Task was cancelled',
       }),
     };
     registerProvider(cancelledProvider);
@@ -249,11 +259,12 @@ describe('OpenAIResearchProvider', () => {
     expect(cancelledProvider.execute).not.toHaveBeenCalled();
   });
 
-  it('reports an immediately failed submission without retrieval as terminal', async () => {
+  it('retrieves an immediately failed background submission', async () => {
     const failedProvider: Provider = {
       id: 'failed-submit-test',
       displayName: 'Failed submit test',
       tier: 'deep-research',
+      execution: 'background',
       envVar: '',
       execute: vi.fn(),
       submit: async (query) => ({
@@ -263,6 +274,15 @@ describe('OpenAIResearchProvider', () => {
         submittedAt: Date.now(),
         status: 'failed',
         providerStatus: 'REJECTED',
+      }),
+      poll: async () => ({ status: 'failed' }),
+      retrieve: async () => ({
+        provider: 'failed-submit-test',
+        tier: 'deep-research',
+        content: '',
+        citations: [],
+        durationMs: 0,
+        error: 'Task failed (REJECTED)',
       }),
     };
     registerProvider(failedProvider);
@@ -300,11 +320,12 @@ describe('OpenAIResearchProvider', () => {
     expect(failedProvider.execute).not.toHaveBeenCalled();
   });
 
-  it('reports an immediately completed submission without retrieval as terminal', async () => {
+  it('retrieves an immediately completed background submission', async () => {
     const completedProvider: Provider = {
       id: 'completed-submit-test',
       displayName: 'Completed submit test',
       tier: 'deep-research',
+      execution: 'background',
       envVar: '',
       execute: vi.fn(),
       submit: async (query) => ({
@@ -313,6 +334,14 @@ describe('OpenAIResearchProvider', () => {
         query,
         submittedAt: Date.now(),
         status: 'completed',
+      }),
+      poll: async () => ({ status: 'completed' }),
+      retrieve: async () => ({
+        provider: 'completed-submit-test',
+        tier: 'deep-research',
+        content: 'Completed research',
+        citations: [],
+        durationMs: 1,
       }),
     };
     registerProvider(completedProvider);
@@ -343,8 +372,7 @@ describe('OpenAIResearchProvider', () => {
     expect(result.asyncTasks).toEqual([]);
     expect(result.reports).toEqual([
       expect.objectContaining({
-        status: 'error',
-        error: 'Task completed, but the provider does not support retrieval',
+        status: 'success',
       }),
     ]);
     expect(completedProvider.execute).not.toHaveBeenCalled();

--- a/tests/answer-command.test.ts
+++ b/tests/answer-command.test.ts
@@ -253,6 +253,7 @@ describe('synthesizeAnswer', () => {
       id: 'primary',
       displayName: 'Primary',
       tier: 'ai-grounded',
+      execution: 'inline',
       envVar: 'VERIFY_PRIMARY_KEY',
       execute,
     });

--- a/tests/claim-verification.test.ts
+++ b/tests/claim-verification.test.ts
@@ -65,6 +65,7 @@ function provider(
     id,
     displayName: id,
     tier,
+    execution: 'inline',
     envVar: `VERIFY_${id.toUpperCase()}_KEY`,
     execute,
   };

--- a/tests/custom-providers.test.ts
+++ b/tests/custom-providers.test.ts
@@ -36,6 +36,7 @@ describe('custom providers', () => {
         "  id: 'untrusted-provider',",
         "  displayName: 'Untrusted Provider',",
         "  tier: 'raw-search',",
+        "  execution: 'inline',",
         "  envVar: '',",
         '  requiresApiKey: false,',
         '  async execute(query) {',
@@ -98,6 +99,7 @@ describe('custom providers', () => {
         '    id: context.id,',
         "    displayName: 'My NPM Provider',",
         "    tier: 'ai-grounded',",
+        "    execution: 'inline',",
         "    envVar: '',",
         '    requiresApiKey: false,',
         '    async execute(query) {',
@@ -161,9 +163,10 @@ describe('custom providers', () => {
         '    data: {',
         "      displayName: 'Script Provider',",
         "      tier: 'deep-research',",
+        "      execution: 'background',",
         "      envVar: '',",
         '      requiresApiKey: false,',
-        '      capabilities: { submit: true, poll: true, retrieve: true, test: true }',
+        '      capabilities: { execute: true, submit: true, poll: true, retrieve: true, test: true }',
         '    }',
         '  }));',
         '} else if (op === "execute") {',
@@ -242,6 +245,7 @@ describe('custom providers', () => {
     const provider = getProvider('script-provider');
     expect(provider).toBeDefined();
     expect(provider!.source).toBe('script');
+    expect(provider!.execution).toBe('background');
     expect(provider!.submit).toBeDefined();
     expect(provider!.poll).toBeDefined();
     expect(provider!.retrieve).toBeDefined();
@@ -252,11 +256,13 @@ describe('custom providers', () => {
     expect(executed.tier).toBe('deep-research');
     expect(executed.content).toBe('exec:question:tagged');
 
-    const handle = await provider!.submit!('question', { timeout: 5 });
+    if (provider!.execution !== 'background')
+      throw new Error('expected background provider');
+    const handle = await provider!.submit('question', { timeout: 5 });
     expect(handle.provider).toBe('script-provider');
-    const pollResult = await provider!.poll!(handle);
+    const pollResult = await provider!.poll(handle);
     expect(pollResult.status).toBe('completed');
-    const retrieved = await provider!.retrieve!(handle);
+    const retrieved = await provider!.retrieve(handle);
     expect(retrieved.content).toBe('retrieved:task-123');
     const health = await provider!.test!();
     expect(health.ok).toBe(true);
@@ -287,6 +293,92 @@ describe('custom providers', () => {
     expect(initResult.warnings.join('\n')).toContain('invalid JSON');
   });
 
+  it('rejects script background providers missing lifecycle hooks', async () => {
+    const scriptPath = join(tmpDir, 'incomplete-background.mjs');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { readFileSync } from 'node:fs';",
+        'const input = JSON.parse(readFileSync(0, "utf-8"));',
+        'if (input.operation === "describe") {',
+        '  process.stdout.write(JSON.stringify({ ok: true, data: {',
+        "    displayName: 'Incomplete Background', tier: 'deep-research', execution: 'background',",
+        '    requiresApiKey: false, capabilities: { execute: true, submit: true, poll: true }',
+        '  }}));',
+        '}',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { incomplete: { enabled: true } },
+      customProviders: {
+        incomplete: { type: 'script', command: 'node', args: [scriptPath] },
+      },
+      trustedProviderIds: ['incomplete'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain(
+      'must declare submit, poll, and retrieve',
+    );
+  });
+
+  it('rejects npm background providers missing lifecycle hooks', async () => {
+    const modulePath = join(tmpDir, 'incomplete-background.mjs');
+    writeFileSync(
+      modulePath,
+      [
+        'export default {',
+        "  id: 'incomplete-npm', displayName: 'Incomplete NPM', tier: 'deep-research',",
+        "  execution: 'background', envVar: '', requiresApiKey: false,",
+        '  async execute() { return { provider: "incomplete-npm", tier: "deep-research", content: "", citations: [], durationMs: 0 }; },',
+        '  async submit(query) { return { provider: "incomplete-npm", taskId: "x", query, submittedAt: 0, status: "pending" }; },',
+        '};',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { 'incomplete-npm': { enabled: true } },
+      customProviders: {
+        'incomplete-npm': { type: 'npm', module: modulePath },
+      },
+      trustedProviderIds: ['incomplete-npm'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain(
+      'Background providers must define submit',
+    );
+  });
+
+  it('rejects npm providers that omit their execution contract', async () => {
+    const modulePath = join(tmpDir, 'missing-execution.mjs');
+    writeFileSync(
+      modulePath,
+      [
+        'export default {',
+        "  id: 'missing-execution', displayName: 'Missing Execution', tier: 'raw-search',",
+        "  envVar: '', requiresApiKey: false,",
+        '  async execute() { return { provider: "missing-execution", tier: "raw-search", content: "", citations: [], durationMs: 0 }; },',
+        '};',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { 'missing-execution': { enabled: true } },
+      customProviders: {
+        'missing-execution': { type: 'npm', module: modulePath },
+      },
+      trustedProviderIds: ['missing-execution'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain('must declare execution');
+  });
+
   it('rejects custom providers that collide with built-in IDs', async () => {
     const modulePath = join(tmpDir, 'exa-override.mjs');
     writeFileSync(
@@ -296,6 +388,7 @@ describe('custom providers', () => {
         "  id: 'exa',",
         "  displayName: 'Exa Override',",
         "  tier: 'ai-grounded',",
+        "  execution: 'inline',",
         "  envVar: '',",
         '  requiresApiKey: false,',
         '  async execute(query, _options) {',

--- a/tests/custom-providers.test.ts
+++ b/tests/custom-providers.test.ts
@@ -324,6 +324,103 @@ describe('custom providers', () => {
     );
   });
 
+  it('rejects script providers that require a key without envVar', async () => {
+    const scriptPath = join(tmpDir, 'missing-env-var.mjs');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { readFileSync } from 'node:fs';",
+        'const input = JSON.parse(readFileSync(0, "utf-8"));',
+        'if (input.operation === "describe") {',
+        '  process.stdout.write(JSON.stringify({ ok: true, data: {',
+        "    displayName: 'Missing Env', tier: 'raw-search', execution: 'inline',",
+        '    capabilities: { execute: true }',
+        '  }}));',
+        '}',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { 'missing-env': { enabled: true } },
+      customProviders: {
+        'missing-env': { type: 'script', command: 'node', args: [scriptPath] },
+      },
+      trustedProviderIds: ['missing-env'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain(
+      'requires an API key but envVar is empty',
+    );
+  });
+
+  it('rejects inline script providers with lifecycle capabilities', async () => {
+    const scriptPath = join(tmpDir, 'inline-lifecycle.mjs');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { readFileSync } from 'node:fs';",
+        'const input = JSON.parse(readFileSync(0, "utf-8"));',
+        'if (input.operation === "describe") {',
+        '  process.stdout.write(JSON.stringify({ ok: true, data: {',
+        "    displayName: 'Inline Lifecycle', tier: 'raw-search', execution: 'inline',",
+        '    requiresApiKey: false, capabilities: { execute: true, submit: true }',
+        '  }}));',
+        '}',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { 'inline-lifecycle': { enabled: true } },
+      customProviders: {
+        'inline-lifecycle': {
+          type: 'script',
+          command: 'node',
+          args: [scriptPath],
+        },
+      },
+      trustedProviderIds: ['inline-lifecycle'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain(
+      'cannot declare submit, poll, or retrieve',
+    );
+  });
+
+  it('rejects script providers that disable execute', async () => {
+    const scriptPath = join(tmpDir, 'no-execute.mjs');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { readFileSync } from 'node:fs';",
+        'const input = JSON.parse(readFileSync(0, "utf-8"));',
+        'if (input.operation === "describe") {',
+        '  process.stdout.write(JSON.stringify({ ok: true, data: {',
+        "    displayName: 'No Execute', tier: 'raw-search', execution: 'inline',",
+        '    requiresApiKey: false, capabilities: { execute: false }',
+        '  }}));',
+        '}',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { 'no-execute': { enabled: true } },
+      customProviders: {
+        'no-execute': { type: 'script', command: 'node', args: [scriptPath] },
+      },
+      trustedProviderIds: ['no-execute'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain(
+      'capabilities.execute must be true',
+    );
+  });
+
   it('rejects npm background providers missing lifecycle hooks', async () => {
     const modulePath = join(tmpDir, 'incomplete-background.mjs');
     writeFileSync(
@@ -377,6 +474,35 @@ describe('custom providers', () => {
 
     expect(result.loadedCustomProviders).toEqual([]);
     expect(result.warnings.join('\n')).toContain('must declare execution');
+  });
+
+  it('rejects inline npm providers with lifecycle hooks', async () => {
+    const modulePath = join(tmpDir, 'inline-npm-lifecycle.mjs');
+    writeFileSync(
+      modulePath,
+      [
+        'export default {',
+        "  id: 'inline-npm-lifecycle', displayName: 'Inline NPM Lifecycle', tier: 'raw-search',",
+        "  execution: 'inline', envVar: '', requiresApiKey: false,",
+        '  async execute() { return { provider: "inline-npm-lifecycle", tier: "raw-search", content: "", citations: [], durationMs: 0 }; },',
+        '  async submit() {},',
+        '};',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await initializeProviders({
+      providers: { 'inline-npm-lifecycle': { enabled: true } },
+      customProviders: {
+        'inline-npm-lifecycle': { type: 'npm', module: modulePath },
+      },
+      trustedProviderIds: ['inline-npm-lifecycle'],
+    });
+
+    expect(result.loadedCustomProviders).toEqual([]);
+    expect(result.warnings.join('\n')).toContain(
+      'Inline providers cannot define submit, poll, or retrieve',
+    );
   });
 
   it('rejects custom providers that collide with built-in IDs', async () => {

--- a/tests/dispatcher-budget.test.ts
+++ b/tests/dispatcher-budget.test.ts
@@ -42,6 +42,7 @@ function costProvider(
     id,
     displayName: `Mock ${id}`,
     tier,
+    execution: 'inline',
     envVar: `MOCK_${id.toUpperCase().replace(/-/g, '_')}_KEY`,
     execute: async (
       _query: string,
@@ -173,6 +174,7 @@ describe('dispatcher budget circuit breaker', () => {
       id: 'mock-b',
       displayName: 'Mock mock-b',
       tier: 'ai-grounded',
+      execution: 'inline',
       envVar: 'MOCK_B_KEY',
       execute: async (): Promise<ProviderResult> => {
         // Fail only after mock-a has reported its over-budget cost, so the

--- a/tests/dispatcher-fallback.test.ts
+++ b/tests/dispatcher-fallback.test.ts
@@ -239,6 +239,50 @@ describe('dispatcher fallback', () => {
     expect(reports[0].fallbackFor).toBeUndefined();
   });
 
+  it('does not execute again after an ambiguous background submit failure', async () => {
+    process.env.MOCK_PRIMARY_KEY = 'key-primary';
+    const execute = vi.fn<Provider['execute']>();
+    const provider: Provider = {
+      id: 'primary',
+      displayName: 'Mock primary',
+      tier: 'deep-research',
+      execution: 'background',
+      envVar: 'MOCK_PRIMARY_KEY',
+      execute,
+      submit: async () => {
+        throw new Error('submit response lost');
+      },
+      poll: async () => ({ status: 'running' }),
+      retrieve: async () => ({
+        provider: 'primary',
+        tier: 'deep-research',
+        content: '',
+        citations: [],
+        durationMs: 0,
+      }),
+    };
+    registerProvider(provider);
+
+    const { reports } = await dispatch({
+      config: makeConfig({
+        primary: { apiKey: '$MOCK_PRIMARY_KEY', enabled: true },
+      }),
+      providerIds: ['primary'],
+      query: 'test query',
+      outputDir: tmpDir,
+      mode: 'mixed',
+      credentials: { env: process.env },
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      id: 'primary',
+      status: 'error',
+    });
+    expect(reports[0].error).toContain('remote task may have been accepted');
+  });
+
   it('reports two errors when fallback also fails', async () => {
     process.env.MOCK_PRIMARY_KEY = 'key-primary';
     process.env.MOCK_FALLBACK_FAIL_KEY = 'key-fallback-fail';

--- a/tests/dispatcher-fallback.test.ts
+++ b/tests/dispatcher-fallback.test.ts
@@ -46,6 +46,7 @@ function createSuccessProvider(
     id,
     displayName: `Mock ${id}`,
     tier,
+    execution: 'inline',
     envVar: `MOCK_${id.toUpperCase().replace(/-/g, '_')}_KEY`,
     execute: async (
       _query: string,
@@ -72,6 +73,7 @@ function createFailingProvider(
     id,
     displayName: `Mock ${id}`,
     tier,
+    execution: 'inline',
     envVar: `MOCK_${id.toUpperCase().replace(/-/g, '_')}_KEY`,
     execute: async (): Promise<ProviderResult> => {
       throw new Error(errorMessage);
@@ -380,6 +382,7 @@ describe('dispatcher fallback', () => {
       id: 'error-result',
       displayName: 'Mock error-result',
       tier: 'ai-grounded',
+      execution: 'inline',
       envVar: 'MOCK_PRIMARY_KEY',
       execute: async (
         _query: string,

--- a/tests/dispatcher-metering.test.ts
+++ b/tests/dispatcher-metering.test.ts
@@ -39,6 +39,7 @@ function searchProvider(id: string): Provider {
     id,
     displayName: `Mock ${id}`,
     tier: 'raw-search',
+    execution: 'inline',
     envVar: `MOCK_${id.toUpperCase().replace(/-/g, '_')}_KEY`,
     execute: async (
       _query: string,
@@ -281,6 +282,7 @@ describe('dispatcher: estimated budget reservation', () => {
       id: 'serpapi',
       displayName: 'Mock serpapi',
       tier: 'raw-search',
+      execution: 'inline',
       envVar: 'MOCK_SERPAPI_KEY',
       execute: async (): Promise<ProviderResult> => ({
         provider: 'serpapi',
@@ -323,6 +325,7 @@ describe('dispatcher: estimated budget reservation', () => {
       id: 'serpapi',
       displayName: 'Mock serpapi',
       tier: 'raw-search',
+      execution: 'inline',
       envVar: 'MOCK_SERPAPI_KEY',
       execute: async (): Promise<ProviderResult> => ({
         provider: 'serpapi',

--- a/tests/fixtures/providers/mock-provider.mjs
+++ b/tests/fixtures/providers/mock-provider.mjs
@@ -78,6 +78,7 @@ async function main() {
         id: providerId,
         displayName,
         tier,
+        execution: 'inline',
         // Keyless: the mock never needs a credential, so the dispatcher runs
         // it without any environment setup.
         requiresApiKey: false,

--- a/tests/http-client.test.ts
+++ b/tests/http-client.test.ts
@@ -125,6 +125,32 @@ describe('httpRequest', () => {
     expect(headers['Idempotency-Key']).toBe('run-123');
   });
 
+  it('overrides a caller idempotency header case-insensitively', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({}),
+      text: async () => '{}',
+    });
+    globalThis.fetch = fetchMock;
+
+    await httpRequest('https://api.example.com/data', {
+      method: 'POST',
+      headers: { 'idempotency-key': 'stale-key' },
+      retry: {
+        mode: 'idempotent',
+        idempotencyKey: 'authoritative-key',
+      },
+    });
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers['Idempotency-Key']).toBe('authoritative-key');
+    expect(headers['idempotency-key']).toBeUndefined();
+  });
+
   it('rejects safe retry policy on a mutating request', async () => {
     const fetchMock = vi.fn();
     globalThis.fetch = fetchMock;

--- a/tests/http-client.test.ts
+++ b/tests/http-client.test.ts
@@ -1,5 +1,9 @@
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
-import { httpRequest } from '../src/core/http-client.js';
+import {
+  HttpRequestAbortedError,
+  HttpResponseTooLargeError,
+  httpRequest,
+} from '../src/core/http-client.js';
 
 // Mock constants to reduce retry delays in tests
 vi.mock('../src/constants.js', async (importOriginal) => {
@@ -9,7 +13,7 @@ vi.mock('../src/constants.js', async (importOriginal) => {
     ...original,
     MAX_RETRIES: 2,
     INITIAL_RETRY_DELAY_MS: 10,
-    MAX_RESPONSE_SIZE: 10 * 1024 * 1024,
+    MAX_RESPONSE_SIZE: 1024,
   };
 });
 
@@ -21,6 +25,7 @@ describe('httpRequest', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -63,6 +68,74 @@ describe('httpRequest', () => {
     expect((fetchOptions.headers as Record<string, string>).Authorization).toBe(
       'Bearer sk-test',
     );
+  });
+
+  it('does not retry mutating requests by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: new Headers({}),
+      text: async () => 'Server Error',
+    });
+    globalThis.fetch = fetchMock;
+
+    const response = await httpRequest('https://api.example.com/data', {
+      method: 'POST',
+      body: { query: 'paid request' },
+    });
+
+    expect(response.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('retries a mutating request only with an explicit idempotency key', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: new Headers({}),
+        text: async () => 'Server Error',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({}),
+        text: async () => JSON.stringify({ ok: true }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const response = await httpRequest('https://api.example.com/data', {
+      method: 'POST',
+      body: { query: 'idempotent request' },
+      retry: {
+        mode: 'idempotent',
+        idempotencyKey: 'run-123',
+        maxAttempts: 2,
+        baseDelayMs: 0,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const headers = fetchMock.mock.calls[0][1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers['Idempotency-Key']).toBe('run-123');
+  });
+
+  it('rejects safe retry policy on a mutating request', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      httpRequest('https://api.example.com/data', {
+        method: 'POST',
+        retry: { mode: 'safe' },
+      }),
+    ).rejects.toThrow('Safe retry policy cannot be used with POST');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('timeout via AbortController', async () => {
@@ -128,6 +201,97 @@ describe('httpRequest', () => {
 
     const response = await httpRequest('https://api.example.com/data');
     expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors Retry-After before retrying', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: new Headers({ 'retry-after': '2' }),
+        text: async () => 'Rate limited',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({}),
+        text: async () => JSON.stringify({ ok: true }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const request = httpRequest('https://api.example.com/data', {
+      retry: { mode: 'safe', maxAttempts: 2 },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors an HTTP-date Retry-After and caps the delay', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-04T20:00:00Z'));
+    const retryAt = new Date(Date.now() + 60_000).toUTCString();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        statusText: 'Unavailable',
+        headers: new Headers({ 'retry-after': retryAt }),
+        text: async () => 'Unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({}),
+        text: async () => '{}',
+      });
+    globalThis.fetch = fetchMock;
+
+    const request = httpRequest('https://api.example.com/data', {
+      retry: { mode: 'safe', maxAttempts: 2, maxDelayMs: 500 },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+  });
+
+  it('cancels a retryable response body before the next attempt', async () => {
+    const cancel = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        statusText: 'Unavailable',
+        headers: new Headers({}),
+        body: new ReadableStream({ cancel }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({}),
+        text: async () => '{}',
+      });
+    globalThis.fetch = fetchMock;
+
+    await httpRequest('https://api.example.com/data', {
+      retry: { mode: 'safe', maxAttempts: 2, baseDelayMs: 0 },
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -227,6 +391,59 @@ describe('httpRequest', () => {
 
     const response = await httpRequest<string>('https://api.example.com/data');
     expect(response.data).toBe('Plain text response');
+  });
+
+  it('enforces the byte limit while streaming a 4xx response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('😀'.repeat(300), { status: 400 }));
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      httpRequest('https://api.example.com/data'),
+    ).rejects.toBeInstanceOf(HttpResponseTooLargeError);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an oversized declared response before reading it', async () => {
+    const text = vi.fn();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-length': '1025' }),
+      body: null,
+      text,
+    });
+
+    await expect(
+      httpRequest('https://api.example.com/data'),
+    ).rejects.toBeInstanceOf(HttpResponseTooLargeError);
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it('aborts immediately while waiting to retry', async () => {
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: new Headers({}),
+      text: async () => 'Server Error',
+    });
+
+    const request = httpRequest('https://api.example.com/data', {
+      signal: controller.signal,
+      retry: {
+        mode: 'safe',
+        maxAttempts: 2,
+        baseDelayMs: 10_000,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(request).rejects.toBeInstanceOf(HttpRequestAbortedError);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
   });
 
   it('aborts with external signal', async () => {

--- a/tests/integration/dist-registry.test.ts
+++ b/tests/integration/dist-registry.test.ts
@@ -73,6 +73,7 @@ describe('dist registry sharing (core + node)', () => {
         `  id: '${id}',`,
         "  displayName: 'Dist Lib Provider',",
         "  tier: 'ai-grounded',",
+        "  execution: 'inline',",
         "  envVar: '',",
         '  requiresApiKey: false,',
         '  async execute(query) {',

--- a/tests/mcp-async-metering.test.ts
+++ b/tests/mcp-async-metering.test.ts
@@ -45,6 +45,7 @@ describe('MCP check_async retrieval persists metering', () => {
       id: 'perplexity-sonar-deep',
       displayName: 'Mock deep',
       tier: 'deep-research',
+      execution: 'background',
       envVar: 'MOCK_PPLX_KEY',
       execute: async (): Promise<ProviderResult> => ({
         provider: 'perplexity-sonar-deep',
@@ -61,6 +62,14 @@ describe('MCP check_async retrieval persists metering', () => {
         durationMs: 10,
         usage: { costUsd: 0.42, totalTokens: 100 },
       }),
+      submit: async (query) => ({
+        provider: 'perplexity-sonar-deep',
+        taskId: 'unused',
+        query,
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+      poll: async () => ({ status: 'completed' }),
     };
     registerProvider(provider);
 
@@ -139,6 +148,7 @@ describe('MCP check_async retrieval persists metering', () => {
       id: 'perplexity-sonar-deep',
       displayName: 'Mock deep',
       tier: 'deep-research',
+      execution: 'background',
       envVar: 'MOCK_PPLX_KEY',
       execute: async (): Promise<ProviderResult> => ({
         provider: 'perplexity-sonar-deep',
@@ -154,6 +164,14 @@ describe('MCP check_async retrieval persists metering', () => {
         citations: [],
         durationMs: 1,
       }),
+      submit: async (query) => ({
+        provider: 'perplexity-sonar-deep',
+        taskId: 'unused',
+        query,
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+      poll: async () => ({ status: 'completed' }),
     };
     registerProvider(provider);
     saveAsyncTasks(dir, [
@@ -206,6 +224,7 @@ describe('MCP check_async poll state persistence', () => {
       id: 'mock-async',
       displayName: 'Mock async',
       tier: 'deep-research',
+      execution: 'background',
       envVar: 'MOCK_KEY',
       execute: async (): Promise<ProviderResult> => ({
         provider: 'mock-async',
@@ -218,6 +237,20 @@ describe('MCP check_async poll state persistence', () => {
         status: 'cancelled',
         rawStatus: 'CANCELLED',
         message: 'cancelled by provider',
+      }),
+      submit: async (query) => ({
+        provider: 'mock-async',
+        taskId: 'unused',
+        query,
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+      retrieve: async () => ({
+        provider: 'mock-async',
+        tier: 'deep-research',
+        content: '',
+        citations: [],
+        durationMs: 0,
       }),
     };
     registerProvider(provider);
@@ -254,6 +287,7 @@ describe('MCP check_async poll state persistence', () => {
       id: 'mock-unknown',
       displayName: 'Mock unknown',
       tier: 'deep-research',
+      execution: 'background',
       envVar: 'MOCK_KEY',
       execute: async (): Promise<ProviderResult> => ({
         provider: 'mock-unknown',
@@ -266,6 +300,20 @@ describe('MCP check_async poll state persistence', () => {
         status: 'running',
         rawStatus: 'MIGRATING',
         message: 'Unknown remote status: MIGRATING',
+      }),
+      submit: async (query) => ({
+        provider: 'mock-unknown',
+        taskId: 'unused',
+        query,
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+      retrieve: async () => ({
+        provider: 'mock-unknown',
+        tier: 'deep-research',
+        content: '',
+        citations: [],
+        durationMs: 0,
       }),
     };
     registerProvider(provider);

--- a/tests/node-entry.test.ts
+++ b/tests/node-entry.test.ts
@@ -69,6 +69,7 @@ describe('librarium/node entry', () => {
         `  id: '${id}',`,
         "  displayName: 'Lib Provider',",
         "  tier: 'ai-grounded',",
+        "  execution: 'inline',",
         "  envVar: '',",
         '  requiresApiKey: false,',
         '  async execute(query) {',

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -10,6 +10,7 @@ function provider(id: string, envVar: string): Provider {
     id,
     displayName: id,
     tier: 'llm',
+    execution: 'inline',
     envVar,
     execute: async () => ({
       provider: id,

--- a/tests/provider-selection.test.ts
+++ b/tests/provider-selection.test.ts
@@ -12,6 +12,7 @@ function provider(id: string, envVar: string): Provider {
     id,
     displayName: id,
     tier: 'raw-search',
+    execution: 'inline',
     envVar,
     execute: async () => ({
       provider: id,

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -17,6 +17,7 @@ function createMockProvider(
     id,
     displayName: `Mock ${id}`,
     tier,
+    execution: 'inline',
     envVar: `MOCK_${id.toUpperCase().replace(/-/g, '_')}_KEY`,
     execute: async (
       _query: string,
@@ -61,6 +62,41 @@ describe('registry', () => {
     const provider = createMockProvider('test-provider');
     registerProvider(provider);
     expect(getProvider('test-provider')).toBe(provider);
+  });
+
+  it('rejects an incomplete background provider at runtime', () => {
+    const provider = {
+      ...createMockProvider('incomplete-background', 'deep-research'),
+      execution: 'background',
+      submit: async () => ({
+        provider: 'incomplete-background',
+        taskId: 'task',
+        query: 'query',
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+    } as unknown as Provider;
+
+    expect(() => registerProvider(provider)).toThrow(
+      'must define submit, poll, and retrieve',
+    );
+  });
+
+  it('rejects lifecycle hooks on an inline provider at runtime', () => {
+    const provider = {
+      ...createMockProvider('invalid-inline'),
+      submit: async () => ({
+        provider: 'invalid-inline',
+        taskId: 'task',
+        query: 'query',
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+    } as unknown as Provider;
+
+    expect(() => registerProvider(provider)).toThrow(
+      'cannot define submit, poll, or retrieve',
+    );
   });
 
   it('getProvider returns registered provider', () => {
@@ -152,6 +188,26 @@ describe('registry', () => {
     expect(ids).toContain('openai-chat');
     expect(ids).toContain('gemini-chat');
     expect(ids).toContain('openrouter-chat');
+  });
+
+  it('marks only providers with a complete task lifecycle as background', async () => {
+    await initializeProviders();
+
+    const background = getAllProviders()
+      .filter((provider) => provider.execution === 'background')
+      .map((provider) => provider.id)
+      .sort();
+
+    expect(background).toEqual([
+      'gemini-deep',
+      'openai-research',
+      'perplexity-advanced-deep',
+      'perplexity-deep-research',
+      'perplexity-sonar-deep',
+    ]);
+    expect(
+      getAllProviders().filter((provider) => provider.execution === 'inline'),
+    ).toHaveLength(19);
   });
 
   it('registers llm-tier providers with the llm tier', async () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -99,6 +99,19 @@ describe('registry', () => {
     );
   });
 
+  it('rejects a provider without execute at runtime', () => {
+    const provider = {
+      id: 'missing-execute',
+      displayName: 'Missing Execute',
+      tier: 'raw-search',
+      execution: 'inline',
+      envVar: '',
+      requiresApiKey: false,
+    } as unknown as Provider;
+
+    expect(() => registerProvider(provider)).toThrow('must define execute');
+  });
+
   it('getProvider returns registered provider', () => {
     const provider = createMockProvider('my-provider');
     registerProvider(provider);
@@ -208,6 +221,53 @@ describe('registry', () => {
     expect(
       getAllProviders().filter((provider) => provider.execution === 'inline'),
     ).toHaveLength(19);
+  });
+
+  it('injects credentials into every background built-in', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'unauthorized' } }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await initializeProviders({
+      credentials: {
+        env: {
+          GEMINI_API_KEY: 'gemini-sentinel',
+          OPENAI_API_KEY: 'openai-sentinel',
+          PERPLEXITY_API_KEY: 'perplexity-sentinel',
+        },
+      },
+    });
+
+    const expectedHeaders: Record<string, [string, string]> = {
+      'gemini-deep': ['x-goog-api-key', 'gemini-sentinel'],
+      'openai-research': ['authorization', 'Bearer openai-sentinel'],
+      'perplexity-advanced-deep': [
+        'authorization',
+        'Bearer perplexity-sentinel',
+      ],
+      'perplexity-deep-research': [
+        'authorization',
+        'Bearer perplexity-sentinel',
+      ],
+      'perplexity-sonar-deep': ['authorization', 'Bearer perplexity-sentinel'],
+    };
+
+    for (const [id, [header, expected]] of Object.entries(expectedHeaders)) {
+      fetchMock.mockClear();
+      const provider = getProvider(id);
+      expect(provider?.execution).toBe('background');
+      if (provider?.execution !== 'background') continue;
+
+      await provider.submit('credential check', { timeout: 1 }).catch(() => {});
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const init = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(new Headers(init.headers).get(header)).toBe(expected);
+    }
   });
 
   it('registers llm-tier providers with the llm tier', async () => {

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -17,6 +17,7 @@ vi.mock('../src/adapters/node-registry.js', () => {
     id: 'status-command-mock',
     displayName: 'Status command mock',
     tier: 'deep-research',
+    execution: 'background',
     envVar: '',
     execute: async () => ({
       provider: 'status-command-mock',
@@ -27,6 +28,13 @@ vi.mock('../src/adapters/node-registry.js', () => {
     }),
     poll: (...args) => state.poll(...args),
     retrieve: (...args) => state.retrieve(...args),
+    submit: async (query) => ({
+      provider: 'status-command-mock',
+      taskId: 'unused',
+      query,
+      submittedAt: Date.now(),
+      status: 'pending',
+    }),
   };
   return {
     initializeProviders: vi.fn(async () => ({

--- a/tests/status-reconciliation.test.ts
+++ b/tests/status-reconciliation.test.ts
@@ -25,6 +25,7 @@ describe('status reconciliation', () => {
       id: 'status-reconcile-mock',
       displayName: 'Status reconcile mock',
       tier: 'deep-research',
+      execution: 'background',
       envVar: '',
       execute: async () => ({
         provider: 'status-reconcile-mock',
@@ -36,6 +37,20 @@ describe('status reconciliation', () => {
       poll: async () => ({
         status: 'completed',
         rawStatus: 'COMPLETED',
+      }),
+      submit: async (query) => ({
+        provider: 'status-reconcile-mock',
+        taskId: 'unused',
+        query,
+        submittedAt: Date.now(),
+        status: 'pending',
+      }),
+      retrieve: async () => ({
+        provider: 'status-reconcile-mock',
+        tier: 'deep-research',
+        content: '',
+        citations: [],
+        durationMs: 0,
       }),
     };
     registerProvider(provider);

--- a/tests/workers/core.test.ts
+++ b/tests/workers/core.test.ts
@@ -50,6 +50,7 @@ describe('librarium/core in workerd', () => {
       id: 'worker-mock',
       displayName: 'Worker Mock',
       tier: 'ai-grounded',
+      execution: 'inline',
       envVar: '',
       requiresApiKey: false,
       execute: async (


### PR DESCRIPTION
## Summary

Hardens Librarium's provider and HTTP contracts before the execution architecture is extracted. Providers now declare inline or background execution explicitly, and shared networking defaults prevent unsafe retries and oversized response buffering.

## What's New

### Provider contracts

- Replaces independently optional async hooks with an `execution` discriminated union.
- Requires background providers to implement `execute`, `submit`, `poll`, and `retrieve` together.
- Migrates all built-in, npm, and script providers to the new contract.
- Validates provider contracts at runtime for JavaScript consumers.
- Preserves injected credentials across inline and background provider bases.
- Prevents ambiguous background submission failures from falling through to a second execution.

### HTTP safety

- Streams terminal response bodies through a byte-accurate 10 MB cap, including 4xx responses.
- Makes retry waits abort-aware and adds bounded jitter.
- Honors seconds and HTTP-date `Retry-After` values with a maximum delay.
- Cancels intermediate retry response bodies.
- Retries GET requests safely by default.
- Makes non-GET requests non-retrying unless an explicit idempotency key is supplied.
- Replaces case-insensitive caller idempotency-header variants with the authoritative key.

### Documentation and compatibility

- Updates custom-provider examples and development documentation.
- Documents the breaking provider and `maxRetries` migrations in the changelog.

## Design Decisions

**On background submission failures:** Unknown failures are terminal because a remote paid task may have been accepted even when its handle was lost. Librarium does not issue a second request automatically.

**On compatibility:** This intentionally breaks the programmatic provider and shared HTTP option shapes. The changelog includes the required migration steps.

## Test Plan

- [x] Lint and TypeScript checks
- [x] 726 unit tests
- [x] Package build and declaration generation
- [x] 11 packaged integration tests
- [x] Cloudflare Worker compatibility test
- [x] PTY CLI test suite
- [x] Deep review GO after closing credential and duplicate-submission findings

## Holdbacks

The unified `run.json` store, headless execution service, and provider descriptors are intentionally deferred to follow-up PRs. No live paid-provider request is part of this contracts-only change.