### PR TITLE
Tune OpenAI Research reasoning defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,9 +939,10 @@ Adaptive thinking and medium effort are automatic only for the default Sonnet
 5 model. When `model` is overridden, thinking and effort are omitted unless
 they are explicitly configured, avoiding unsupported fields on older models.
 
-OpenAI Research defaults to GPT-5.6 Sol with `xhigh` reasoning and OpenAI's
-standard web-search return-token budget. Configure its model and research
-limits under the canonical `openai-research` provider ID:
+OpenAI Research defaults to GPT-5.6 Sol with `high` reasoning, OpenAI's
+standard web-search return-token budget, and no tool-call ceiling. Configure
+its model and research limits under the canonical `openai-research` provider
+ID:
 
 ```json
 {
@@ -951,8 +952,7 @@ limits under the canonical `openai-research` provider ID:
       "enabled": true,
       "model": "gpt-5.6-sol",
       "options": {
-        "reasoningEffort": "high",
-        "maxToolCalls": 5,
+        "reasoningEffort": "medium",
         "returnTokenBudget": "default"
       }
     }
@@ -961,10 +961,13 @@ limits under the canonical `openai-research` provider ID:
 ```
 
 `reasoningEffort` accepts `none`, `low`, `medium`, `high`, `xhigh`, or `max`
-and defaults to `xhigh`. `maxToolCalls` must be a positive integer when set.
-`returnTokenBudget` accepts `default` or `unlimited` and defaults to `default`.
-Use `unlimited` only for high-effort research that needs to inspect unusually
-large amounts of web content; it can increase latency and token usage.
+and defaults to `high`. Use `medium` as a speed-oriented setting and `xhigh`
+as a quality-first override. `maxToolCalls` must be a positive integer when
+set; it is uncapped by default because low ceilings can prevent complete
+research. `returnTokenBudget` accepts `default` or `unlimited` and defaults to
+`default`. Use `unlimited` only for high-effort research that needs to inspect
+unusually large amounts of web content; it can increase latency and token
+usage.
 
 Some providers support optional model overrides. Gemini Deep Research defaults to the `deep-research-preview-04-2026` agent; set `model` to `deep-research-max-preview-04-2026` for the heavier (and more expensive) variant:
 

--- a/src/adapters/openai-research.ts
+++ b/src/adapters/openai-research.ts
@@ -83,7 +83,7 @@ function parseMaxToolCalls(value: unknown): number | undefined {
 }
 
 function parseReasoningEffort(value: unknown): ReasoningEffort {
-  if (value === undefined) return 'xhigh';
+  if (value === undefined) return 'high';
   if (
     typeof value === 'string' &&
     REASONING_EFFORTS.includes(value as ReasoningEffort)

--- a/tests/adapters/openai-research.test.ts
+++ b/tests/adapters/openai-research.test.ts
@@ -76,7 +76,7 @@ describe('OpenAIResearchProvider', () => {
 
     const task = await provider({
       maxToolCalls: 3,
-      reasoningEffort: 'high',
+      reasoningEffort: 'medium',
       returnTokenBudget: 'unlimited',
     }).submit('What changed?', { timeout: 1800 });
     expect(task).toMatchObject({
@@ -93,7 +93,7 @@ describe('OpenAIResearchProvider', () => {
       model: 'gpt-5.6-sol',
       input: [{ role: 'user', content: 'What changed?' }],
       tools: [{ type: 'web_search', return_token_budget: 'unlimited' }],
-      reasoning: { effort: 'high' },
+      reasoning: { effort: 'medium' },
       max_tool_calls: 3,
       background: true,
     });

--- a/tests/adapters/openai-research.test.ts
+++ b/tests/adapters/openai-research.test.ts
@@ -99,7 +99,7 @@ describe('OpenAIResearchProvider', () => {
     });
   });
 
-  it('uses xhigh reasoning, the standard search budget, and omits max_tool_calls by default', async () => {
+  it('uses high reasoning, the standard search budget, and omits max_tool_calls by default', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -110,7 +110,7 @@ describe('OpenAIResearchProvider', () => {
     await provider().submit('What changed?', { timeout: 1800 });
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.reasoning).toEqual({ effort: 'xhigh' });
+    expect(body.reasoning).toEqual({ effort: 'high' });
     expect(body.tools).toEqual([
       { type: 'web_search', return_token_budget: 'default' },
     ]);

--- a/tests/provider-descriptors.test.ts
+++ b/tests/provider-descriptors.test.ts
@@ -84,6 +84,37 @@ describe('built-in provider descriptors', () => {
     ]);
   });
 
+  it('applies the OpenAI research defaults through provider initialization', async () => {
+    const httpClient = vi.fn(async () => ({
+      status: 200,
+      headers: new Headers(),
+      data: { id: 'response-1', status: 'queued' },
+    }));
+    await initializeProviders({
+      credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
+      httpClient,
+      providers: { 'openai-research': { enabled: true } },
+    });
+
+    const openai = getProvider('openai-research');
+    expect(openai?.execution).toBe('background');
+    if (openai?.execution !== 'background') return;
+
+    await openai.submit('What changed?', { timeout: 10 });
+    expect(httpClient).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/responses',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.objectContaining({
+          reasoning: { effort: 'high' },
+          tools: [{ type: 'web_search', return_token_budget: 'default' }],
+        }),
+      }),
+    );
+    const request = httpClient.mock.calls[0]?.[1];
+    expect(request?.body).not.toHaveProperty('max_tool_calls');
+  });
+
   it('isolates an invalid provider option schema from other adapters', async () => {
     const httpClient = vi.fn(async () => ({
       status: 200,


### PR DESCRIPTION
## Summary
- change OpenAI Research default reasoning from xhigh to high
- retain the standard return-token budget and uncapped tool calls
- document medium as the speed option and xhigh as the quality-first override
- add adapter and provider-initialization regression coverage

## Verification
- 752 unit tests
- 13 integration tests
- 1 Workers test
- 5 PTY tests
- typecheck, lint, and build
- independent deep review: GO