### PR TITLE
refactor: extract headless research run service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1275,7 +1275,7 @@ const run = await executeResearchRun({
 console.log(run.manifest.status, run.sources.length);
 ```
 
-Production defaults are used when `overrides` is omitted. Embedders and tests may independently replace `providerRegistry`, `taskStore`, `httpClient`, or `dispatch`. `onEvent` receives a typed event union and is observational: an event handler failure cannot interrupt dispatch or corrupt persistence. A `postDispatch` callback can add `answer` or `verification` metadata before the manifest reaches its final lifecycle state; callback failures are reported as `post-dispatch-warning` events and do not discard the run.
+Production defaults are used when `overrides` is omitted. Embedders and tests may independently replace `providerRegistry`, `taskStore`, `httpClient`, or `dispatch`. The HTTP override creates run-local copies of built-in and other `ProviderBase` adapters; a registry containing plain-object providers can implement `withHttpClient()` to supply its own run-local projection. `onEvent` receives a typed event union and is observational: an event handler failure cannot interrupt dispatch or corrupt persistence. A `postDispatch` callback can add `answer` or `verification` metadata before the manifest reaches its final lifecycle state; callback failures are reported as `post-dispatch-warning` events and do not discard the run.
 
 ### Custom providers (`librarium/node`)
 

--- a/README.md
+++ b/README.md
@@ -1198,7 +1198,7 @@ The `usage` and `metering` fields are optional. `usage` is reported-only: its `i
 
 ## Library Usage (`librarium/core`)
 
-Everything the CLI does with providers is importable. The `librarium/core` entry exposes the adapters, registry, dispatcher, normalizer, and types -- and returns results **in memory** (writing `run.json`/report files is a CLI concern). The core entry has zero Node-only dependencies: no `node:fs`, no `process.env` access, fetch-based HTTP only. It is tested in workerd (Cloudflare's runtime) on every CI run.
+Everything the CLI does with providers is importable. The `librarium/core` entry exposes the adapters, registry, dispatcher, normalizer, and types, and returns results **in memory**. The core entry has zero Node-only dependencies: no `node:fs`, no `process.env` access, fetch-based HTTP only. It is tested in workerd (Cloudflare's runtime) on every CI run. Node applications that want Librarium's complete durable file-writing lifecycle can use `executeResearchRun()` from `librarium/node`.
 
 ```bash
 npm install librarium
@@ -1246,6 +1246,36 @@ Notes:
 - **Custom providers from the library.** Hand-written providers work anywhere via `registerProvider()` (edge included). npm- and script-based custom providers need Node (module resolution, child processes), so they load through the dedicated `librarium/node` entry -- the same loader the CLI uses. See [Custom providers](#custom-providers-librariumnode).
 - **Async deep-research from the library.** `dispatch` with `mode: 'async'`/`'mixed'` returns `asyncTasks` handles; polling/retrieval is the caller's responsibility. See [Async deep-research](#async-deep-research-from-the-library).
 - **Bring your own persistence.** Core returns data; where it goes (D1, R2, files, nowhere) is up to you.
+
+### Headless durable runs (`librarium/node`)
+
+`executeResearchRun(request, overrides?)` is the shared application service behind the CLI and MCP server. It has no spinner, prompt, stdout, or stderr behavior. The caller supplies an initialized config, selected provider IDs, and an output directory; the service creates and reconciles `run.json`, dispatches providers, writes provider results, deduplicates citations, and writes `prompt.md`, `sources.json`, and `summary.md`.
+
+```ts
+import { initializeProviders } from 'librarium/core';
+import { executeResearchRun } from 'librarium/node';
+
+const credentials = { env: process.env };
+await initializeProviders({ ...config, credentials });
+
+const run = await executeResearchRun({
+  query: 'Compare current deep-research APIs',
+  config,
+  providerIds: ['openai-research'],
+  outputDir: '/absolute/path/to/run',
+  slug: 'compare-current-deep-research-apis',
+  credentials,
+  onEvent(event) {
+    if (event.type === 'dispatch-progress') {
+      renderProgress(event.progress);
+    }
+  },
+});
+
+console.log(run.manifest.status, run.sources.length);
+```
+
+Production defaults are used when `overrides` is omitted. Embedders and tests may independently replace `providerRegistry`, `taskStore`, `httpClient`, or `dispatch`. `onEvent` receives a typed event union and is observational: an event handler failure cannot interrupt dispatch or corrupt persistence. A `postDispatch` callback can add `answer` or `verification` metadata before the manifest reaches its final lifecycle state; callback failures are reported as `post-dispatch-warning` events and do not discard the run.
 
 ### Custom providers (`librarium/node`)
 

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -63,9 +63,17 @@ export abstract class ProviderBase {
     this.httpClient = options.httpClient ?? httpRequest;
   }
 
-  /** Override only the transport, preserving credentials and provider config. */
-  setHttpClient(httpClient: HttpClient = httpRequest): void {
-    this.httpClient = httpClient;
+  /**
+   * Create a run-local provider instance with a different transport while
+   * preserving the initialized credentials and adapter configuration.
+   */
+  withHttpClient(httpClient: HttpClient): this {
+    const clone = Object.assign(
+      Object.create(Object.getPrototypeOf(this)) as this,
+      this,
+    );
+    clone.httpClient = httpClient;
+    return clone;
   }
 
   /**

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -4,6 +4,7 @@ import {
   resolveCredential,
 } from '../core/credentials.js';
 import {
+  type HttpClient,
   type HttpRequestOptions,
   type HttpResponse,
   httpRequest,
@@ -22,6 +23,7 @@ import type {
 export interface BaseProviderOptions {
   apiKey?: string;
   credentials?: CredentialContext;
+  httpClient?: HttpClient;
 }
 
 /**
@@ -39,10 +41,12 @@ export abstract class ProviderBase {
 
   private apiKeyRef?: string;
   private credentials: CredentialContext;
+  private httpClient: HttpClient;
 
   constructor(options: BaseProviderOptions = {}) {
     this.apiKeyRef = options.apiKey;
     this.credentials = options.credentials ?? {};
+    this.httpClient = options.httpClient ?? httpRequest;
   }
 
   get displayName(): string {
@@ -56,6 +60,12 @@ export abstract class ProviderBase {
   configure(options: BaseProviderOptions): void {
     this.apiKeyRef = options.apiKey;
     this.credentials = options.credentials ?? {};
+    this.httpClient = options.httpClient ?? httpRequest;
+  }
+
+  /** Override only the transport, preserving credentials and provider config. */
+  setHttpClient(httpClient: HttpClient = httpRequest): void {
+    this.httpClient = httpClient;
   }
 
   /**
@@ -79,7 +89,7 @@ export abstract class ProviderBase {
     url: string,
     options: HttpRequestOptions = {},
   ): Promise<HttpResponse<T>> {
-    return httpRequest<T>(url, options);
+    return this.httpClient<T>(url, options);
   }
 
   /**

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -3,6 +3,7 @@ import {
   type CredentialContext,
   describeCredentialReference,
 } from '../core/credentials.js';
+import type { HttpClient } from '../core/http-client.js';
 import { getMeteringKind } from '../core/metering.js';
 import {
   providerCredentialRef,
@@ -44,6 +45,7 @@ export type ProviderInitConfig = Partial<
   >
 > & {
   credentials?: CredentialContext;
+  httpClient?: HttpClient;
 };
 
 export interface ProviderInitResult {
@@ -176,6 +178,7 @@ export async function initializeProviders(
   providers.clear();
   const providerConfig = config.providers ?? {};
   const credentials = config.credentials ?? {};
+  const httpClient = config.httpClient;
   const llmWebSearch = config.defaults?.llmWebSearch ?? true;
 
   const builtIns: Provider[] = [
@@ -246,6 +249,7 @@ export async function initializeProviders(
       provider.configure({
         apiKey: providerConfig[provider.id]?.apiKey,
         credentials,
+        httpClient,
       });
     }
     provider.source = 'builtin';

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -409,6 +409,20 @@ export async function executeRun(
               );
               return;
             }
+            if (event.type === 'dispatch-completed') {
+              spinner.stop();
+              if (live) {
+                live.resolveRemaining(event.reports);
+                live.stop();
+              } else {
+                for (const report of event.reports) {
+                  if (report.status === 'skipped') {
+                    printLine(formatProviderLine(report, widths, color));
+                  }
+                }
+              }
+              return;
+            }
             if (event.type !== 'dispatch-progress') return;
             const { progress } = event;
             if (live) {
@@ -459,22 +473,6 @@ export async function executeRun(
                 })
             : undefined,
         });
-
-      spinner.stop();
-
-      if (live) {
-        // Rows that never emitted events (e.g. skipped providers) resolve
-        // from the final reports before the block is finalized.
-        live.resolveRemaining(reports);
-        live.stop();
-      } else {
-        // Skipped providers never emit progress events — show them too.
-        for (const report of reports) {
-          if (report.status === 'skipped') {
-            printLine(formatProviderLine(report, widths, color));
-          }
-        }
-      }
 
       // Determine exit code. When a primary fails but its fallback succeeds,
       // the user's intent was fully satisfied — exclude the recovered primary's

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -49,6 +49,7 @@ import {
   formatRunSummary,
   hyperlink,
   isColorEnabled,
+  type LineWidths,
   shortenHomePath,
 } from './run-format.js';
 
@@ -410,17 +411,13 @@ export async function executeRun(
               return;
             }
             if (event.type === 'dispatch-completed') {
-              spinner.stop();
-              if (live) {
-                live.resolveRemaining(event.reports);
-                live.stop();
-              } else {
-                for (const report of event.reports) {
-                  if (report.status === 'skipped') {
-                    printLine(formatProviderLine(report, widths, color));
-                  }
-                }
-              }
+              finalizeDispatchPresentation(event.reports, {
+                spinner,
+                live,
+                printLine,
+                widths,
+                color,
+              });
               return;
             }
             if (event.type !== 'dispatch-progress') return;
@@ -616,6 +613,34 @@ export async function executeRun(
       spinner.fail(message);
       process.exitCode = 2;
       return { exitCode: 2 };
+    }
+  }
+}
+
+export interface DispatchPresentation {
+  spinner: { stop(): unknown };
+  live: Pick<LiveRunTable, 'resolveRemaining' | 'stop'> | null;
+  printLine: (line: string) => void;
+  widths: LineWidths;
+  color: boolean;
+}
+
+/** Finalize provider rows before artifacts and post-dispatch hooks can print. */
+export function finalizeDispatchPresentation(
+  reports: ProviderReport[],
+  presentation: DispatchPresentation,
+): void {
+  presentation.spinner.stop();
+  if (presentation.live) {
+    presentation.live.resolveRemaining(reports);
+    presentation.live.stop();
+    return;
+  }
+  for (const report of reports) {
+    if (report.status === 'skipped') {
+      presentation.printLine(
+        formatProviderLine(report, presentation.widths, presentation.color),
+      );
     }
   }
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import * as p from '@clack/prompts';
 import { type Command, InvalidArgumentError } from 'commander';
 import ora from 'ora';
@@ -15,29 +15,14 @@ import {
   ESTIMATE_BUDGET_SKIP_REASON,
 } from '../core/budget.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
-import { dispatch } from '../core/dispatcher.js';
-import { safeWriteFile } from '../core/fs-utils.js';
-import { deduplicateSources } from '../core/normalizer.js';
-import {
-  buildPrompt,
-  generateSlug,
-  resolveOutputDir,
-} from '../core/prompt-builder.js';
+import { generateSlug, resolveOutputDir } from '../core/prompt-builder.js';
 import {
   ProviderSelectionError,
   resolveProviderSelection,
 } from '../core/provider-selection.js';
-import {
-  applyRunLifecycle,
-  createRunManifest,
-  markRunFailed,
-  mutateRunManifest,
-  upsertProviderReport,
-} from '../core/run-manifest.js';
-import { generateSummary } from '../core/synthesis.js';
+import { executeResearchRun } from '../core/research-run.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
 import type {
-  Citation,
   Config,
   DeduplicatedSource,
   Defaults,
@@ -222,8 +207,6 @@ export async function executeRun(
       prettyStream.write(`${line}\n`);
       if (wasSpinning) spinner.start();
     };
-    let activeOutputDir: string | undefined;
-
     try {
       const globalConfig = loadConfig();
       const projectConfig = loadProjectConfig(process.cwd());
@@ -342,30 +325,6 @@ export async function executeRun(
       const baseDir = resolve(config.defaults.outputDir);
       const outputDir = resolveOutputDir(baseDir, slug);
       mkdirSync(outputDir, { recursive: true });
-      activeOutputDir = outputDir;
-
-      // Write prompt (with refined variants recorded for reproducibility)
-      let promptDoc = buildPrompt(query);
-      if (refined) {
-        promptDoc += `\n\n## Refined Query Variants\n\n- deep-research: ${refined.tierQueries['deep-research']}\n- ai-grounded: ${refined.tierQueries['ai-grounded']}\n- raw-search: ${refined.tierQueries['raw-search']}\n`;
-      }
-      safeWriteFile(join(outputDir, 'prompt.md'), promptDoc);
-
-      // run.json is a live write-ahead manifest. It exists before any provider
-      // can create a paid remote task, and remains authoritative thereafter.
-      const timestamp = Math.floor(Date.now() / 1000);
-      createRunManifest(outputDir, {
-        status: 'running',
-        timestamp,
-        slug,
-        query,
-        mode: config.defaults.mode,
-        outputDir,
-        providers: [],
-        sources: { total: 0, unique: 0, file: 'sources.json' },
-        exitCode: null,
-        refinedQueries: refined?.tierQueries,
-      });
 
       // Column widths cover both primaries and any configured fallbacks so
       // lines stay aligned if a fallback fires mid-run.
@@ -431,62 +390,75 @@ export async function executeRun(
         config.defaults.maxEstimatedCostUsd,
       );
 
-      const dispatchStartedAt = Date.now();
-      const { reports, results, asyncTasks } = await dispatch({
-        config,
-        providerIds,
-        query,
-        tierQueries: refined?.tierQueries,
-        mode: config.defaults.mode,
-        credentials,
-        budget,
-        estimatedBudget,
-        allowFallbacks: opts.fallback !== false,
-        onProgress: (event) => {
-          if (event.report) {
-            upsertProviderReport(outputDir, event.report, event.task);
-          }
-          if (live) {
-            switch (event.event) {
+      const { reports, sources, totalCitations, totalDurationMs, manifest } =
+        await executeResearchRun({
+          query,
+          config,
+          providerIds,
+          outputDir,
+          slug,
+          tierQueries: refined?.tierQueries,
+          credentials,
+          budget,
+          estimatedBudget,
+          allowFallbacks: opts.fallback !== false,
+          onEvent: (event) => {
+            if (event.type === 'post-dispatch-warning') {
+              console.error(
+                `[librarium] warning: post-dispatch hook failed (${event.message})`,
+              );
+              return;
+            }
+            if (event.type !== 'dispatch-progress') return;
+            const { progress } = event;
+            if (live) {
+              switch (progress.event) {
+                case 'started':
+                  live.markStarted(progress.providerId);
+                  break;
+                case 'fallback-started':
+                  live.addFallback(
+                    progress.report?.id ?? progress.providerId,
+                    progress.providerId,
+                    tierById.get(progress.providerId) ?? 'raw-search',
+                  );
+                  break;
+                case 'completed':
+                case 'error':
+                case 'async-submitted':
+                  if (progress.report) live.resolve(progress.report);
+                  break;
+              }
+              return;
+            }
+            switch (progress.event) {
               case 'started':
-                live.markStarted(event.providerId);
+                running.add(progress.providerId);
                 break;
               case 'fallback-started':
-                live.addFallback(
-                  event.report?.id ?? event.providerId,
-                  event.providerId,
-                  tierById.get(event.providerId) ?? 'raw-search',
-                );
+                printLine(formatFallbackNotice(progress.providerId, color));
+                running.add(progress.providerId);
                 break;
               case 'completed':
               case 'error':
               case 'async-submitted':
-                if (event.report) live.resolve(event.report);
+                running.delete(progress.providerId);
+                if (progress.report) {
+                  printLine(formatProviderLine(progress.report, widths, color));
+                }
                 break;
             }
-            return;
-          }
-          switch (event.event) {
-            case 'started':
-              running.add(event.providerId);
-              break;
-            case 'fallback-started':
-              printLine(formatFallbackNotice(event.providerId, color));
-              running.add(event.providerId);
-              break;
-            case 'completed':
-            case 'error':
-            case 'async-submitted':
-              running.delete(event.providerId);
-              if (event.report) {
-                printLine(formatProviderLine(event.report, widths, color));
-              }
-              break;
-          }
-          spinner.text = spinnerText();
-        },
-      });
-      const totalDurationMs = Date.now() - dispatchStartedAt;
+            spinner.text = spinnerText();
+          },
+          postDispatch: hooks?.postDispatch
+            ? async (context) =>
+                hooks.postDispatch?.({
+                  ...context,
+                  color,
+                  printLine,
+                })
+            : undefined,
+        });
 
       spinner.stop();
 
@@ -504,47 +476,6 @@ export async function executeRun(
         }
       }
 
-      writeProviderOutputs(outputDir, reports, results);
-
-      // Collect all citations for dedup
-      const allCitations: Citation[] = results.flatMap((result) =>
-        result.status === 'success' ? result.citations : [],
-      );
-
-      const sources = deduplicateSources(allCitations);
-
-      // Write sources.json
-      safeWriteFile(
-        join(outputDir, 'sources.json'),
-        JSON.stringify(sources, null, 2),
-      );
-
-      // Post-dispatch hook (e.g. `librarium answer` grounded synthesis). It
-      // owns its own fail-open behavior; a throw here must never lose the run.
-      let manifestExtra: Partial<Pick<RunManifest, 'answer' | 'verification'>> =
-        {};
-      if (hooks?.postDispatch) {
-        try {
-          const hookResult = await hooks.postDispatch({
-            query,
-            config,
-            results,
-            reports,
-            sources,
-            outputDir,
-            color,
-            printLine,
-          });
-          if (hookResult?.manifestExtra) {
-            manifestExtra = hookResult.manifestExtra;
-          }
-        } catch (e) {
-          console.error(
-            `[librarium] warning: post-dispatch hook failed (${e instanceof Error ? e.message : String(e)})`,
-          );
-        }
-      }
-
       // Determine exit code. When a primary fails but its fallback succeeds,
       // the user's intent was fully satisfied — exclude the recovered primary's
       // error report so it doesn't inflate the failure count.
@@ -556,36 +487,8 @@ export async function executeRun(
       const effectiveReports = reports.filter(
         (r) => !recoveredPrimaries.has(r.id),
       );
-      const manifest = mutateRunManifest(outputDir, (current) => {
-        const tasks = new Map(
-          current.providers
-            .filter((provider) => provider.task)
-            .map((provider) => [provider.id, provider.task]),
-        );
-        current.providers = reports.map((report) => ({
-          ...report,
-          ...(tasks.get(report.id) ? { task: tasks.get(report.id) } : {}),
-        }));
-        current.sources = {
-          total: allCitations.length,
-          unique: sources.length,
-          file: 'sources.json',
-        };
-        Object.assign(current, manifestExtra);
-        applyRunLifecycle(current);
-      });
       // Awaiting background work is intentionally non-terminal.
       const exitCode = manifest.exitCode ?? 0;
-
-      // Write summary
-      const summary = generateSummary({
-        query,
-        reports,
-        sources,
-        asyncTasks,
-        timestamp,
-      });
-      safeWriteFile(join(outputDir, 'summary.md'), summary);
 
       // Print summary (exclude recovered primaries so they don't show as failures)
       const successful = effectiveReports.filter((r) => r.status === 'success');
@@ -669,7 +572,7 @@ export async function executeRun(
         failed: failed.length,
         pending: pending.length,
         uniqueSources: sources.length,
-        totalCitations: allCitations.length,
+        totalCitations,
         outputDir,
         color,
         totalDurationMs,
@@ -712,13 +615,6 @@ export async function executeRun(
       return { exitCode, outputDir };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      if (activeOutputDir) {
-        try {
-          markRunFailed(activeOutputDir, message);
-        } catch {
-          // Preserve the original failure; manifest diagnostics are best effort.
-        }
-      }
       spinner.fail(message);
       process.exitCode = 2;
       return { exitCode: 2 };
@@ -751,40 +647,5 @@ export function openPath(target: string): void {
     child.unref();
   } catch {
     // Best-effort only.
-  }
-}
-
-function writeProviderOutputs(
-  outputDir: string,
-  reports: ProviderReport[],
-  results: ProviderDispatchResult[],
-): void {
-  for (const result of results) {
-    const report = reports.find(
-      (candidate) =>
-        candidate.id === result.provider &&
-        candidate.fallbackFor === result.fallbackFor,
-    );
-    if (!report?.outputFile || !report.metaFile) continue;
-
-    safeWriteFile(join(outputDir, report.outputFile), result.text);
-    safeWriteFile(
-      join(outputDir, report.metaFile),
-      JSON.stringify(
-        {
-          provider: result.provider,
-          tier: result.tier,
-          model: result.model,
-          durationMs: result.durationMs,
-          citationCount: result.citations.length,
-          tokenUsage: result.tokenUsage,
-          usage: result.usage,
-          metering: result.metering,
-          citations: result.citations,
-        },
-        null,
-        2,
-      ),
-    );
   }
 }

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -60,7 +60,15 @@ export interface DispatchOptions {
    * repository benchmark, can disable fallback dispatch explicitly.
    */
   allowFallbacks?: boolean;
+  /** Provider lookup dependency. Defaults to Librarium's process registry. */
+  providerRegistry?: ProviderLookup;
 }
+
+export interface ProviderLookup {
+  getProvider(id: string): Provider | undefined;
+}
+
+export const defaultProviderLookup: ProviderLookup = { getProvider };
 
 export interface DispatchResult {
   reports: ProviderReport[];
@@ -94,6 +102,7 @@ export async function dispatch(
     budget,
     estimatedBudget,
   } = options;
+  const providerRegistry = options.providerRegistry ?? defaultProviderLookup;
   const queryForTier = (tier: Provider['tier']): string =>
     options.tierQueries?.[tier] ?? query;
   // Single metering normalization path: static kind + network-free estimate +
@@ -176,7 +185,7 @@ export async function dispatch(
     const fallbackId = config.providers[id]?.fallback;
     if (!fallbackId) return null;
 
-    const fallbackProvider = getProvider(fallbackId);
+    const fallbackProvider = providerRegistry.getProvider(fallbackId);
     if (!fallbackProvider) return null;
 
     const fallbackConfig = config.providers[fallbackId];
@@ -289,7 +298,7 @@ export async function dispatch(
 
   const tasks = providerIds.map((id) =>
     limit(async (): Promise<void> => {
-      const provider = getProvider(id);
+      const provider = providerRegistry.getProvider(id);
       if (!provider) {
         const metering = meteringFor(id);
         results.push({

--- a/src/core/http-client.ts
+++ b/src/core/http-client.ts
@@ -43,6 +43,12 @@ export interface HttpResponse<T = unknown> {
   durationMs: number;
 }
 
+/** Injectable transport contract used by providers and application services. */
+export type HttpClient = <T = unknown>(
+  url: string,
+  options?: HttpRequestOptions,
+) => Promise<HttpResponse<T>>;
+
 export class HttpRequestAbortedError extends Error {
   constructor() {
     super('Request aborted');

--- a/src/core/research-run.ts
+++ b/src/core/research-run.ts
@@ -36,17 +36,12 @@ import { generateSummary } from './synthesis.js';
 
 export interface ProviderRegistry extends ProviderLookup {
   getAllProviders(): Provider[];
-  configureHttpClient?(httpClient: HttpClient): void;
+  withHttpClient?(httpClient: HttpClient): ProviderRegistry;
 }
 
 export const defaultProviderRegistry: ProviderRegistry = {
   getProvider,
   getAllProviders,
-  configureHttpClient: (httpClient) => {
-    for (const provider of getAllProviders()) {
-      if (provider instanceof ProviderBase) provider.setHttpClient(httpClient);
-    }
-  },
 };
 
 export interface RunManifestStore {
@@ -66,6 +61,7 @@ export const defaultRunManifestStore: RunManifestStore = {
 export type ResearchRunEvent =
   | { type: 'manifest-created'; manifest: RunManifest }
   | { type: 'dispatch-progress'; progress: ProgressEvent }
+  | { type: 'dispatch-completed'; reports: ProviderReport[] }
   | { type: 'post-dispatch-warning'; message: string }
   | { type: 'completed'; manifest: RunManifest }
   | { type: 'failed'; outputDir: string; error: Error };
@@ -81,7 +77,6 @@ export interface ResearchRunPostDispatchContext {
 
 export interface ResearchRunPostDispatchResult {
   manifestExtra?: Partial<Pick<RunManifest, 'answer' | 'verification'>>;
-  answerText?: string;
 }
 
 export interface ExecuteResearchRunRequest {
@@ -95,7 +90,7 @@ export interface ExecuteResearchRunRequest {
   budget?: BudgetTracker;
   estimatedBudget?: EstimateBudgetTracker;
   allowFallbacks?: boolean;
-  onEvent?: (event: ResearchRunEvent) => void;
+  onEvent?: (event: ResearchRunEvent) => void | Promise<void>;
   postDispatch?: (
     context: ResearchRunPostDispatchContext,
   ) => Promise<ResearchRunPostDispatchResult | undefined>;
@@ -138,7 +133,8 @@ export async function executeResearchRun(
   const now = dependencies.now ?? Date.now;
   const emit = (event: ResearchRunEvent): void => {
     try {
-      request.onEvent?.(event);
+      const observation = request.onEvent?.(event);
+      if (observation) void Promise.resolve(observation).catch(() => {});
     } catch {
       // Observers are presentation adapters and cannot compromise persistence.
     }
@@ -159,8 +155,6 @@ export async function executeResearchRun(
     }
     prompt += '\n';
   }
-  safeWriteFile(join(request.outputDir, 'prompt.md'), prompt);
-
   const timestamp = Math.floor(now() / 1000);
   const created = taskStore.create(request.outputDir, {
     status: 'running',
@@ -177,17 +171,10 @@ export async function executeResearchRun(
   emit({ type: 'manifest-created', manifest: created });
 
   try {
-    if (dependencies.httpClient) {
-      if (providerRegistry.configureHttpClient) {
-        providerRegistry.configureHttpClient(dependencies.httpClient);
-      } else {
-        for (const provider of providerRegistry.getAllProviders()) {
-          if (provider instanceof ProviderBase) {
-            provider.setHttpClient(dependencies.httpClient);
-          }
-        }
-      }
-    }
+    safeWriteFile(join(request.outputDir, 'prompt.md'), prompt);
+    const runRegistry = dependencies.httpClient
+      ? registryWithHttpClient(providerRegistry, dependencies.httpClient)
+      : providerRegistry;
 
     const dispatchStartedAt = now();
     const { reports, results, asyncTasks } = await dispatchRun({
@@ -200,7 +187,7 @@ export async function executeResearchRun(
       budget: request.budget,
       estimatedBudget: request.estimatedBudget,
       allowFallbacks: request.allowFallbacks,
-      providerRegistry,
+      providerRegistry: runRegistry,
       onProgress: (progress) => {
         if (progress.report) {
           taskStore.upsertProviderReport(
@@ -213,6 +200,7 @@ export async function executeResearchRun(
       },
     });
     const totalDurationMs = now() - dispatchStartedAt;
+    emit({ type: 'dispatch-completed', reports });
 
     writeProviderOutputs(request.outputDir, reports, results);
     const allCitations: Citation[] = results.flatMap((result) =>
@@ -309,6 +297,31 @@ export async function executeResearchRun(
     emit({ type: 'failed', outputDir: request.outputDir, error: normalized });
     throw error;
   }
+}
+
+function registryWithHttpClient(
+  registry: ProviderRegistry,
+  httpClient: HttpClient,
+): ProviderRegistry {
+  if (registry.withHttpClient) return registry.withHttpClient(httpClient);
+
+  const clones = new WeakMap<Provider, Provider>();
+  const runLocal = (provider: Provider | undefined): Provider | undefined => {
+    if (!provider || !(provider instanceof ProviderBase)) return provider;
+    const existing = clones.get(provider);
+    if (existing) return existing;
+    const clone = provider.withHttpClient(httpClient);
+    clones.set(provider, clone);
+    return clone;
+  };
+
+  return {
+    getProvider: (id) => runLocal(registry.getProvider(id)),
+    getAllProviders: () =>
+      registry
+        .getAllProviders()
+        .map((provider) => runLocal(provider) as Provider),
+  };
 }
 
 function writeProviderOutputs(

--- a/src/core/research-run.ts
+++ b/src/core/research-run.ts
@@ -1,0 +1,347 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { ProviderBase } from '../adapters/base.js';
+import { getAllProviders, getProvider } from '../adapters/index.js';
+import type {
+  Citation,
+  Config,
+  DeduplicatedSource,
+  ProgressEvent,
+  Provider,
+  ProviderDispatchResult,
+  ProviderReport,
+  RunManifest,
+} from '../types.js';
+import type { BudgetTracker, EstimateBudgetTracker } from './budget.js';
+import type { CredentialContext } from './credentials.js';
+import {
+  type DispatchOptions,
+  type DispatchResult,
+  dispatch,
+  type ProviderLookup,
+} from './dispatcher.js';
+import { safeWriteFile } from './fs-utils.js';
+import type { HttpClient } from './http-client.js';
+import { deduplicateSources } from './normalizer.js';
+import { buildPrompt } from './prompt-builder.js';
+import {
+  applyRunLifecycle,
+  createRunManifest,
+  markRunFailed,
+  mutateRunManifest,
+  toRunTaskState,
+  upsertProviderReport,
+} from './run-manifest.js';
+import { generateSummary } from './synthesis.js';
+
+export interface ProviderRegistry extends ProviderLookup {
+  getAllProviders(): Provider[];
+  configureHttpClient?(httpClient: HttpClient): void;
+}
+
+export const defaultProviderRegistry: ProviderRegistry = {
+  getProvider,
+  getAllProviders,
+  configureHttpClient: (httpClient) => {
+    for (const provider of getAllProviders()) {
+      if (provider instanceof ProviderBase) provider.setHttpClient(httpClient);
+    }
+  },
+};
+
+export interface RunManifestStore {
+  create: typeof createRunManifest;
+  mutate: typeof mutateRunManifest;
+  upsertProviderReport: typeof upsertProviderReport;
+  markFailed: typeof markRunFailed;
+}
+
+export const defaultRunManifestStore: RunManifestStore = {
+  create: createRunManifest,
+  mutate: mutateRunManifest,
+  upsertProviderReport,
+  markFailed: markRunFailed,
+};
+
+export type ResearchRunEvent =
+  | { type: 'manifest-created'; manifest: RunManifest }
+  | { type: 'dispatch-progress'; progress: ProgressEvent }
+  | { type: 'post-dispatch-warning'; message: string }
+  | { type: 'completed'; manifest: RunManifest }
+  | { type: 'failed'; outputDir: string; error: Error };
+
+export interface ResearchRunPostDispatchContext {
+  query: string;
+  config: Config;
+  results: ProviderDispatchResult[];
+  reports: ProviderReport[];
+  sources: DeduplicatedSource[];
+  outputDir: string;
+}
+
+export interface ResearchRunPostDispatchResult {
+  manifestExtra?: Partial<Pick<RunManifest, 'answer' | 'verification'>>;
+  answerText?: string;
+}
+
+export interface ExecuteResearchRunRequest {
+  query: string;
+  config: Config;
+  providerIds: string[];
+  outputDir: string;
+  slug: string;
+  credentials?: CredentialContext;
+  tierQueries?: Partial<Record<Provider['tier'], string>>;
+  budget?: BudgetTracker;
+  estimatedBudget?: EstimateBudgetTracker;
+  allowFallbacks?: boolean;
+  onEvent?: (event: ResearchRunEvent) => void;
+  postDispatch?: (
+    context: ResearchRunPostDispatchContext,
+  ) => Promise<ResearchRunPostDispatchResult | undefined>;
+}
+
+export interface ExecuteResearchRunDependencies {
+  providerRegistry?: ProviderRegistry;
+  taskStore?: RunManifestStore;
+  httpClient?: HttpClient;
+  dispatch?: (options: DispatchOptions) => Promise<DispatchResult>;
+  now?: () => number;
+}
+
+export interface ResearchRunResult {
+  manifest: RunManifest;
+  reports: ProviderReport[];
+  results: ProviderDispatchResult[];
+  asyncTasks: DispatchResult['asyncTasks'];
+  sources: DeduplicatedSource[];
+  totalCitations: number;
+  totalDurationMs: number;
+}
+
+/**
+ * Execute the durable, presentation-free portion of a research run.
+ *
+ * Callers own configuration, provider selection, consent, and presentation.
+ * This service owns the write-ahead manifest, dispatch, artifacts, lifecycle,
+ * and structured events. All dependencies have production defaults and may be
+ * overridden independently for embedding and tests.
+ */
+export async function executeResearchRun(
+  request: ExecuteResearchRunRequest,
+  dependencies: ExecuteResearchRunDependencies = {},
+): Promise<ResearchRunResult> {
+  const providerRegistry =
+    dependencies.providerRegistry ?? defaultProviderRegistry;
+  const taskStore = dependencies.taskStore ?? defaultRunManifestStore;
+  const dispatchRun = dependencies.dispatch ?? dispatch;
+  const now = dependencies.now ?? Date.now;
+  const emit = (event: ResearchRunEvent): void => {
+    try {
+      request.onEvent?.(event);
+    } catch {
+      // Observers are presentation adapters and cannot compromise persistence.
+    }
+  };
+
+  mkdirSync(request.outputDir, { recursive: true });
+  let prompt = buildPrompt(request.query);
+  if (request.tierQueries) {
+    prompt += '\n\n## Refined Query Variants\n';
+    for (const tier of [
+      'deep-research',
+      'ai-grounded',
+      'raw-search',
+      'llm',
+    ] as const) {
+      const variant = request.tierQueries[tier];
+      if (variant) prompt += `\n- ${tier}: ${variant}`;
+    }
+    prompt += '\n';
+  }
+  safeWriteFile(join(request.outputDir, 'prompt.md'), prompt);
+
+  const timestamp = Math.floor(now() / 1000);
+  const created = taskStore.create(request.outputDir, {
+    status: 'running',
+    timestamp,
+    slug: request.slug,
+    query: request.query,
+    mode: request.config.defaults.mode,
+    outputDir: request.outputDir,
+    providers: [],
+    sources: { total: 0, unique: 0, file: 'sources.json' },
+    exitCode: null,
+    refinedQueries: request.tierQueries,
+  });
+  emit({ type: 'manifest-created', manifest: created });
+
+  try {
+    if (dependencies.httpClient) {
+      if (providerRegistry.configureHttpClient) {
+        providerRegistry.configureHttpClient(dependencies.httpClient);
+      } else {
+        for (const provider of providerRegistry.getAllProviders()) {
+          if (provider instanceof ProviderBase) {
+            provider.setHttpClient(dependencies.httpClient);
+          }
+        }
+      }
+    }
+
+    const dispatchStartedAt = now();
+    const { reports, results, asyncTasks } = await dispatchRun({
+      config: request.config,
+      providerIds: request.providerIds,
+      query: request.query,
+      tierQueries: request.tierQueries,
+      mode: request.config.defaults.mode,
+      credentials: request.credentials,
+      budget: request.budget,
+      estimatedBudget: request.estimatedBudget,
+      allowFallbacks: request.allowFallbacks,
+      providerRegistry,
+      onProgress: (progress) => {
+        if (progress.report) {
+          taskStore.upsertProviderReport(
+            request.outputDir,
+            progress.report,
+            progress.task,
+          );
+        }
+        emit({ type: 'dispatch-progress', progress });
+      },
+    });
+    const totalDurationMs = now() - dispatchStartedAt;
+
+    writeProviderOutputs(request.outputDir, reports, results);
+    const allCitations: Citation[] = results.flatMap((result) =>
+      result.status === 'success' ? result.citations : [],
+    );
+    const sources = deduplicateSources(allCitations);
+    safeWriteFile(
+      join(request.outputDir, 'sources.json'),
+      JSON.stringify(sources, null, 2),
+    );
+
+    let manifestExtra: ResearchRunPostDispatchResult['manifestExtra'] = {};
+    if (request.postDispatch) {
+      try {
+        manifestExtra =
+          (
+            await request.postDispatch({
+              query: request.query,
+              config: request.config,
+              results,
+              reports,
+              sources,
+              outputDir: request.outputDir,
+            })
+          )?.manifestExtra ?? {};
+      } catch (error) {
+        emit({
+          type: 'post-dispatch-warning',
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const taskByProvider = new Map(
+      asyncTasks.map((task) => [task.provider, toRunTaskState(task)]),
+    );
+    const manifest = taskStore.mutate(request.outputDir, (current) => {
+      const persistedTasks = new Map(
+        current.providers
+          .filter((provider) => provider.task)
+          .map((provider) => [provider.id, provider.task]),
+      );
+      current.providers = reports.map((report) => ({
+        ...report,
+        ...((report.task ??
+        taskByProvider.get(report.id) ??
+        persistedTasks.get(report.id))
+          ? {
+              task:
+                report.task ??
+                taskByProvider.get(report.id) ??
+                persistedTasks.get(report.id),
+            }
+          : {}),
+      }));
+      current.sources = {
+        total: allCitations.length,
+        unique: sources.length,
+        file: 'sources.json',
+      };
+      Object.assign(current, manifestExtra);
+      applyRunLifecycle(current, now());
+    });
+
+    safeWriteFile(
+      join(request.outputDir, 'summary.md'),
+      generateSummary({
+        query: request.query,
+        reports,
+        sources,
+        asyncTasks,
+        timestamp,
+      }),
+    );
+    emit({ type: 'completed', manifest });
+
+    return {
+      manifest,
+      reports,
+      results,
+      asyncTasks,
+      sources,
+      totalCitations: allCitations.length,
+      totalDurationMs,
+    };
+  } catch (error) {
+    const normalized =
+      error instanceof Error ? error : new Error(String(error));
+    try {
+      taskStore.markFailed(request.outputDir, normalized.message, now());
+    } catch {
+      // Preserve the original orchestration failure.
+    }
+    emit({ type: 'failed', outputDir: request.outputDir, error: normalized });
+    throw error;
+  }
+}
+
+function writeProviderOutputs(
+  outputDir: string,
+  reports: ProviderReport[],
+  results: ProviderDispatchResult[],
+): void {
+  for (const result of results) {
+    const report = reports.find(
+      (candidate) =>
+        candidate.id === result.provider &&
+        candidate.fallbackFor === result.fallbackFor,
+    );
+    if (!report?.outputFile || !report.metaFile) continue;
+
+    safeWriteFile(join(outputDir, report.outputFile), result.text);
+    safeWriteFile(
+      join(outputDir, report.metaFile),
+      JSON.stringify(
+        {
+          provider: result.provider,
+          tier: result.tier,
+          model: result.model,
+          durationMs: result.durationMs,
+          citationCount: result.citations.length,
+          tokenUsage: result.tokenUsage,
+          usage: result.usage,
+          metering: result.metering,
+          citations: result.citations,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}

--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import {
   getAllProviders,
   initializeProviders,
@@ -6,11 +6,7 @@ import {
 import { type RefinedQueries, refineQuery } from '../commands/refine.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import type { CredentialContext } from '../core/credentials.js';
-import { dispatch } from '../core/dispatcher.js';
-import { safeWriteFile } from '../core/fs-utils.js';
-import { deduplicateSources } from '../core/normalizer.js';
 import {
-  buildPrompt,
   type CreateRunDirDeps,
   createRunDir,
   generateSlug,
@@ -20,24 +16,11 @@ import {
   resolveProviderSelection as resolveProviderSelectionCore,
 } from '../core/provider-selection.js';
 import {
-  applyRunLifecycle,
-  createRunManifest,
-  markRunFailed,
-  mutateRunManifest,
-  toRunTaskState,
-  upsertProviderReport,
-} from '../core/run-manifest.js';
-import { generateSummary } from '../core/synthesis.js';
+  type ExecuteResearchRunDependencies,
+  executeResearchRun,
+} from '../core/research-run.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
-import type {
-  Citation,
-  Config,
-  DeduplicatedSource,
-  Defaults,
-  ProviderDispatchResult,
-  ProviderReport,
-  RunManifest,
-} from '../types.js';
+import type { Config, Defaults } from '../types.js';
 
 /**
  * Silent, file-writing research pipeline used by the MCP server. This mirrors
@@ -60,7 +43,7 @@ export interface SilentRunDeps {
   /** Load + merge config (global + project + CLI flags). Injectable for tests. */
   loadMergedConfig?: () => Config;
   /** Core dispatch. Injectable so tests can stub network. */
-  dispatch?: typeof dispatch;
+  dispatch?: ExecuteResearchRunDependencies['dispatch'];
   /** Initialize providers (registry side effect). Injectable for tests. */
   initialize?: typeof initializeProviders;
   /** Credentials (env). Defaults to process.env. */
@@ -75,14 +58,7 @@ export interface SilentRunDeps {
   runDirDeps?: CreateRunDirDeps;
 }
 
-export interface SilentRunResult {
-  manifest: RunManifest;
-  reports: ProviderReport[];
-  results: ProviderDispatchResult[];
-  sources: DeduplicatedSource[];
-  totalCitations: number;
-  totalDurationMs: number;
-}
+export type SilentRunResult = Awaited<ReturnType<typeof executeResearchRun>>;
 
 export { ProviderSelectionError as ResearchInputError };
 
@@ -112,42 +88,6 @@ export function resolveProviderSelection(
   return resolveProviderSelectionCore(config, args, getAllProviders(), {
     onWarn,
   });
-}
-
-/** Write per-provider markdown + meta files for a completed dispatch. */
-function writeProviderOutputs(
-  outputDir: string,
-  reports: ProviderReport[],
-  results: ProviderDispatchResult[],
-): void {
-  for (const result of results) {
-    const report = reports.find(
-      (candidate) =>
-        candidate.id === result.provider &&
-        candidate.fallbackFor === result.fallbackFor,
-    );
-    if (!report?.outputFile || !report.metaFile) continue;
-
-    safeWriteFile(join(outputDir, report.outputFile), result.text);
-    safeWriteFile(
-      join(outputDir, report.metaFile),
-      JSON.stringify(
-        {
-          provider: result.provider,
-          tier: result.tier,
-          model: result.model,
-          durationMs: result.durationMs,
-          citationCount: result.citations.length,
-          tokenUsage: result.tokenUsage,
-          usage: result.usage,
-          metering: result.metering,
-          citations: result.citations,
-        },
-        null,
-        2,
-      ),
-    );
-  }
 }
 
 /**
@@ -212,110 +152,21 @@ export async function runResearchSilent(
   // created directory is what gets recorded in the manifest below.
   const outputDir = createRunDir(baseDir, slug, deps.runDirDeps);
 
-  let promptDoc = buildPrompt(args.query);
-  if (refined) {
-    promptDoc += `\n\n## Refined Query Variants\n\n- deep-research: ${refined.tierQueries['deep-research']}\n- ai-grounded: ${refined.tierQueries['ai-grounded']}\n- raw-search: ${refined.tierQueries['raw-search']}\n`;
-  }
-  safeWriteFile(join(outputDir, 'prompt.md'), promptDoc);
-
-  const timestamp = Math.floor(Date.now() / 1000);
-  createRunManifest(outputDir, {
-    status: 'running',
-    timestamp,
-    slug,
-    query: args.query,
-    mode: config.defaults.mode,
-    outputDir,
-    providers: [],
-    sources: { total: 0, unique: 0, file: 'sources.json' },
-    exitCode: null,
-    refinedQueries: refined?.tierQueries,
-  });
-
-  try {
-    const dispatchFn = deps.dispatch ?? dispatch;
-    const dispatchStartedAt = Date.now();
-    const { reports, results, asyncTasks } = await dispatchFn({
+  return executeResearchRun(
+    {
+      query: args.query,
       config,
       providerIds,
-      query: args.query,
+      outputDir,
+      slug,
       tierQueries: refined?.tierQueries,
-      mode: config.defaults.mode,
       credentials,
-      onProgress: (event) => {
-        if (event.report) {
-          upsertProviderReport(outputDir, event.report, event.task);
+      onEvent: (event) => {
+        if (event.type === 'post-dispatch-warning') {
+          onWarn(`[librarium] warning: ${event.message}`);
         }
       },
-    });
-    const totalDurationMs = Date.now() - dispatchStartedAt;
-
-    writeProviderOutputs(outputDir, reports, results);
-
-    const allCitations: Citation[] = results.flatMap((result) =>
-      result.status === 'success' ? result.citations : [],
-    );
-    const sources = deduplicateSources(allCitations);
-
-    safeWriteFile(
-      join(outputDir, 'sources.json'),
-      JSON.stringify(sources, null, 2),
-    );
-
-    const taskByProvider = new Map(
-      asyncTasks.map((task) => [task.provider, toRunTaskState(task)]),
-    );
-    const manifest = mutateRunManifest(outputDir, (current) => {
-      const persistedTasks = new Map(
-        current.providers
-          .filter((provider) => provider.task)
-          .map((provider) => [provider.id, provider.task]),
-      );
-      current.providers = reports.map((report) => ({
-        ...report,
-        ...((report.task ??
-        taskByProvider.get(report.id) ??
-        persistedTasks.get(report.id))
-          ? {
-              task:
-                report.task ??
-                taskByProvider.get(report.id) ??
-                persistedTasks.get(report.id),
-            }
-          : {}),
-      }));
-      current.sources = {
-        total: allCitations.length,
-        unique: sources.length,
-        file: 'sources.json',
-      };
-      applyRunLifecycle(current);
-    });
-
-    const summary = generateSummary({
-      query: args.query,
-      reports,
-      sources,
-      asyncTasks,
-      timestamp,
-    });
-    safeWriteFile(join(outputDir, 'summary.md'), summary);
-
-    return {
-      manifest,
-      reports,
-      results,
-      sources,
-      totalCitations: allCitations.length,
-      totalDurationMs,
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    try {
-      markRunFailed(outputDir, message);
-    } catch {
-      // Preserve the original failure; manifest diagnostics are best effort.
-    }
-    throw error;
-  }
+    },
+    { dispatch: deps.dispatch },
+  );
 }

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -19,6 +19,7 @@ import { getAllProviders, registerProvider } from './adapters/index.js';
 import type { Config } from './types.js';
 
 export type { CustomProviderLoadResult } from './adapters/custom.js';
+export * from './core/research-run.js';
 export * from './node-credentials.js';
 
 export interface LoadCustomProvidersOptions {

--- a/tests/node-entry.test.ts
+++ b/tests/node-entry.test.ts
@@ -13,6 +13,7 @@ describe('librarium/node entry', () => {
   let originalCwd: string;
   let loadCustomProviders: typeof import('../src/node-entry.js').loadCustomProviders;
   let registerCustomProviders: typeof import('../src/node-entry.js').registerCustomProviders;
+  let executeResearchRun: typeof import('../src/node-entry.js').executeResearchRun;
   let getProvider: typeof import('../src/adapters/index.js').getProvider;
   let getAllProviders: typeof import('../src/adapters/index.js').getAllProviders;
   let registerProvider: typeof import('../src/adapters/index.js').registerProvider;
@@ -27,6 +28,7 @@ describe('librarium/node entry', () => {
     const nodeEntry = await import('../src/node-entry.js');
     loadCustomProviders = nodeEntry.loadCustomProviders;
     registerCustomProviders = nodeEntry.registerCustomProviders;
+    executeResearchRun = nodeEntry.executeResearchRun;
     const registry = await import('../src/adapters/index.js');
     getProvider = registry.getProvider;
     getAllProviders = registry.getAllProviders;
@@ -43,6 +45,7 @@ describe('librarium/node entry', () => {
   it('exposes the documented load/register API', () => {
     expect(typeof loadCustomProviders).toBe('function');
     expect(typeof registerCustomProviders).toBe('function');
+    expect(typeof executeResearchRun).toBe('function');
   });
 
   function writeNpmProvider(id: string): void {

--- a/tests/research-run.test.ts
+++ b/tests/research-run.test.ts
@@ -1,0 +1,197 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BaseProvider } from '../src/adapters/base.js';
+import {
+  defaultRunManifestStore,
+  executeResearchRun,
+  type ProviderRegistry,
+  type ResearchRunEvent,
+  type RunManifestStore,
+} from '../src/core/research-run.js';
+import { readRunManifest } from '../src/core/run-manifest.js';
+import type { Config, ProviderOptions, ProviderResult } from '../src/types.js';
+
+const config: Config = {
+  version: 1,
+  defaults: {
+    outputDir: '',
+    maxParallel: 1,
+    timeout: 30,
+    asyncTimeout: 1800,
+    asyncPollInterval: 10,
+    mode: 'mixed',
+    llmWebSearch: true,
+  },
+  providers: { embedded: { enabled: true } },
+  customProviders: {},
+  trustedProviderIds: [],
+  groups: {},
+};
+
+class EmbeddedProvider extends BaseProvider {
+  readonly id = 'embedded';
+  readonly tier = 'raw-search' as const;
+  readonly requiresApiKey = false;
+
+  async execute(
+    _query: string,
+    options: ProviderOptions,
+  ): Promise<ProviderResult> {
+    const response = await this.request<{ answer: string }>(
+      'https://example.test/research',
+      { timeout: options.timeout },
+    );
+    return {
+      provider: this.id,
+      tier: this.tier,
+      content: response.data.answer,
+      citations: [{ provider: this.id, url: 'https://example.test/source' }],
+      durationMs: response.durationMs,
+    };
+  }
+}
+
+describe('executeResearchRun', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses injected registry, task store, and HTTP client with typed events', async () => {
+    const outputDir = join(
+      tmpdir(),
+      `librarium-service-${crypto.randomUUID()}`,
+    );
+    dirs.push(outputDir);
+    mkdirSync(outputDir, { recursive: true });
+    const provider = new EmbeddedProvider();
+    const registry: ProviderRegistry = {
+      getProvider: (id) => (id === provider.id ? provider : undefined),
+      getAllProviders: () => [provider],
+    };
+    const httpClient = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      data: { answer: 'Embedded result' },
+      headers: {},
+      durationMs: 7,
+    }));
+    const create = vi.fn(defaultRunManifestStore.create);
+    const taskStore: RunManifestStore = {
+      ...defaultRunManifestStore,
+      create,
+    };
+    const events: ResearchRunEvent[] = [];
+
+    const result = await executeResearchRun(
+      {
+        query: 'dependency injection',
+        config: { ...config, defaults: { ...config.defaults, outputDir } },
+        providerIds: [provider.id],
+        outputDir,
+        slug: 'dependency-injection',
+        onEvent: (event) => events.push(event),
+      },
+      { providerRegistry: registry, taskStore, httpClient },
+    );
+
+    expect(httpClient).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledOnce();
+    expect(events.map((event) => event.type)).toEqual([
+      'manifest-created',
+      'dispatch-progress',
+      'dispatch-progress',
+      'completed',
+    ]);
+    expect(result.manifest).toMatchObject({
+      schemaVersion: 2,
+      status: 'completed',
+      exitCode: 0,
+    });
+    expect(readFileSync(join(outputDir, 'embedded.md'), 'utf8')).toBe(
+      'Embedded result',
+    );
+    expect(existsSync(join(outputDir, 'embedded.meta.json'))).toBe(true);
+    expect(existsSync(join(outputDir, 'sources.json'))).toBe(true);
+    expect(existsSync(join(outputDir, 'summary.md'))).toBe(true);
+    expect(existsSync(join(outputDir, 'prompt.md'))).toBe(true);
+  });
+
+  it('fails open when an observer or post-dispatch hook throws', async () => {
+    const outputDir = join(tmpdir(), `librarium-events-${crypto.randomUUID()}`);
+    dirs.push(outputDir);
+    const provider = new EmbeddedProvider();
+    const registry: ProviderRegistry = {
+      getProvider: () => provider,
+      getAllProviders: () => [provider],
+    };
+
+    const result = await executeResearchRun(
+      {
+        query: 'observer isolation',
+        config: { ...config, defaults: { ...config.defaults, outputDir } },
+        providerIds: [provider.id],
+        outputDir,
+        slug: 'observer-isolation',
+        onEvent: () => {
+          throw new Error('observer exploded');
+        },
+        postDispatch: async () => {
+          throw new Error('hook exploded');
+        },
+      },
+      {
+        providerRegistry: registry,
+        httpClient: async () => ({
+          status: 200,
+          statusText: 'OK',
+          data: { answer: 'Still completed' },
+          headers: {},
+          durationMs: 1,
+        }),
+      },
+    );
+
+    expect(result.manifest.status).toBe('completed');
+  });
+
+  it('terminalizes the manifest when orchestration fails', async () => {
+    const outputDir = join(tmpdir(), `librarium-failed-${crypto.randomUUID()}`);
+    dirs.push(outputDir);
+    const failedEvents: ResearchRunEvent[] = [];
+
+    await expect(
+      executeResearchRun(
+        {
+          query: 'failure lifecycle',
+          config: { ...config, defaults: { ...config.defaults, outputDir } },
+          providerIds: ['embedded'],
+          outputDir,
+          slug: 'failure-lifecycle',
+          onEvent: (event) => failedEvents.push(event),
+        },
+        {
+          providerRegistry: {
+            getProvider: () => undefined,
+            getAllProviders: () => [],
+          },
+          dispatch: async () => {
+            throw new Error('dispatch exploded');
+          },
+        },
+      ),
+    ).rejects.toThrow('dispatch exploded');
+
+    expect(readRunManifest(outputDir)).toMatchObject({
+      status: 'failed',
+      exitCode: 2,
+      error: 'dispatch exploded',
+    });
+    expect(failedEvents.at(-1)?.type).toBe('failed');
+  });
+});

--- a/tests/research-run.test.ts
+++ b/tests/research-run.test.ts
@@ -11,7 +11,13 @@ import {
   type RunManifestStore,
 } from '../src/core/research-run.js';
 import { readRunManifest } from '../src/core/run-manifest.js';
-import type { Config, ProviderOptions, ProviderResult } from '../src/types.js';
+import type {
+  AsyncTaskHandle,
+  Config,
+  ProviderOptions,
+  ProviderReport,
+  ProviderResult,
+} from '../src/types.js';
 
 const config: Config = {
   version: 1,
@@ -106,6 +112,7 @@ describe('executeResearchRun', () => {
       'manifest-created',
       'dispatch-progress',
       'dispatch-progress',
+      'dispatch-completed',
       'completed',
     ]);
     expect(result.manifest).toMatchObject({
@@ -131,6 +138,8 @@ describe('executeResearchRun', () => {
       getAllProviders: () => [provider],
     };
 
+    const events: ResearchRunEvent[] = [];
+    let postDispatchStartedAfterDispatch = false;
     const result = await executeResearchRun(
       {
         query: 'observer isolation',
@@ -138,10 +147,12 @@ describe('executeResearchRun', () => {
         providerIds: [provider.id],
         outputDir,
         slug: 'observer-isolation',
-        onEvent: () => {
-          throw new Error('observer exploded');
+        onEvent: (event) => {
+          events.push(event);
         },
         postDispatch: async () => {
+          postDispatchStartedAfterDispatch =
+            events.at(-1)?.type === 'dispatch-completed';
           throw new Error('hook exploded');
         },
       },
@@ -158,6 +169,193 @@ describe('executeResearchRun', () => {
     );
 
     expect(result.manifest.status).toBe('completed');
+    expect(postDispatchStartedAfterDispatch).toBe(true);
+    expect(events).toContainEqual({
+      type: 'post-dispatch-warning',
+      message: 'hook exploded',
+    });
+  });
+
+  it('isolates rejecting async observers', async () => {
+    const outputDir = join(tmpdir(), `librarium-async-${crypto.randomUUID()}`);
+    dirs.push(outputDir);
+    const provider = new EmbeddedProvider();
+
+    const result = await executeResearchRun(
+      {
+        query: 'async observer isolation',
+        config: { ...config, defaults: { ...config.defaults, outputDir } },
+        providerIds: [provider.id],
+        outputDir,
+        slug: 'async-observer-isolation',
+        onEvent: async () => {
+          throw new Error('async observer exploded');
+        },
+      },
+      {
+        providerRegistry: {
+          getProvider: () => provider,
+          getAllProviders: () => [provider],
+        },
+        httpClient: async () => ({
+          status: 200,
+          statusText: 'OK',
+          data: { answer: 'Still completed asynchronously' },
+          headers: {},
+          durationMs: 1,
+        }),
+      },
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(result.manifest.status).toBe('completed');
+  });
+
+  it('keeps HTTP overrides isolated across concurrent and later runs', async () => {
+    const outputDirA = join(
+      tmpdir(),
+      `librarium-client-a-${crypto.randomUUID()}`,
+    );
+    const outputDirB = join(
+      tmpdir(),
+      `librarium-client-b-${crypto.randomUUID()}`,
+    );
+    dirs.push(outputDirA, outputDirB);
+    const defaultClient = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      data: { answer: 'Default transport' },
+      headers: {},
+      durationMs: 1,
+    }));
+    const provider = new EmbeddedProvider({ httpClient: defaultClient });
+    const registry: ProviderRegistry = {
+      getProvider: () => provider,
+      getAllProviders: () => [provider],
+    };
+    const clientA = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      data: { answer: 'Transport A' },
+      headers: {},
+      durationMs: 1,
+    }));
+    const clientB = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      data: { answer: 'Transport B' },
+      headers: {},
+      durationMs: 1,
+    }));
+
+    const [runA, runB] = await Promise.all([
+      executeResearchRun(
+        {
+          query: 'client a',
+          config: {
+            ...config,
+            defaults: { ...config.defaults, outputDir: outputDirA },
+          },
+          providerIds: [provider.id],
+          outputDir: outputDirA,
+          slug: 'client-a',
+        },
+        { providerRegistry: registry, httpClient: clientA },
+      ),
+      executeResearchRun(
+        {
+          query: 'client b',
+          config: {
+            ...config,
+            defaults: { ...config.defaults, outputDir: outputDirB },
+          },
+          providerIds: [provider.id],
+          outputDir: outputDirB,
+          slug: 'client-b',
+        },
+        { providerRegistry: registry, httpClient: clientB },
+      ),
+    ]);
+
+    expect(runA.results[0]?.text).toBe('Transport A');
+    expect(runB.results[0]?.text).toBe('Transport B');
+    expect(clientA).toHaveBeenCalledOnce();
+    expect(clientB).toHaveBeenCalledOnce();
+
+    const direct = await provider.execute('default', { timeout: 1 });
+    expect(direct.content).toBe('Default transport');
+    expect(defaultClient).toHaveBeenCalledOnce();
+  });
+
+  it('embeds accepted background tasks in the final manifest', async () => {
+    const outputDir = join(tmpdir(), `librarium-task-${crypto.randomUUID()}`);
+    dirs.push(outputDir);
+    const task: AsyncTaskHandle = {
+      provider: 'embedded',
+      taskId: 'task-123',
+      query: 'background acceptance',
+      submittedAt: 1_780_000_000_000,
+      status: 'pending',
+      outputDir,
+    };
+    const report: ProviderReport = {
+      id: 'embedded',
+      tier: 'raw-search',
+      status: 'async-pending',
+      durationMs: 0,
+      wordCount: 0,
+      citationCount: 0,
+      outputFile: '',
+      metaFile: '',
+    };
+
+    const result = await executeResearchRun(
+      {
+        query: task.query,
+        config: { ...config, defaults: { ...config.defaults, outputDir } },
+        providerIds: [task.provider],
+        outputDir,
+        slug: 'background-acceptance',
+      },
+      {
+        providerRegistry: {
+          getProvider: () => undefined,
+          getAllProviders: () => [],
+        },
+        dispatch: async () => ({
+          reports: [report],
+          results: [
+            {
+              provider: task.provider,
+              tier: report.tier,
+              status: 'async-pending',
+              text: '',
+              sourceUrls: [],
+              citations: [],
+              durationMs: 0,
+            },
+          ],
+          asyncTasks: [task],
+        }),
+      },
+    );
+
+    expect(result.asyncTasks).toEqual([task]);
+    expect(result.manifest).toMatchObject({
+      status: 'awaiting_async',
+      exitCode: null,
+      providers: [
+        {
+          id: task.provider,
+          status: 'async-pending',
+          task: {
+            taskId: task.taskId,
+            status: 'pending',
+            submittedAt: task.submittedAt,
+          },
+        },
+      ],
+    });
   });
 
   it('terminalizes the manifest when orchestration fails', async () => {

--- a/tests/research-run.test.ts
+++ b/tests/research-run.test.ts
@@ -181,34 +181,83 @@ describe('executeResearchRun', () => {
     dirs.push(outputDir);
     const provider = new EmbeddedProvider();
 
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      const result = await executeResearchRun(
+        {
+          query: 'async observer isolation',
+          config: { ...config, defaults: { ...config.defaults, outputDir } },
+          providerIds: [provider.id],
+          outputDir,
+          slug: 'async-observer-isolation',
+          onEvent: async () => {
+            throw new Error('async observer exploded');
+          },
+        },
+        {
+          providerRegistry: {
+            getProvider: () => provider,
+            getAllProviders: () => [provider],
+          },
+          httpClient: async () => ({
+            status: 200,
+            statusText: 'OK',
+            data: { answer: 'Still completed asynchronously' },
+            headers: {},
+            durationMs: 1,
+          }),
+        },
+      );
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(result.manifest.status).toBe('completed');
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+
+  it('delegates HTTP projection to custom registries', async () => {
+    const outputDir = join(
+      tmpdir(),
+      `librarium-projection-${crypto.randomUUID()}`,
+    );
+    dirs.push(outputDir);
+    const projectedClient = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      data: { answer: 'Registry projection' },
+      headers: {},
+      durationMs: 1,
+    }));
+    const provider = new EmbeddedProvider({ httpClient: projectedClient });
+    const projected: ProviderRegistry = {
+      getProvider: () => provider,
+      getAllProviders: () => [provider],
+    };
+    const withHttpClient = vi.fn(() => projected);
+    const registry: ProviderRegistry = {
+      getProvider: () => undefined,
+      getAllProviders: () => [],
+      withHttpClient,
+    };
+    const override = vi.fn();
+
     const result = await executeResearchRun(
       {
-        query: 'async observer isolation',
+        query: 'custom registry projection',
         config: { ...config, defaults: { ...config.defaults, outputDir } },
         providerIds: [provider.id],
         outputDir,
-        slug: 'async-observer-isolation',
-        onEvent: async () => {
-          throw new Error('async observer exploded');
-        },
+        slug: 'custom-registry-projection',
       },
-      {
-        providerRegistry: {
-          getProvider: () => provider,
-          getAllProviders: () => [provider],
-        },
-        httpClient: async () => ({
-          status: 200,
-          statusText: 'OK',
-          data: { answer: 'Still completed asynchronously' },
-          headers: {},
-          durationMs: 1,
-        }),
-      },
+      { providerRegistry: registry, httpClient: override },
     );
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(result.manifest.status).toBe('completed');
+    expect(withHttpClient).toHaveBeenCalledWith(override);
+    expect(result.results[0]?.text).toBe('Registry projection');
+    expect(projectedClient).toHaveBeenCalledOnce();
   });
 
   it('keeps HTTP overrides isolated across concurrent and later runs', async () => {

--- a/tests/run-presentation.test.ts
+++ b/tests/run-presentation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { finalizeDispatchPresentation } from '../src/commands/run.js';
+import type { ProviderReport } from '../src/types.js';
+
+const reports: ProviderReport[] = [
+  {
+    id: 'completed-provider',
+    tier: 'raw-search',
+    status: 'success',
+    durationMs: 1,
+    wordCount: 1,
+    citationCount: 0,
+    outputFile: 'completed-provider.md',
+    metaFile: 'completed-provider.meta.json',
+  },
+];
+
+describe('dispatch presentation boundary', () => {
+  it('stops and resolves the live renderer before later hook output', () => {
+    const order: string[] = [];
+    const live = {
+      resolveRemaining: vi.fn(() => order.push('resolve')),
+      stop: vi.fn(() => order.push('live-stop')),
+    };
+
+    finalizeDispatchPresentation(reports, {
+      spinner: { stop: () => order.push('spinner-stop') },
+      live,
+      printLine: () => order.push('provider-line'),
+      widths: { id: 18, tier: 10 },
+      color: false,
+    });
+    order.push('post-dispatch-output');
+
+    expect(order).toEqual([
+      'spinner-stop',
+      'resolve',
+      'live-stop',
+      'post-dispatch-output',
+    ]);
+    expect(live.resolveRemaining).toHaveBeenCalledWith(reports);
+  });
+
+  it('prints skipped rows after stopping a non-live spinner', () => {
+    const order: string[] = [];
+    const skipped: ProviderReport = {
+      ...reports[0],
+      id: 'skipped-provider',
+      status: 'skipped',
+      outputFile: '',
+      metaFile: '',
+    };
+
+    finalizeDispatchPresentation([skipped], {
+      spinner: { stop: () => order.push('spinner-stop') },
+      live: null,
+      printLine: (line) => order.push(`line:${line}`),
+      widths: { id: 16, tier: 10 },
+      color: false,
+    });
+
+    expect(order[0]).toBe('spinner-stop');
+    expect(order[1]).toContain('skipped-provider');
+  });
+});


### PR DESCRIPTION
## Summary

Extract the durable research-run pipeline into one headless Node application service shared by the CLI and MCP server. This gives embedders a typed, testable execution API while preserving the existing run artifacts, manifest lifecycle, provider behavior, and presentation adapters.

## What's New

### Headless execution service

- Add `executeResearchRun(request, overrides?)` to `librarium/node`
- Centralize write-ahead manifest creation, dispatch, provider artifacts, source deduplication, summary generation, and failure terminalization
- Add typed lifecycle events with isolated sync and async observers
- Keep CLI rendering, consent, selection, refinement, and MCP response shaping outside the service

### Dependency boundaries

- Add defaultable provider-registry, unified task/manifest-store, HTTP-client, and dispatcher overrides
- Route primary and fallback provider lookup through the supplied registry
- Scope HTTP overrides to run-local provider instances so concurrent and subsequent runs cannot inherit another run's transport
- Allow custom registries to provide their own `withHttpClient()` projection

### Compatibility and verification

- Preserve schemaVersion 2 `run.json`, accepted background-task write-ahead persistence, provider output files, `sources.json`, `summary.md`, and answer/verification hooks
- Keep `librarium/core` Worker-safe; the filesystem service is exported only from `librarium/node`
- Document the public headless API and override behavior

## Test Plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (58 files, 746 tests)
- [x] `npm run build`
- [x] `npm run test:integration` (11 tests)
- [x] `npm run test:workers` (1 test)
- [x] `npm run test:pty` (5 tests)
- [x] Deep review completed with security, architecture/goals, and testability/e2e closure GO

## Compatibility Notes

- No legacy manifest or `async-tasks.json` compatibility is added.
- `executeResearchRun()` is Node-only because it owns filesystem artifacts.
- Existing `dispatch()` callers in `librarium/core` remain supported.
