### PR TITLE
feat: add v2 execution foundation

### DIFF
--- a/src/contracts/interchange/compatibility.ts
+++ b/src/contracts/interchange/compatibility.ts
@@ -1,0 +1,103 @@
+import type { ExecutionProfile } from '../domain/index.js';
+import type { EvidenceRequirements, RequestSlot } from './request.js';
+
+export function profileKey(profile: ExecutionProfile): string {
+  return `${profile.identity.provider_id}\u0000${profile.identity.profile_id}`;
+}
+
+export function compatibilityIssues(
+  requirements: EvidenceRequirements,
+  profile: ExecutionProfile,
+): string[] {
+  const issues: string[] = [];
+  if (profile.result_kind !== requirements.result_kind) {
+    issues.push('result_kind');
+  }
+  if (
+    requirements.grounding_policy === 'required' &&
+    profile.grounding_policy !== 'required'
+  ) {
+    issues.push('grounding_policy');
+  }
+  if (
+    requirements.grounding_policy === 'optional' &&
+    profile.grounding_policy === 'none'
+  ) {
+    issues.push('grounding_policy');
+  }
+  if (
+    requirements.grounding_policy === 'none' &&
+    profile.grounding_policy !== 'none'
+  ) {
+    issues.push('grounding_policy');
+  }
+  if (
+    requirements.observation_mode &&
+    profile.observation_mode !== requirements.observation_mode
+  ) {
+    issues.push('observation_mode');
+  }
+  for (const corpus of requirements.corpora) {
+    if (!profile.corpora.includes(corpus)) {
+      issues.push(`corpora:${corpus}`);
+    }
+  }
+  if (
+    requirements.retrieval_methods &&
+    !requirements.retrieval_methods.includes(profile.retrieval_method)
+  ) {
+    issues.push('retrieval_method');
+  }
+  if (
+    requirements.surface_id &&
+    profile.surface_id !== requirements.surface_id
+  ) {
+    issues.push('surface_id');
+  }
+  if (requirements.surface_context_constraint) {
+    const context = profile.surface_context;
+    if (!context) {
+      issues.push('surface_context');
+    } else {
+      for (const [field, expected] of Object.entries(
+        requirements.surface_context_constraint,
+      )) {
+        if (
+          expected !== undefined &&
+          context[field as keyof typeof context] !== expected
+        ) {
+          issues.push(`surface_context.${field}`);
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+export function fallbackCompatibilityIssues(
+  slot: RequestSlot,
+  profile: ExecutionProfile,
+): string[] {
+  const issues = compatibilityIssues(slot.requirements, profile);
+
+  if (
+    slot.primary.result_kind === 'surface_observation' &&
+    profile.observation_mode !== slot.primary.observation_mode
+  ) {
+    issues.push('observation_mode:primary');
+  }
+  if (
+    slot.primary.result_kind === 'surface_observation' &&
+    profile.surface_id !== slot.primary.surface_id
+  ) {
+    issues.push('surface_id:primary');
+  }
+  if (
+    slot.primary.observation_mode === 'surface_snapshot' &&
+    profile.retrieval_method !== slot.primary.retrieval_method
+  ) {
+    issues.push('retrieval_method:primary');
+  }
+
+  return issues;
+}

--- a/src/contracts/interchange/request.ts
+++ b/src/contracts/interchange/request.ts
@@ -6,7 +6,6 @@ import {
 } from '../common.js';
 import {
   CorpusSchema,
-  type ExecutionProfile,
   ExecutionProfileSchema,
   GroundingPolicySchema,
   ObservationModeSchema,
@@ -14,6 +13,11 @@ import {
   RetrievalMethodSchema,
   SurfaceContextConstraintSchema,
 } from '../domain/index.js';
+import {
+  compatibilityIssues,
+  fallbackCompatibilityIssues,
+  profileKey,
+} from './compatibility.js';
 
 export const INTERCHANGE_VERSION = '1.0.0' as const;
 
@@ -67,104 +71,6 @@ export const FallbackCandidateSchema = z.strictObject({
   eligible_slot_ids: z.array(OpaqueIdSchema).min(1).max(64),
   extensions: ExtensionsSchema.optional(),
 });
-
-function profileKey(profile: ExecutionProfile): string {
-  return `${profile.identity.provider_id}\u0000${profile.identity.profile_id}`;
-}
-
-function compatibilityIssues(
-  requirements: z.infer<typeof EvidenceRequirementsSchema>,
-  profile: ExecutionProfile,
-): string[] {
-  const issues: string[] = [];
-  if (profile.result_kind !== requirements.result_kind)
-    issues.push('result_kind');
-  if (
-    requirements.grounding_policy === 'required' &&
-    profile.grounding_policy !== 'required'
-  ) {
-    issues.push('grounding_policy');
-  }
-  if (
-    requirements.grounding_policy === 'optional' &&
-    profile.grounding_policy === 'none'
-  ) {
-    issues.push('grounding_policy');
-  }
-  if (
-    requirements.grounding_policy === 'none' &&
-    profile.grounding_policy !== 'none'
-  ) {
-    issues.push('grounding_policy');
-  }
-  if (
-    requirements.observation_mode &&
-    profile.observation_mode !== requirements.observation_mode
-  ) {
-    issues.push('observation_mode');
-  }
-  for (const corpus of requirements.corpora) {
-    if (!profile.corpora.includes(corpus)) issues.push(`corpora:${corpus}`);
-  }
-  if (
-    requirements.retrieval_methods &&
-    !requirements.retrieval_methods.includes(profile.retrieval_method)
-  ) {
-    issues.push('retrieval_method');
-  }
-  if (
-    requirements.surface_id &&
-    profile.surface_id !== requirements.surface_id
-  ) {
-    issues.push('surface_id');
-  }
-  if (requirements.surface_context_constraint) {
-    const context = profile.surface_context;
-    if (!context) {
-      issues.push('surface_context');
-    } else {
-      for (const [field, expected] of Object.entries(
-        requirements.surface_context_constraint,
-      )) {
-        if (
-          expected !== undefined &&
-          context[field as keyof typeof context] !== expected
-        ) {
-          issues.push(`surface_context.${field}`);
-        }
-      }
-    }
-  }
-  return issues;
-}
-
-function fallbackCompatibilityIssues(
-  slot: z.infer<typeof RequestSlotSchema>,
-  profile: ExecutionProfile,
-): string[] {
-  const issues = compatibilityIssues(slot.requirements, profile);
-
-  if (
-    slot.primary.result_kind === 'surface_observation' &&
-    profile.observation_mode !== slot.primary.observation_mode
-  ) {
-    issues.push('observation_mode:primary');
-  }
-  if (
-    slot.primary.result_kind === 'surface_observation' &&
-    profile.surface_id !== slot.primary.surface_id
-  ) {
-    issues.push('surface_id:primary');
-  }
-  if (
-    slot.primary.observation_mode === 'surface_snapshot' &&
-    profile.retrieval_method !== slot.primary.retrieval_method
-  ) {
-    issues.push('retrieval_method:primary');
-  }
-
-  return issues;
-}
 
 export const InterchangeRequestSchema = z
   .strictObject({

--- a/src/core/coordinator-store.ts
+++ b/src/core/coordinator-store.ts
@@ -1,0 +1,114 @@
+import type { CoordinatorState } from './coordinator.js';
+
+export interface VersionedCoordinationState {
+  readonly version: number;
+  readonly state: CoordinatorState;
+}
+
+export type CoordinationCompareAndSwapResult =
+  | {
+      readonly ok: true;
+      readonly value: VersionedCoordinationState;
+    }
+  | {
+      readonly ok: false;
+      readonly current: VersionedCoordinationState | undefined;
+    };
+
+export interface CoordinationStateStore {
+  load(requestId: string): Promise<VersionedCoordinationState | undefined>;
+  create(state: CoordinatorState): Promise<VersionedCoordinationState>;
+  compareAndSwap(
+    requestId: string,
+    expectedVersion: number,
+    state: CoordinatorState,
+  ): Promise<CoordinationCompareAndSwapResult>;
+}
+
+function cloneState(state: CoordinatorState): CoordinatorState {
+  return structuredClone(state);
+}
+
+export class InMemoryCoordinationStateStore implements CoordinationStateStore {
+  readonly #states = new Map<string, VersionedCoordinationState>();
+
+  async load(
+    requestId: string,
+  ): Promise<VersionedCoordinationState | undefined> {
+    const value = this.#states.get(requestId);
+    return value
+      ? { version: value.version, state: cloneState(value.state) }
+      : undefined;
+  }
+
+  async create(state: CoordinatorState): Promise<VersionedCoordinationState> {
+    if (this.#states.has(state.request_id)) {
+      throw new Error(`Coordination state already exists: ${state.request_id}`);
+    }
+    const stored = { version: 1, state: cloneState(state) };
+    this.#states.set(state.request_id, stored);
+    return { version: stored.version, state: cloneState(stored.state) };
+  }
+
+  async compareAndSwap(
+    requestId: string,
+    expectedVersion: number,
+    state: CoordinatorState,
+  ): Promise<CoordinationCompareAndSwapResult> {
+    if (state.request_id !== requestId) {
+      throw new Error('Coordination state request id cannot change.');
+    }
+    const current = this.#states.get(requestId);
+    if (!current || current.version !== expectedVersion) {
+      return {
+        ok: false,
+        current: current
+          ? { version: current.version, state: cloneState(current.state) }
+          : undefined,
+      };
+    }
+    const stored = {
+      version: current.version + 1,
+      state: cloneState(state),
+    };
+    this.#states.set(requestId, stored);
+    return {
+      ok: true,
+      value: { version: stored.version, state: cloneState(stored.state) },
+    };
+  }
+}
+
+export function assertCompareAndSwapAttemptBudget(maxAttempts: number): void {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error(
+      'The compare-and-swap attempt budget must be a positive integer.',
+    );
+  }
+}
+
+export async function updateCoordinationState(
+  store: CoordinationStateStore,
+  requestId: string,
+  update: (state: CoordinatorState) => CoordinatorState | undefined,
+  maxAttempts = 16,
+): Promise<VersionedCoordinationState> {
+  assertCompareAndSwapAttemptBudget(maxAttempts);
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const current = await store.load(requestId);
+    if (!current) {
+      throw new Error(`Coordination state not found: ${requestId}`);
+    }
+    const next = update(current.state);
+    if (!next) return current;
+    const swapped = await store.compareAndSwap(
+      requestId,
+      current.version,
+      next,
+    );
+    if (swapped.ok) return swapped.value;
+  }
+  throw new Error(
+    `Coordination state update exceeded ${maxAttempts} compare-and-swap attempts.`,
+  );
+}

--- a/src/core/coordinator.ts
+++ b/src/core/coordinator.ts
@@ -1,7 +1,11 @@
-import type {
-  DurableHandle,
-  ExecutionProfile,
-  StructuredError,
+import { z } from 'zod/v4';
+import { OpaqueIdSchema } from '../contracts/common.js';
+import {
+  type DurableHandle,
+  DurableHandleSchema,
+  type ExecutionProfile,
+  type StructuredError,
+  StructuredErrorSchema,
 } from '../contracts/domain/index.js';
 import type { LifecycleEvent } from '../contracts/interchange/lifecycle.js';
 import { INTERCHANGE_VERSION } from '../contracts/interchange/request.js';
@@ -15,7 +19,10 @@ import {
   type PreparedResearchExecution,
   profileIdentityKey,
 } from './execution-plan.js';
-import { RESEARCH_REQUEST_LIMITS } from './research-request.js';
+import {
+  ExactMicrousdSchema,
+  RESEARCH_REQUEST_LIMITS,
+} from './research-request.js';
 
 export type CoordinatorTerminalOutcome =
   | 'succeeded'
@@ -27,6 +34,7 @@ export type CoordinatorTerminalOutcome =
 export type CoordinatorStatus = 'running' | CoordinatorTerminalOutcome;
 
 export type CoordinatorAttemptStatus =
+  | 'dispatch_pending'
   | 'submitting'
   | 'acceptance_unknown'
   | 'submitted'
@@ -69,8 +77,11 @@ export interface CoordinatorAttemptState {
   profile: ExecutionProfile;
   status: CoordinatorAttemptStatus;
   query: string;
-  started_at: string;
+  queued_at: string;
+  started_at?: string;
   deadline_at: string;
+  delivery_lease_id?: string;
+  delivery_lease_expires_at?: string;
   finished_at?: string;
   replaces_attempt_id?: string;
   candidate_id?: string;
@@ -118,6 +129,14 @@ export interface UnresolvedAcceptance {
   adapter_state_ref?: string;
 }
 
+const UnresolvedAcceptanceReasonSchema = z.enum([
+  'submission_response_uncertain',
+  'submission_deadline_exceeded',
+  'request_deadline_exceeded',
+  'cancelled_while_acceptance_unknown',
+  'infrastructure_failure_while_acceptance_unknown',
+]);
+
 export interface CoordinatorState {
   request_id: string;
   mode: 'sync' | 'async';
@@ -135,7 +154,6 @@ export interface CoordinatorState {
   attempts: CoordinatorAttemptState[];
   reserve: CoordinatorReserveCandidate[];
   pending_fallbacks: PendingFallbackLaunch[];
-  claimed_candidate_ids: string[];
   used_profile_keys: string[];
   unresolved_acceptances: UnresolvedAcceptance[];
   profile_plans_by_identity: PreparedResearchExecution['profile_plans_by_identity'];
@@ -151,7 +169,7 @@ export interface CoordinatorClock {
 }
 
 export interface CoordinatorIdGenerator {
-  next(scope: 'attempt' | 'event'): string;
+  next(scope: 'attempt' | 'event' | 'delivery_lease'): string;
 }
 
 export interface CoordinatorDependencies {
@@ -166,6 +184,8 @@ export interface AttemptLaunch {
   readonly binding: AdapterBindingIdentity;
   readonly query: string;
   readonly deadline_at: string;
+  readonly delivery_lease_id: string;
+  readonly idempotency_key: string;
 }
 
 export interface CoordinatorAdvanceResult {
@@ -173,27 +193,31 @@ export interface CoordinatorAdvanceResult {
   readonly launches: readonly AttemptLaunch[];
 }
 
-export type AttemptFinishedInput =
-  | {
-      readonly outcome: 'succeeded';
-      readonly result_id: string;
-      readonly durable_handle?: DurableHandle;
-      readonly actual_cost_microusd?: string;
-    }
-  | {
-      readonly outcome: 'failed' | 'timed_out';
-      readonly error: StructuredError;
-      readonly durable_handle?: DurableHandle;
-      readonly actual_cost_microusd?: string;
-    }
-  | {
-      readonly outcome: 'cancelled';
-      readonly error?: StructuredError;
-      readonly durable_handle?: DurableHandle;
-      readonly actual_cost_microusd?: string;
-    };
+const AttemptFinishedInputSchema = z.discriminatedUnion('outcome', [
+  z.strictObject({
+    outcome: z.literal('succeeded'),
+    result_id: OpaqueIdSchema,
+    durable_handle: DurableHandleSchema.optional(),
+    actual_cost_microusd: ExactMicrousdSchema.optional(),
+  }),
+  z.strictObject({
+    outcome: z.enum(['failed', 'timed_out']),
+    error: StructuredErrorSchema,
+    durable_handle: DurableHandleSchema.optional(),
+    actual_cost_microusd: ExactMicrousdSchema.optional(),
+  }),
+  z.strictObject({
+    outcome: z.literal('cancelled'),
+    error: StructuredErrorSchema.optional(),
+    durable_handle: DurableHandleSchema.optional(),
+    actual_cost_microusd: ExactMicrousdSchema.optional(),
+  }),
+]);
+
+export type AttemptFinishedInput = z.infer<typeof AttemptFinishedInputSchema>;
 
 const ACTIVE_ATTEMPT_STATUSES = new Set<CoordinatorAttemptStatus>([
+  'dispatch_pending',
   'submitting',
   'submitted',
   'running',
@@ -254,6 +278,9 @@ function appendAttemptStarted(
   attempt: CoordinatorAttemptState,
   dependencies: CoordinatorDependencies,
 ): void {
+  if (!attempt.started_at) {
+    throw new Error('A dispatched attempt requires a started_at timestamp.');
+  }
   appendLifecycle(state, {
     ...eventBase(state, dependencies, attempt.started_at),
     slot_id: attempt.slot_id,
@@ -411,21 +438,43 @@ function reservationFor(
 function budgetPermitsLaunch(
   state: CoordinatorState,
   reservation: string,
+  additionalReservation = '0',
 ): boolean {
   const estimatedLimit = state.budget.max_estimated_cost_microusd;
   if (
     estimatedLimit !== undefined &&
     exactGreaterThan(
-      exactAdd(state.budget.reserved_estimated_cost_microusd, reservation),
+      exactAdd(
+        exactAdd(
+          state.budget.reserved_estimated_cost_microusd,
+          additionalReservation,
+        ),
+        reservation,
+      ),
       estimatedLimit,
     )
   ) {
     return false;
   }
   const actualLimit = state.budget.max_actual_cost_microusd;
+  const projectedCommittedActual = state.attempts.reduce(
+    (total, attempt) =>
+      exactAdd(
+        total,
+        attempt.actual_cost_microusd ??
+          attempt.reserved_estimated_cost_microusd,
+      ),
+    '0',
+  );
   return !(
     actualLimit !== undefined &&
-    exactGreaterThan(state.budget.actual_cost_microusd, actualLimit)
+    exactGreaterThan(
+      exactAdd(
+        exactAdd(projectedCommittedActual, additionalReservation),
+        reservation,
+      ),
+      actualLimit,
+    )
   );
 }
 
@@ -532,7 +581,6 @@ export function createCoordinatorState(
       eligible_slot_ids: [...candidate.eligible_slot_ids],
     })),
     pending_fallbacks: [],
-    claimed_candidate_ids: [],
     used_profile_keys: [],
     unresolved_acceptances: [],
     profile_plans_by_identity: structuredClone(
@@ -596,34 +644,28 @@ function startAttempt(
     CoordinatorAttemptState,
     | 'status'
     | 'query'
+    | 'queued_at'
     | 'started_at'
     | 'deadline_at'
+    | 'delivery_lease_id'
+    | 'delivery_lease_expires_at'
     | 'reserved_estimated_cost_microusd'
   >,
   dependencies: CoordinatorDependencies,
-): AttemptLaunch | undefined {
+): boolean {
   const reservation = reservationFor(state, attempt.profile);
   if (!budgetPermitsLaunch(state, reservation)) {
     suppressSlotForBudget(state, slot);
-    return undefined;
+    return false;
   }
 
-  const startedAtMs = dependencies.clock.now();
-  const requestDeadlineMs = Date.parse(state.request_deadline_at);
-  const attemptDeadlineMs =
-    attempt.profile.invocation === 'inline'
-      ? state.inline_attempt_deadline_ms
-      : state.background_attempt_deadline_ms;
+  const queuedAtMs = dependencies.clock.now();
   const started: CoordinatorAttemptState = {
     ...attempt,
-    status: canHaveRemoteAcceptanceUncertainty(attempt.profile)
-      ? 'submitting'
-      : 'running',
+    status: 'dispatch_pending',
     query: slot.refined_query ?? state.original_query,
-    started_at: iso(startedAtMs),
-    deadline_at: iso(
-      Math.min(startedAtMs + attemptDeadlineMs, requestDeadlineMs),
-    ),
+    queued_at: iso(queuedAtMs),
+    deadline_at: state.request_deadline_at,
     reserved_estimated_cost_microusd: reservation,
   };
   state.attempts.push(started);
@@ -637,15 +679,59 @@ function startAttempt(
     state.budget.reserved_estimated_cost_microusd,
     reservation,
   );
-  appendAttemptStarted(state, started, dependencies);
-  return {
-    attempt_id: started.attempt_id,
-    slot_id: started.slot_id,
-    profile: started.profile,
-    binding: profilePlanFor(state, started.profile).binding,
-    query: started.query,
-    deadline_at: started.deadline_at,
-  };
+  return true;
+}
+
+function claimDispatchPendingAttempts(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): AttemptLaunch[] {
+  const nowMs = dependencies.clock.now();
+  const requestDeadlineMs = Date.parse(state.request_deadline_at);
+  const launches: AttemptLaunch[] = [];
+  const queued = state.attempts
+    .filter((attempt) => attempt.status === 'dispatch_pending')
+    .sort(
+      (left, right) =>
+        slotFor(state, left.slot_id).position -
+        slotFor(state, right.slot_id).position,
+    );
+  for (const attempt of queued) {
+    if (
+      attempt.delivery_lease_expires_at &&
+      nowMs < Date.parse(attempt.delivery_lease_expires_at)
+    ) {
+      continue;
+    }
+    const deliveryLeaseId = dependencies.ids.next('delivery_lease');
+    const attemptDeadlineMs =
+      attempt.profile.invocation === 'inline'
+        ? state.inline_attempt_deadline_ms
+        : state.background_attempt_deadline_ms;
+    attempt.deadline_at = iso(
+      Math.min(nowMs + attemptDeadlineMs, requestDeadlineMs),
+    );
+    const leaseExpiresAt = iso(
+      Math.min(
+        nowMs + state.poll_interval_ms,
+        requestDeadlineMs,
+        Date.parse(attempt.deadline_at),
+      ),
+    );
+    attempt.delivery_lease_id = deliveryLeaseId;
+    attempt.delivery_lease_expires_at = leaseExpiresAt;
+    launches.push({
+      attempt_id: attempt.attempt_id,
+      slot_id: attempt.slot_id,
+      profile: attempt.profile,
+      binding: profilePlanFor(state, attempt.profile).binding,
+      query: attempt.query,
+      deadline_at: attempt.deadline_at,
+      delivery_lease_id: deliveryLeaseId,
+      idempotency_key: attempt.attempt_id,
+    });
+  }
+  return launches;
 }
 
 export function startLaunchableAttempts(
@@ -663,8 +749,16 @@ export function startLaunchableAttempts(
   const next = cloneState(state);
   let changed = false;
   let capacity = availableConcurrency(next);
-  if (capacity === 0) return { state, launches: [] };
-  const launches: AttemptLaunch[] = [];
+  const claimedBeforeScheduling = claimDispatchPendingAttempts(
+    next,
+    dependencies,
+  );
+  if (capacity === 0) {
+    return {
+      state: claimedBeforeScheduling.length > 0 ? next : state,
+      launches: claimedBeforeScheduling,
+    };
+  }
 
   const pending = [...next.pending_fallbacks].sort(
     (left, right) =>
@@ -684,7 +778,7 @@ export function startLaunchableAttempts(
       (entry) => entry.attempt_id !== fallback.attempt_id,
     );
     changed = true;
-    const launch = startAttempt(
+    const started = startAttempt(
       next,
       slot,
       {
@@ -698,14 +792,19 @@ export function startLaunchableAttempts(
       },
       dependencies,
     );
-    if (launch) {
-      launches.push(launch);
+    if (started) {
       capacity -= 1;
     }
   }
 
   if (next.pending_fallbacks.length > 0 || capacity === 0) {
-    return { state: next, launches };
+    return {
+      state: next,
+      launches: [
+        ...claimedBeforeScheduling,
+        ...claimDispatchPendingAttempts(next, dependencies),
+      ],
+    };
   }
 
   for (const slot of [...next.slots].sort(
@@ -714,7 +813,7 @@ export function startLaunchableAttempts(
     if (capacity === 0) break;
     if (slot.status !== 'unstarted') continue;
     changed = true;
-    const launch = startAttempt(
+    const started = startAttempt(
       next,
       slot,
       {
@@ -726,23 +825,50 @@ export function startLaunchableAttempts(
       },
       dependencies,
     );
-    if (launch) {
-      launches.push(launch);
+    if (started) {
       capacity -= 1;
     }
   }
-  return { state: changed ? next : state, launches };
+  const launches = [
+    ...claimedBeforeScheduling,
+    ...claimDispatchPendingAttempts(next, dependencies),
+  ];
+  return { state: changed || launches.length > 0 ? next : state, launches };
 }
 
 export function recordSubmissionAccepted(
   state: CoordinatorState,
   attemptId: string,
-  handle: DurableHandle,
+  handleInput: unknown,
   dependencies: CoordinatorDependencies,
-  adapterStateRef?: string,
+  adapterStateRefInput?: unknown,
 ): CoordinatorState {
-  const next = cloneState(state);
+  const priorAttempt = attemptFor(state, attemptId);
+  const priorStatus = priorAttempt.status;
+  if (!canHaveRemoteAcceptanceUncertainty(priorAttempt.profile)) {
+    throw new Error('Only durable background profiles can be submitted.');
+  }
+  if (priorStatus !== 'submitting' && priorStatus !== 'acceptance_unknown') {
+    throw new Error(
+      'Only a submitting or acceptance-unknown attempt can be accepted.',
+    );
+  }
+  const deadlineState = advanceDeadlines(state, dependencies);
+  if (deadlineState.status !== 'running') return deadlineState;
+  const next = cloneState(deadlineState);
   const attempt = attemptFor(next, attemptId);
+  if (TERMINAL_ATTEMPT_STATUSES.has(attempt.status)) return next;
+  if (
+    priorStatus !== 'acceptance_unknown' &&
+    attempt.status === 'acceptance_unknown'
+  ) {
+    return next;
+  }
+  const handle = DurableHandleSchema.parse(handleInput);
+  const adapterStateRef =
+    adapterStateRefInput === undefined
+      ? undefined
+      : OpaqueIdSchema.parse(adapterStateRefInput);
   if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
     throw new Error('Only durable background profiles can be submitted.');
   }
@@ -778,11 +904,59 @@ export function recordSubmissionAccepted(
   return next;
 }
 
+export function recordLaunchDispatched(
+  state: CoordinatorState,
+  attemptId: string,
+  deliveryLeaseIdInput: unknown,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  const deadlineState = advanceDeadlines(state, dependencies);
+  if (deadlineState.status !== 'running') return deadlineState;
+  const next = cloneState(deadlineState);
+  const attempt = attemptFor(next, attemptId);
+  const deliveryLeaseId = OpaqueIdSchema.parse(deliveryLeaseIdInput);
+  if (attempt.status !== 'dispatch_pending') {
+    throw new Error('Only a dispatch-pending attempt can begin delivery.');
+  }
+  if (attempt.delivery_lease_id !== deliveryLeaseId) {
+    throw new Error('The dispatch delivery lease does not match the attempt.');
+  }
+  const startedAtMs = dependencies.clock.now();
+  if (
+    !attempt.delivery_lease_expires_at ||
+    startedAtMs >= Date.parse(attempt.delivery_lease_expires_at)
+  ) {
+    throw new Error('The dispatch delivery lease has expired.');
+  }
+  attempt.status = canHaveRemoteAcceptanceUncertainty(attempt.profile)
+    ? 'submitting'
+    : 'running';
+  attempt.started_at = iso(startedAtMs);
+  attempt.delivery_lease_id = undefined;
+  attempt.delivery_lease_expires_at = undefined;
+  slotFor(next, attempt.slot_id).status = attempt.status;
+  appendAttemptStarted(next, attempt, dependencies);
+  return next;
+}
+
 export function recordAttemptRunning(
   state: CoordinatorState,
   attemptId: string,
+  dependencies: CoordinatorDependencies,
 ): CoordinatorState {
-  const next = cloneState(state);
+  const priorAttempt = attemptFor(state, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(priorAttempt.profile)) {
+    throw new Error(
+      'Only durable background submissions can transition from submitted to running.',
+    );
+  }
+  if (priorAttempt.status !== 'submitted') {
+    throw new Error('Only a submitted attempt can transition to running.');
+  }
+  const deadlineState = advanceDeadlines(state, dependencies);
+  const deadlineAttempt = attemptFor(deadlineState, attemptId);
+  if (deadlineAttempt.status !== 'submitted') return deadlineState;
+  const next = cloneState(deadlineState);
   const attempt = attemptFor(next, attemptId);
   if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
     throw new Error(
@@ -798,15 +972,20 @@ export function recordAttemptRunning(
   return next;
 }
 
-export function recordAcceptanceUnknown(
+function markAcceptanceUnknownUnchecked(
   state: CoordinatorState,
   attemptId: string,
   dependencies: CoordinatorDependencies,
-  adapterStateRef?: string,
-  reason: UnresolvedAcceptance['reason'] = 'submission_response_uncertain',
+  adapterStateRefInput?: unknown,
+  reasonInput: unknown = 'submission_response_uncertain',
 ): CoordinatorState {
   const next = cloneState(state);
   const attempt = attemptFor(next, attemptId);
+  const adapterStateRef =
+    adapterStateRefInput === undefined
+      ? undefined
+      : OpaqueIdSchema.parse(adapterStateRefInput);
+  const reason = UnresolvedAcceptanceReasonSchema.parse(reasonInput);
   if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
     throw new Error(
       'Only durable background profiles can have unknown acceptance.',
@@ -827,12 +1006,68 @@ export function recordAcceptanceUnknown(
   return next;
 }
 
+export function recordAcceptanceUnknown(
+  state: CoordinatorState,
+  attemptId: string,
+  dependencies: CoordinatorDependencies,
+  adapterStateRefInput?: unknown,
+  reasonInput: unknown = 'submission_response_uncertain',
+): CoordinatorState {
+  const priorAttempt = attemptFor(state, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(priorAttempt.profile)) {
+    throw new Error(
+      'Only durable background profiles can have unknown acceptance.',
+    );
+  }
+  if (priorAttempt.status !== 'submitting') {
+    throw new Error('Only a submitting attempt can become acceptance-unknown.');
+  }
+  const deadlineState = advanceDeadlines(state, dependencies);
+  const deadlineAttempt = attemptFor(deadlineState, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(deadlineAttempt.profile)) {
+    throw new Error(
+      'Only durable background profiles can have unknown acceptance.',
+    );
+  }
+  if (deadlineAttempt.status !== 'submitting') return deadlineState;
+  return markAcceptanceUnknownUnchecked(
+    deadlineState,
+    attemptId,
+    dependencies,
+    adapterStateRefInput,
+    reasonInput,
+  );
+}
+
 export function recordTransientPollFailure(
   state: CoordinatorState,
   attemptId: string,
-  error: StructuredError,
+  errorInput: unknown,
+  dependencies: CoordinatorDependencies,
 ): CoordinatorState {
-  const next = cloneState(state);
+  const priorAttempt = attemptFor(state, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(priorAttempt.profile)) {
+    throw new Error('Transient poll failures require durable background work.');
+  }
+  if (
+    priorAttempt.status !== 'submitted' &&
+    priorAttempt.status !== 'running'
+  ) {
+    throw new Error('Transient poll failures require an accepted attempt.');
+  }
+  const error = StructuredErrorSchema.parse(errorInput);
+  if (!error.retryable) {
+    throw new Error('Transient poll failures must carry a retryable error.');
+  }
+  const deadlineState = advanceDeadlines(state, dependencies);
+  const deadlineAttempt = attemptFor(deadlineState, attemptId);
+  if (
+    deadlineAttempt.status !== 'submitted' &&
+    deadlineAttempt.status !== 'running'
+  ) {
+    return deadlineState;
+  }
+  const next = cloneState(deadlineState);
   const attempt = attemptFor(next, attemptId);
   if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
     throw new Error('Transient poll failures require durable background work.');
@@ -847,7 +1082,7 @@ export function recordTransientPollFailure(
   return next;
 }
 
-export function recordAttemptFinished(
+function finishAttemptUnchecked(
   state: CoordinatorState,
   attemptId: string,
   input: AttemptFinishedInput,
@@ -857,7 +1092,7 @@ export function recordAttemptFinished(
   const attempt = attemptFor(next, attemptId);
   if (
     TERMINAL_ATTEMPT_STATUSES.has(attempt.status) ||
-    attempt.status === 'acceptance_unknown'
+    attempt.status === 'dispatch_pending'
   ) {
     throw new Error('The attempt cannot transition to a terminal outcome.');
   }
@@ -886,11 +1121,6 @@ export function recordAttemptFinished(
   attempt.transient_poll_error = undefined;
   attempt.actual_cost_microusd = input.actual_cost_microusd;
   if (input.actual_cost_microusd !== undefined) {
-    if (!/^(?:0|[1-9]\d*)$/.test(input.actual_cost_microusd)) {
-      throw new Error(
-        'Actual cost must be an exact non-negative integer string.',
-      );
-    }
     next.budget.actual_cost_microusd = exactAdd(
       next.budget.actual_cost_microusd,
       input.actual_cost_microusd,
@@ -910,6 +1140,61 @@ export function recordAttemptFinished(
   }
   appendAttemptFinished(next, attempt, dependencies);
   return next;
+}
+
+export function recordAttemptFinished(
+  state: CoordinatorState,
+  attemptId: string,
+  input: unknown,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  const deadlineState = advanceDeadlines(state, dependencies);
+  if (deadlineState.status !== 'running') return deadlineState;
+  const attempt = attemptFor(deadlineState, attemptId);
+  if (
+    TERMINAL_ATTEMPT_STATUSES.has(attempt.status) ||
+    attempt.status === 'acceptance_unknown'
+  ) {
+    return deadlineState;
+  }
+  return finishAttemptUnchecked(
+    deadlineState,
+    attemptId,
+    AttemptFinishedInputSchema.parse(input),
+    dependencies,
+  );
+}
+
+export function recordAcceptanceRejected(
+  state: CoordinatorState,
+  attemptId: string,
+  errorInput: unknown,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  const priorAttempt = attemptFor(state, attemptId);
+  if (priorAttempt.status !== 'acceptance_unknown') {
+    throw new Error(
+      'Only an acceptance-unknown attempt can be definitively rejected.',
+    );
+  }
+  const deadlineState = advanceDeadlines(state, dependencies);
+  if (deadlineState.status !== 'running') return deadlineState;
+  const attempt = attemptFor(deadlineState, attemptId);
+  if (attempt.status !== 'acceptance_unknown') {
+    throw new Error(
+      'Only an acceptance-unknown attempt can be definitively rejected.',
+    );
+  }
+  const next = cloneState(deadlineState);
+  next.unresolved_acceptances = next.unresolved_acceptances.filter(
+    (entry) => entry.attempt_id !== attemptId,
+  );
+  return finishAttemptUnchecked(
+    next,
+    attemptId,
+    { outcome: 'failed', error: StructuredErrorSchema.parse(errorInput) },
+    dependencies,
+  );
 }
 
 export interface FallbackRoundResult {
@@ -952,6 +1237,7 @@ export function claimFallbackRound(
     .sort((left, right) => left.position - right.position);
   if (failedSlots.length === 0) return { state, claims: [] };
   const claims: PendingFallbackLaunch[] = [];
+  let roundReservations = '0';
 
   for (const slot of failedSlots) {
     const replaced = latestAttempt(next, slot);
@@ -964,6 +1250,11 @@ export function claimFallbackRound(
           entry.eligible_slot_ids.includes(slot.slot_id) &&
           !next.used_profile_keys.includes(
             profileIdentityKey(entry.profile.identity),
+          ) &&
+          budgetPermitsLaunch(
+            next,
+            reservationFor(next, entry.profile),
+            roundReservations,
           ),
       );
     if (!candidate) {
@@ -980,7 +1271,10 @@ export function claimFallbackRound(
       replaces_attempt_id: replaced.attempt_id,
     };
     candidate.claimed_by_slot_id = slot.slot_id;
-    next.claimed_candidate_ids.push(candidate.candidate_id);
+    roundReservations = exactAdd(
+      roundReservations,
+      reservationFor(next, candidate.profile),
+    );
     next.used_profile_keys.push(profileIdentityKey(candidate.profile.identity));
     next.pending_fallbacks.push(pending);
     slot.status = 'fallback_pending';
@@ -1003,15 +1297,17 @@ export function claimFallbackRound(
 export function cancelCoordination(
   state: CoordinatorState,
   dependencies: CoordinatorDependencies,
-  error: StructuredError = cancellationError(),
+  errorInput: unknown = cancellationError(),
 ): CoordinatorState {
   if (state.status !== 'running') return state;
+  const error = StructuredErrorSchema.parse(errorInput);
   const next = cloneState(state);
   const cancelledAt = iso(dependencies.clock.now());
   next.cancellation = { requested_at: cancelledAt, error };
 
   for (const attempt of next.attempts) {
     if (TERMINAL_ATTEMPT_STATUSES.has(attempt.status)) continue;
+    const wasDispatchPending = attempt.status === 'dispatch_pending';
     if (
       canHaveRemoteAcceptanceUncertainty(attempt.profile) &&
       (attempt.status === 'submitting' ||
@@ -1027,10 +1323,12 @@ export function cancelCoordination(
     attempt.status = 'cancelled';
     attempt.finished_at = cancelledAt;
     attempt.error = error;
-    appendAttemptFinished(next, attempt, dependencies);
+    if (!wasDispatchPending) {
+      appendAttemptFinished(next, attempt, dependencies);
+    }
   }
   for (const slot of next.slots) {
-    if (slot.status === 'succeeded') continue;
+    if (TERMINAL_SLOT_STATUSES.has(slot.status)) continue;
     slot.status = 'cancelled';
     slot.error = error;
     slot.fallback_exhausted = true;
@@ -1047,10 +1345,11 @@ export function cancelCoordination(
 
 export function failCoordination(
   state: CoordinatorState,
-  error: StructuredError,
+  errorInput: unknown,
   dependencies: CoordinatorDependencies,
 ): CoordinatorState {
   if (state.status !== 'running') return state;
+  const error = StructuredErrorSchema.parse(errorInput);
   const next = cloneState(state);
   const failedAt = iso(dependencies.clock.now());
   next.infrastructure_error = error;
@@ -1068,13 +1367,14 @@ export function failCoordination(
         'infrastructure_failure_while_acceptance_unknown',
       );
     }
+    const wasDispatchPending = attempt.status === 'dispatch_pending';
     attempt.status = 'failed';
     attempt.finished_at = failedAt;
     attempt.error = error;
-    appendAttemptFinished(next, attempt, dependencies);
+    if (!wasDispatchPending) appendAttemptFinished(next, attempt, dependencies);
   }
   for (const slot of next.slots) {
-    if (slot.status === 'succeeded') continue;
+    if (TERMINAL_SLOT_STATUSES.has(slot.status)) continue;
     slot.status = 'failed';
     slot.error = error;
     slot.fallback_exhausted = true;
@@ -1124,6 +1424,7 @@ export function advanceDeadlines(
     const error = requestDeadlineError();
     for (const attempt of next.attempts) {
       if (TERMINAL_ATTEMPT_STATUSES.has(attempt.status)) continue;
+      const wasDispatchPending = attempt.status === 'dispatch_pending';
       if (
         canHaveRemoteAcceptanceUncertainty(attempt.profile) &&
         (attempt.status === 'submitting' ||
@@ -1144,12 +1445,19 @@ export function advanceDeadlines(
       slot.status = 'timed_out';
       slot.error = error;
       slot.fallback_exhausted = true;
-      appendAttemptFinished(next, attempt, dependencies);
+      if (!wasDispatchPending)
+        appendAttemptFinished(next, attempt, dependencies);
     }
     for (const slot of next.slots) {
-      if (slot.status === 'succeeded') continue;
-      if (!slot.latest_attempt_id) slot.status = 'cancelled';
-      slot.error = error;
+      if (TERMINAL_SLOT_STATUSES.has(slot.status)) continue;
+      const latest = latestAttempt(next, slot);
+      if (latest && TERMINAL_ATTEMPT_STATUSES.has(latest.status)) {
+        slot.status = latest.status;
+        slot.error = latest.error;
+      } else {
+        slot.status = latest ? 'timed_out' : 'cancelled';
+        slot.error = error;
+      }
       slot.fallback_exhausted = true;
     }
     next.pending_fallbacks = [];
@@ -1176,12 +1484,13 @@ export function advanceDeadlines(
     if (
       nowMs < Date.parse(current.deadline_at) ||
       TERMINAL_ATTEMPT_STATUSES.has(current.status) ||
+      current.status === 'dispatch_pending' ||
       current.status === 'acceptance_unknown'
     ) {
       continue;
     }
     if (current.status === 'submitting') {
-      next = recordAcceptanceUnknown(
+      next = markAcceptanceUnknownUnchecked(
         next,
         current.attempt_id,
         dependencies,
@@ -1189,7 +1498,7 @@ export function advanceDeadlines(
         'submission_deadline_exceeded',
       );
     } else {
-      next = recordAttemptFinished(
+      next = finishAttemptUnchecked(
         next,
         current.attempt_id,
         { outcome: 'timed_out', error: attemptDeadlineError() },

--- a/src/core/coordinator.ts
+++ b/src/core/coordinator.ts
@@ -1,0 +1,1316 @@
+import type {
+  DurableHandle,
+  ExecutionProfile,
+  StructuredError,
+} from '../contracts/domain/index.js';
+import type { LifecycleEvent } from '../contracts/interchange/lifecycle.js';
+import { INTERCHANGE_VERSION } from '../contracts/interchange/request.js';
+import {
+  assertCompareAndSwapAttemptBudget,
+  type CoordinationStateStore,
+  type VersionedCoordinationState,
+} from './coordinator-store.js';
+import {
+  type AdapterBindingIdentity,
+  type PreparedResearchExecution,
+  profileIdentityKey,
+} from './execution-plan.js';
+import { RESEARCH_REQUEST_LIMITS } from './research-request.js';
+
+export type CoordinatorTerminalOutcome =
+  | 'succeeded'
+  | 'partial'
+  | 'unsuccessful'
+  | 'cancelled'
+  | 'failed';
+
+export type CoordinatorStatus = 'running' | CoordinatorTerminalOutcome;
+
+export type CoordinatorAttemptStatus =
+  | 'submitting'
+  | 'acceptance_unknown'
+  | 'submitted'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'timed_out'
+  | 'cancelled';
+
+export type CoordinatorSlotStatus =
+  | 'unstarted'
+  | 'fallback_pending'
+  | CoordinatorAttemptStatus;
+
+export interface CoordinatorBudgetState {
+  max_estimated_cost_microusd?: string;
+  max_actual_cost_microusd?: string;
+  reserved_estimated_cost_microusd: string;
+  actual_cost_microusd: string;
+}
+
+export interface CoordinatorSlotState {
+  slot_id: string;
+  position: number;
+  primary: ExecutionProfile;
+  status: CoordinatorSlotStatus;
+  deadline_at: string;
+  refined_query?: string;
+  latest_attempt_id?: string;
+  result_id?: string;
+  error?: StructuredError;
+  fallback_exhausted: boolean;
+}
+
+export interface CoordinatorAttemptState {
+  attempt_id: string;
+  slot_id: string;
+  attempt_number: number;
+  round: number;
+  profile: ExecutionProfile;
+  status: CoordinatorAttemptStatus;
+  query: string;
+  started_at: string;
+  deadline_at: string;
+  finished_at?: string;
+  replaces_attempt_id?: string;
+  candidate_id?: string;
+  adapter_state_ref?: string;
+  durable_handle?: DurableHandle;
+  transient_poll_error?: StructuredError;
+  result_id?: string;
+  error?: StructuredError;
+  reserved_estimated_cost_microusd: string;
+  actual_cost_microusd?: string;
+}
+
+export interface CoordinatorReserveCandidate {
+  candidate_id: string;
+  position: number;
+  profile: ExecutionProfile;
+  eligible_slot_ids: string[];
+  claimed_by_slot_id?: string;
+}
+
+export interface PendingFallbackLaunch {
+  attempt_id: string;
+  slot_id: string;
+  attempt_number: number;
+  round: number;
+  candidate_id: string;
+  replaces_attempt_id: string;
+}
+
+export interface CoordinatorCancellation {
+  requested_at: string;
+  error?: StructuredError;
+}
+
+export interface UnresolvedAcceptance {
+  attempt_id: string;
+  profile_key: string;
+  observed_at: string;
+  reason:
+    | 'submission_response_uncertain'
+    | 'submission_deadline_exceeded'
+    | 'request_deadline_exceeded'
+    | 'cancelled_while_acceptance_unknown'
+    | 'infrastructure_failure_while_acceptance_unknown';
+  adapter_state_ref?: string;
+}
+
+export interface CoordinatorState {
+  request_id: string;
+  mode: 'sync' | 'async';
+  original_query: string;
+  status: CoordinatorStatus;
+  created_at: string;
+  request_deadline_at: string;
+  inline_attempt_deadline_ms: number;
+  background_attempt_deadline_ms: number;
+  poll_interval_ms: number;
+  max_concurrency: number;
+  catalog_revision: string;
+  catalog_digest: string;
+  slots: CoordinatorSlotState[];
+  attempts: CoordinatorAttemptState[];
+  reserve: CoordinatorReserveCandidate[];
+  pending_fallbacks: PendingFallbackLaunch[];
+  claimed_candidate_ids: string[];
+  used_profile_keys: string[];
+  unresolved_acceptances: UnresolvedAcceptance[];
+  profile_plans_by_identity: PreparedResearchExecution['profile_plans_by_identity'];
+  budget: CoordinatorBudgetState;
+  cancellation?: CoordinatorCancellation;
+  infrastructure_error?: StructuredError;
+  lifecycle_sequence: number;
+  lifecycle: LifecycleEvent[];
+}
+
+export interface CoordinatorClock {
+  now(): number;
+}
+
+export interface CoordinatorIdGenerator {
+  next(scope: 'attempt' | 'event'): string;
+}
+
+export interface CoordinatorDependencies {
+  readonly clock: CoordinatorClock;
+  readonly ids: CoordinatorIdGenerator;
+}
+
+export interface AttemptLaunch {
+  readonly attempt_id: string;
+  readonly slot_id: string;
+  readonly profile: ExecutionProfile;
+  readonly binding: AdapterBindingIdentity;
+  readonly query: string;
+  readonly deadline_at: string;
+}
+
+export interface CoordinatorAdvanceResult {
+  readonly state: CoordinatorState;
+  readonly launches: readonly AttemptLaunch[];
+}
+
+export type AttemptFinishedInput =
+  | {
+      readonly outcome: 'succeeded';
+      readonly result_id: string;
+      readonly durable_handle?: DurableHandle;
+      readonly actual_cost_microusd?: string;
+    }
+  | {
+      readonly outcome: 'failed' | 'timed_out';
+      readonly error: StructuredError;
+      readonly durable_handle?: DurableHandle;
+      readonly actual_cost_microusd?: string;
+    }
+  | {
+      readonly outcome: 'cancelled';
+      readonly error?: StructuredError;
+      readonly durable_handle?: DurableHandle;
+      readonly actual_cost_microusd?: string;
+    };
+
+const ACTIVE_ATTEMPT_STATUSES = new Set<CoordinatorAttemptStatus>([
+  'submitting',
+  'submitted',
+  'running',
+]);
+
+const TERMINAL_ATTEMPT_STATUSES = new Set<CoordinatorAttemptStatus>([
+  'succeeded',
+  'failed',
+  'timed_out',
+  'cancelled',
+]);
+
+const TERMINAL_SLOT_STATUSES = new Set<CoordinatorSlotStatus>([
+  'succeeded',
+  'failed',
+  'timed_out',
+  'cancelled',
+]);
+
+function cloneState(state: CoordinatorState): CoordinatorState {
+  return structuredClone(state);
+}
+
+function iso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function exactAdd(left: string, right: string): string {
+  return (BigInt(left) + BigInt(right)).toString();
+}
+
+function exactGreaterThan(left: string, right: string): boolean {
+  return BigInt(left) > BigInt(right);
+}
+
+function appendLifecycle(state: CoordinatorState, event: LifecycleEvent): void {
+  state.lifecycle.push(event);
+  state.lifecycle_sequence += 1;
+}
+
+function eventBase(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+  occurredAt: string,
+) {
+  return {
+    interchange_version: INTERCHANGE_VERSION,
+    message_type: 'lifecycle_event' as const,
+    event_id: dependencies.ids.next('event'),
+    request_id: state.request_id,
+    sequence: state.lifecycle_sequence,
+    occurred_at: occurredAt,
+  };
+}
+
+function appendAttemptStarted(
+  state: CoordinatorState,
+  attempt: CoordinatorAttemptState,
+  dependencies: CoordinatorDependencies,
+): void {
+  appendLifecycle(state, {
+    ...eventBase(state, dependencies, attempt.started_at),
+    slot_id: attempt.slot_id,
+    attempt_id: attempt.attempt_id,
+    event_kind: 'attempt_started',
+    data: {
+      provider: attempt.profile.identity,
+      attempt_number: attempt.attempt_number,
+    },
+  });
+}
+
+function appendAttemptFinished(
+  state: CoordinatorState,
+  attempt: CoordinatorAttemptState,
+  dependencies: CoordinatorDependencies,
+): void {
+  const base = {
+    ...eventBase(
+      state,
+      dependencies,
+      attempt.finished_at ?? iso(dependencies.clock.now()),
+    ),
+    slot_id: attempt.slot_id,
+    attempt_id: attempt.attempt_id,
+    event_kind: 'attempt_finished' as const,
+  };
+  if (attempt.status === 'succeeded') {
+    appendLifecycle(state, { ...base, data: { outcome: 'succeeded' } });
+  } else if (attempt.status === 'failed' || attempt.status === 'timed_out') {
+    if (!attempt.error) {
+      throw new Error('Failed and timed-out attempts require an error.');
+    }
+    appendLifecycle(state, {
+      ...base,
+      data: { outcome: attempt.status, error: attempt.error },
+    });
+  } else if (attempt.status === 'cancelled') {
+    appendLifecycle(state, {
+      ...base,
+      data: { outcome: 'cancelled', error: attempt.error },
+    });
+  } else {
+    throw new Error(`Attempt ${attempt.attempt_id} is not terminal.`);
+  }
+}
+
+function budgetError(): StructuredError {
+  return {
+    code: 'budget_reservation_exceeded',
+    message: 'The exact runtime budget does not permit this unstarted slot.',
+    category: 'budget',
+    retryable: false,
+    fallback_allowed: false,
+  };
+}
+
+function cancellationError(): StructuredError {
+  return {
+    code: 'request_cancelled',
+    message: 'The request was cancelled by the caller.',
+    category: 'cancelled',
+    retryable: false,
+    fallback_allowed: false,
+  };
+}
+
+function attemptDeadlineError(): StructuredError {
+  return {
+    code: 'attempt_deadline_exceeded',
+    message: 'The attempt exceeded its absolute deadline.',
+    category: 'timeout',
+    retryable: true,
+    fallback_allowed: true,
+  };
+}
+
+function requestDeadlineError(): StructuredError {
+  return {
+    code: 'request_deadline_exceeded',
+    message: 'The request exceeded its absolute deadline.',
+    category: 'timeout',
+    retryable: false,
+    fallback_allowed: false,
+  };
+}
+
+function validateHandleProvider(
+  attempt: CoordinatorAttemptState,
+  handle: DurableHandle,
+): void {
+  if (
+    profileIdentityKey(handle.provider) !==
+    profileIdentityKey(attempt.profile.identity)
+  ) {
+    throw new Error('Durable handle provider must match the attempt profile.');
+  }
+}
+
+function validateTerminalHandleStatus(
+  outcome: AttemptFinishedInput['outcome'],
+  handle: DurableHandle,
+): void {
+  const coherent =
+    (outcome === 'succeeded' && handle.status === 'succeeded') ||
+    (outcome === 'failed' &&
+      (handle.status === 'failed' || handle.status === 'succeeded')) ||
+    outcome === 'cancelled' ||
+    outcome === 'timed_out';
+  if (!coherent) {
+    throw new Error(
+      `Durable handle status ${handle.status} is incoherent with ${outcome}.`,
+    );
+  }
+}
+
+function rememberUnresolvedAcceptance(
+  state: CoordinatorState,
+  attempt: CoordinatorAttemptState,
+  observedAt: string,
+  reason: UnresolvedAcceptance['reason'],
+): void {
+  const existing = state.unresolved_acceptances.find(
+    (entry) => entry.attempt_id === attempt.attempt_id,
+  );
+  const marker: UnresolvedAcceptance = {
+    attempt_id: attempt.attempt_id,
+    profile_key: profileIdentityKey(attempt.profile.identity),
+    observed_at: observedAt,
+    reason,
+    adapter_state_ref: attempt.adapter_state_ref,
+  };
+  if (existing) Object.assign(existing, marker);
+  else state.unresolved_acceptances.push(marker);
+}
+
+function profilePlanFor(state: CoordinatorState, profile: ExecutionProfile) {
+  const key = profileIdentityKey(profile.identity);
+  const plan = state.profile_plans_by_identity[key];
+  if (!plan) {
+    throw new Error(`Missing prepared profile plan for ${key}.`);
+  }
+  return plan;
+}
+
+function reservationFor(
+  state: CoordinatorState,
+  profile: ExecutionProfile,
+): string {
+  return (
+    profilePlanFor(state, profile).estimate?.estimated_cost_microusd ?? '0'
+  );
+}
+
+function budgetPermitsLaunch(
+  state: CoordinatorState,
+  reservation: string,
+): boolean {
+  const estimatedLimit = state.budget.max_estimated_cost_microusd;
+  if (
+    estimatedLimit !== undefined &&
+    exactGreaterThan(
+      exactAdd(state.budget.reserved_estimated_cost_microusd, reservation),
+      estimatedLimit,
+    )
+  ) {
+    return false;
+  }
+  const actualLimit = state.budget.max_actual_cost_microusd;
+  return !(
+    actualLimit !== undefined &&
+    exactGreaterThan(state.budget.actual_cost_microusd, actualLimit)
+  );
+}
+
+function availableConcurrency(state: CoordinatorState): number {
+  const active = state.attempts.filter((attempt) =>
+    ACTIVE_ATTEMPT_STATUSES.has(attempt.status),
+  ).length;
+  return Math.max(0, state.max_concurrency - active);
+}
+
+function hasAcceptanceUnknown(state: CoordinatorState): boolean {
+  return state.attempts.some(
+    (attempt) => attempt.status === 'acceptance_unknown',
+  );
+}
+
+function canHaveRemoteAcceptanceUncertainty(
+  profile: ExecutionProfile,
+): boolean {
+  return (
+    profile.invocation === 'background' && profile.resumability === 'durable'
+  );
+}
+
+function attemptFor(
+  state: CoordinatorState,
+  attemptId: string,
+): CoordinatorAttemptState {
+  const attempt = state.attempts.find(
+    (candidate) => candidate.attempt_id === attemptId,
+  );
+  if (!attempt) throw new Error(`Unknown attempt: ${attemptId}`);
+  return attempt;
+}
+
+function slotFor(
+  state: CoordinatorState,
+  slotId: string,
+): CoordinatorSlotState {
+  const slot = state.slots.find((candidate) => candidate.slot_id === slotId);
+  if (!slot) throw new Error(`Unknown slot: ${slotId}`);
+  return slot;
+}
+
+function latestAttempt(
+  state: CoordinatorState,
+  slot: CoordinatorSlotState,
+): CoordinatorAttemptState | undefined {
+  return slot.latest_attempt_id
+    ? state.attempts.find(
+        (attempt) => attempt.attempt_id === slot.latest_attempt_id,
+      )
+    : undefined;
+}
+
+function requestStartedEvent(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): LifecycleEvent {
+  return {
+    ...eventBase(state, dependencies, state.created_at),
+    event_kind: 'request_started',
+    data: { mode: state.mode },
+  };
+}
+
+export function createCoordinatorState(
+  prepared: PreparedResearchExecution,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  const createdAtMs = dependencies.clock.now();
+  const createdAt = iso(createdAtMs);
+  const requestDeadlineAt = iso(
+    createdAtMs + prepared.policy.limits.request_deadline_ms,
+  );
+  const state: CoordinatorState = {
+    request_id: prepared.request.request_id,
+    mode: prepared.request.mode,
+    original_query: prepared.request.query,
+    status: 'running',
+    created_at: createdAt,
+    request_deadline_at: requestDeadlineAt,
+    inline_attempt_deadline_ms:
+      prepared.policy.limits.inline_attempt_deadline_ms,
+    background_attempt_deadline_ms:
+      prepared.policy.limits.background_attempt_deadline_ms,
+    poll_interval_ms: prepared.policy.limits.poll_interval_ms,
+    max_concurrency: prepared.policy.limits.max_concurrency,
+    catalog_revision: prepared.catalog.revision,
+    catalog_digest: prepared.catalog.digest,
+    slots: prepared.request.slots.map((slot) => ({
+      slot_id: slot.slot_id,
+      position: slot.position,
+      primary: slot.primary,
+      status: 'unstarted',
+      deadline_at: requestDeadlineAt,
+      fallback_exhausted: false,
+    })),
+    attempts: [],
+    reserve: prepared.request.fallback_reserve.map((candidate) => ({
+      candidate_id: candidate.candidate_id,
+      position: candidate.position,
+      profile: candidate.profile,
+      eligible_slot_ids: [...candidate.eligible_slot_ids],
+    })),
+    pending_fallbacks: [],
+    claimed_candidate_ids: [],
+    used_profile_keys: [],
+    unresolved_acceptances: [],
+    profile_plans_by_identity: structuredClone(
+      prepared.profile_plans_by_identity,
+    ),
+    budget: {
+      max_estimated_cost_microusd:
+        prepared.policy.budgets?.max_estimated_cost_microusd,
+      max_actual_cost_microusd:
+        prepared.policy.budgets?.max_actual_cost_microusd,
+      reserved_estimated_cost_microusd: '0',
+      actual_cost_microusd: '0',
+    },
+    lifecycle_sequence: 0,
+    lifecycle: [],
+  };
+  appendLifecycle(state, requestStartedEvent(state, dependencies));
+  return state;
+}
+
+export function setRefinedSlotQuery(
+  state: CoordinatorState,
+  slotId: string,
+  query: string,
+): CoordinatorState {
+  const next = cloneState(state);
+  const slot = slotFor(next, slotId);
+  if (slot.latest_attempt_id || slot.status !== 'unstarted') {
+    throw new Error('A refined query must be set before the slot starts.');
+  }
+  const normalized = query.trim();
+  if (normalized.length === 0) {
+    throw new Error('A refined query cannot be empty.');
+  }
+  if (normalized.length > RESEARCH_REQUEST_LIMITS.queryLength) {
+    throw new Error(
+      `A refined query cannot exceed ${RESEARCH_REQUEST_LIMITS.queryLength} characters.`,
+    );
+  }
+  slot.refined_query = normalized;
+  return next;
+}
+
+function suppressSlotForBudget(
+  state: CoordinatorState,
+  slot: CoordinatorSlotState,
+): void {
+  const error = budgetError();
+  slot.status = 'cancelled';
+  slot.error = error;
+  slot.fallback_exhausted = true;
+  state.pending_fallbacks = state.pending_fallbacks.filter(
+    (pending) => pending.slot_id !== slot.slot_id,
+  );
+}
+
+function startAttempt(
+  state: CoordinatorState,
+  slot: CoordinatorSlotState,
+  attempt: Omit<
+    CoordinatorAttemptState,
+    | 'status'
+    | 'query'
+    | 'started_at'
+    | 'deadline_at'
+    | 'reserved_estimated_cost_microusd'
+  >,
+  dependencies: CoordinatorDependencies,
+): AttemptLaunch | undefined {
+  const reservation = reservationFor(state, attempt.profile);
+  if (!budgetPermitsLaunch(state, reservation)) {
+    suppressSlotForBudget(state, slot);
+    return undefined;
+  }
+
+  const startedAtMs = dependencies.clock.now();
+  const requestDeadlineMs = Date.parse(state.request_deadline_at);
+  const attemptDeadlineMs =
+    attempt.profile.invocation === 'inline'
+      ? state.inline_attempt_deadline_ms
+      : state.background_attempt_deadline_ms;
+  const started: CoordinatorAttemptState = {
+    ...attempt,
+    status: canHaveRemoteAcceptanceUncertainty(attempt.profile)
+      ? 'submitting'
+      : 'running',
+    query: slot.refined_query ?? state.original_query,
+    started_at: iso(startedAtMs),
+    deadline_at: iso(
+      Math.min(startedAtMs + attemptDeadlineMs, requestDeadlineMs),
+    ),
+    reserved_estimated_cost_microusd: reservation,
+  };
+  state.attempts.push(started);
+  slot.status = started.status;
+  slot.latest_attempt_id = started.attempt_id;
+  slot.error = undefined;
+  slot.result_id = undefined;
+  const key = profileIdentityKey(started.profile.identity);
+  if (!state.used_profile_keys.includes(key)) state.used_profile_keys.push(key);
+  state.budget.reserved_estimated_cost_microusd = exactAdd(
+    state.budget.reserved_estimated_cost_microusd,
+    reservation,
+  );
+  appendAttemptStarted(state, started, dependencies);
+  return {
+    attempt_id: started.attempt_id,
+    slot_id: started.slot_id,
+    profile: started.profile,
+    binding: profilePlanFor(state, started.profile).binding,
+    query: started.query,
+    deadline_at: started.deadline_at,
+  };
+}
+
+export function startLaunchableAttempts(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): CoordinatorAdvanceResult {
+  if (
+    state.status !== 'running' ||
+    state.cancellation ||
+    hasAcceptanceUnknown(state)
+  ) {
+    return { state, launches: [] };
+  }
+
+  const next = cloneState(state);
+  let changed = false;
+  let capacity = availableConcurrency(next);
+  if (capacity === 0) return { state, launches: [] };
+  const launches: AttemptLaunch[] = [];
+
+  const pending = [...next.pending_fallbacks].sort(
+    (left, right) =>
+      slotFor(next, left.slot_id).position -
+      slotFor(next, right.slot_id).position,
+  );
+  for (const fallback of pending) {
+    if (capacity === 0) break;
+    const slot = slotFor(next, fallback.slot_id);
+    const candidate = next.reserve.find(
+      (entry) => entry.candidate_id === fallback.candidate_id,
+    );
+    if (!candidate) {
+      throw new Error(`Missing fallback candidate ${fallback.candidate_id}.`);
+    }
+    next.pending_fallbacks = next.pending_fallbacks.filter(
+      (entry) => entry.attempt_id !== fallback.attempt_id,
+    );
+    changed = true;
+    const launch = startAttempt(
+      next,
+      slot,
+      {
+        attempt_id: fallback.attempt_id,
+        slot_id: fallback.slot_id,
+        attempt_number: fallback.attempt_number,
+        round: fallback.round,
+        profile: candidate.profile,
+        replaces_attempt_id: fallback.replaces_attempt_id,
+        candidate_id: fallback.candidate_id,
+      },
+      dependencies,
+    );
+    if (launch) {
+      launches.push(launch);
+      capacity -= 1;
+    }
+  }
+
+  if (next.pending_fallbacks.length > 0 || capacity === 0) {
+    return { state: next, launches };
+  }
+
+  for (const slot of [...next.slots].sort(
+    (left, right) => left.position - right.position,
+  )) {
+    if (capacity === 0) break;
+    if (slot.status !== 'unstarted') continue;
+    changed = true;
+    const launch = startAttempt(
+      next,
+      slot,
+      {
+        attempt_id: dependencies.ids.next('attempt'),
+        slot_id: slot.slot_id,
+        attempt_number: 1,
+        round: 0,
+        profile: slot.primary,
+      },
+      dependencies,
+    );
+    if (launch) {
+      launches.push(launch);
+      capacity -= 1;
+    }
+  }
+  return { state: changed ? next : state, launches };
+}
+
+export function recordSubmissionAccepted(
+  state: CoordinatorState,
+  attemptId: string,
+  handle: DurableHandle,
+  dependencies: CoordinatorDependencies,
+  adapterStateRef?: string,
+): CoordinatorState {
+  const next = cloneState(state);
+  const attempt = attemptFor(next, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
+    throw new Error('Only durable background profiles can be submitted.');
+  }
+  if (
+    attempt.status !== 'submitting' &&
+    attempt.status !== 'acceptance_unknown'
+  ) {
+    throw new Error(
+      'Only a submitting or acceptance-unknown attempt can be accepted.',
+    );
+  }
+  validateHandleProvider(attempt, handle);
+  if (handle.status !== 'pending' && handle.status !== 'running') {
+    throw new Error(
+      'A newly accepted durable handle must be pending or running.',
+    );
+  }
+  attempt.status = 'submitted';
+  attempt.durable_handle = handle;
+  attempt.adapter_state_ref = adapterStateRef ?? attempt.adapter_state_ref;
+  attempt.transient_poll_error = undefined;
+  next.unresolved_acceptances = next.unresolved_acceptances.filter(
+    (entry) => entry.attempt_id !== attempt.attempt_id,
+  );
+  slotFor(next, attempt.slot_id).status = 'submitted';
+  appendLifecycle(next, {
+    ...eventBase(next, dependencies, iso(dependencies.clock.now())),
+    slot_id: attempt.slot_id,
+    attempt_id: attempt.attempt_id,
+    event_kind: 'durable_task_submitted',
+    data: { handle },
+  });
+  return next;
+}
+
+export function recordAttemptRunning(
+  state: CoordinatorState,
+  attemptId: string,
+): CoordinatorState {
+  const next = cloneState(state);
+  const attempt = attemptFor(next, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
+    throw new Error(
+      'Only durable background submissions can transition from submitted to running.',
+    );
+  }
+  if (attempt.status !== 'submitted') {
+    throw new Error('Only a submitted attempt can transition to running.');
+  }
+  attempt.status = 'running';
+  attempt.transient_poll_error = undefined;
+  slotFor(next, attempt.slot_id).status = 'running';
+  return next;
+}
+
+export function recordAcceptanceUnknown(
+  state: CoordinatorState,
+  attemptId: string,
+  dependencies: CoordinatorDependencies,
+  adapterStateRef?: string,
+  reason: UnresolvedAcceptance['reason'] = 'submission_response_uncertain',
+): CoordinatorState {
+  const next = cloneState(state);
+  const attempt = attemptFor(next, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
+    throw new Error(
+      'Only durable background profiles can have unknown acceptance.',
+    );
+  }
+  if (attempt.status !== 'submitting') {
+    throw new Error('Only a submitting attempt can become acceptance-unknown.');
+  }
+  attempt.status = 'acceptance_unknown';
+  attempt.adapter_state_ref = adapterStateRef;
+  slotFor(next, attempt.slot_id).status = 'acceptance_unknown';
+  rememberUnresolvedAcceptance(
+    next,
+    attempt,
+    iso(dependencies.clock.now()),
+    reason,
+  );
+  return next;
+}
+
+export function recordTransientPollFailure(
+  state: CoordinatorState,
+  attemptId: string,
+  error: StructuredError,
+): CoordinatorState {
+  const next = cloneState(state);
+  const attempt = attemptFor(next, attemptId);
+  if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
+    throw new Error('Transient poll failures require durable background work.');
+  }
+  if (attempt.status !== 'submitted' && attempt.status !== 'running') {
+    throw new Error('Transient poll failures require an accepted attempt.');
+  }
+  if (!error.retryable) {
+    throw new Error('Transient poll failures must carry a retryable error.');
+  }
+  attempt.transient_poll_error = error;
+  return next;
+}
+
+export function recordAttemptFinished(
+  state: CoordinatorState,
+  attemptId: string,
+  input: AttemptFinishedInput,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  const next = cloneState(state);
+  const attempt = attemptFor(next, attemptId);
+  if (
+    TERMINAL_ATTEMPT_STATUSES.has(attempt.status) ||
+    attempt.status === 'acceptance_unknown'
+  ) {
+    throw new Error('The attempt cannot transition to a terminal outcome.');
+  }
+  if (input.durable_handle) {
+    if (!canHaveRemoteAcceptanceUncertainty(attempt.profile)) {
+      throw new Error(
+        'Durable handles are permitted only on durable background attempts.',
+      );
+    }
+    validateHandleProvider(attempt, input.durable_handle);
+    validateTerminalHandleStatus(input.outcome, input.durable_handle);
+  }
+  const effectiveHandle = input.durable_handle ?? attempt.durable_handle;
+  if (
+    input.outcome === 'succeeded' &&
+    effectiveHandle &&
+    effectiveHandle.status !== 'succeeded'
+  ) {
+    throw new Error(
+      `A succeeded durable attempt cannot retain a ${effectiveHandle.status} handle; the effective handle must be succeeded.`,
+    );
+  }
+  attempt.status = input.outcome;
+  attempt.finished_at = iso(dependencies.clock.now());
+  attempt.durable_handle = input.durable_handle ?? attempt.durable_handle;
+  attempt.transient_poll_error = undefined;
+  attempt.actual_cost_microusd = input.actual_cost_microusd;
+  if (input.actual_cost_microusd !== undefined) {
+    if (!/^(?:0|[1-9]\d*)$/.test(input.actual_cost_microusd)) {
+      throw new Error(
+        'Actual cost must be an exact non-negative integer string.',
+      );
+    }
+    next.budget.actual_cost_microusd = exactAdd(
+      next.budget.actual_cost_microusd,
+      input.actual_cost_microusd,
+    );
+  }
+  const slot = slotFor(next, attempt.slot_id);
+  slot.status = input.outcome;
+  slot.error = 'error' in input ? input.error : undefined;
+  if (input.outcome === 'succeeded') {
+    attempt.result_id = input.result_id;
+    slot.result_id = input.result_id;
+  } else if (input.outcome === 'failed' || input.outcome === 'timed_out') {
+    attempt.error = input.error;
+  } else {
+    attempt.error = input.error;
+    slot.fallback_exhausted = true;
+  }
+  appendAttemptFinished(next, attempt, dependencies);
+  return next;
+}
+
+export interface FallbackRoundResult {
+  readonly state: CoordinatorState;
+  readonly claims: readonly PendingFallbackLaunch[];
+}
+
+export function claimFallbackRound(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): FallbackRoundResult {
+  if (
+    state.status !== 'running' ||
+    state.cancellation ||
+    hasAcceptanceUnknown(state) ||
+    state.pending_fallbacks.length > 0 ||
+    state.slots.some((slot) => slot.status === 'unstarted') ||
+    state.attempts.some((attempt) =>
+      ACTIVE_ATTEMPT_STATUSES.has(attempt.status),
+    )
+  ) {
+    return { state, claims: [] };
+  }
+
+  const next = cloneState(state);
+  const currentRound = Math.max(
+    -1,
+    ...next.attempts.map((attempt) => attempt.round),
+  );
+  const failedSlots = next.slots
+    .filter((slot) => {
+      const attempt = latestAttempt(next, slot);
+      return (
+        !slot.fallback_exhausted &&
+        attempt?.round === currentRound &&
+        (attempt.status === 'failed' || attempt.status === 'timed_out') &&
+        attempt.error?.fallback_allowed === true
+      );
+    })
+    .sort((left, right) => left.position - right.position);
+  if (failedSlots.length === 0) return { state, claims: [] };
+  const claims: PendingFallbackLaunch[] = [];
+
+  for (const slot of failedSlots) {
+    const replaced = latestAttempt(next, slot);
+    if (!replaced) continue;
+    const candidate = [...next.reserve]
+      .sort((left, right) => left.position - right.position)
+      .find(
+        (entry) =>
+          entry.claimed_by_slot_id === undefined &&
+          entry.eligible_slot_ids.includes(slot.slot_id) &&
+          !next.used_profile_keys.includes(
+            profileIdentityKey(entry.profile.identity),
+          ),
+      );
+    if (!candidate) {
+      slot.fallback_exhausted = true;
+      continue;
+    }
+
+    const pending: PendingFallbackLaunch = {
+      attempt_id: dependencies.ids.next('attempt'),
+      slot_id: slot.slot_id,
+      attempt_number: replaced.attempt_number + 1,
+      round: currentRound + 1,
+      candidate_id: candidate.candidate_id,
+      replaces_attempt_id: replaced.attempt_id,
+    };
+    candidate.claimed_by_slot_id = slot.slot_id;
+    next.claimed_candidate_ids.push(candidate.candidate_id);
+    next.used_profile_keys.push(profileIdentityKey(candidate.profile.identity));
+    next.pending_fallbacks.push(pending);
+    slot.status = 'fallback_pending';
+    appendLifecycle(next, {
+      ...eventBase(next, dependencies, iso(dependencies.clock.now())),
+      slot_id: slot.slot_id,
+      attempt_id: pending.attempt_id,
+      event_kind: 'fallback_selected',
+      data: {
+        failed_attempt_id: replaced.attempt_id,
+        replacement_attempt_id: pending.attempt_id,
+        candidate_id: pending.candidate_id,
+      },
+    });
+    claims.push(pending);
+  }
+  return { state: next, claims };
+}
+
+export function cancelCoordination(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+  error: StructuredError = cancellationError(),
+): CoordinatorState {
+  if (state.status !== 'running') return state;
+  const next = cloneState(state);
+  const cancelledAt = iso(dependencies.clock.now());
+  next.cancellation = { requested_at: cancelledAt, error };
+
+  for (const attempt of next.attempts) {
+    if (TERMINAL_ATTEMPT_STATUSES.has(attempt.status)) continue;
+    if (
+      canHaveRemoteAcceptanceUncertainty(attempt.profile) &&
+      (attempt.status === 'submitting' ||
+        attempt.status === 'acceptance_unknown')
+    ) {
+      rememberUnresolvedAcceptance(
+        next,
+        attempt,
+        cancelledAt,
+        'cancelled_while_acceptance_unknown',
+      );
+    }
+    attempt.status = 'cancelled';
+    attempt.finished_at = cancelledAt;
+    attempt.error = error;
+    appendAttemptFinished(next, attempt, dependencies);
+  }
+  for (const slot of next.slots) {
+    if (slot.status === 'succeeded') continue;
+    slot.status = 'cancelled';
+    slot.error = error;
+    slot.fallback_exhausted = true;
+  }
+  next.pending_fallbacks = [];
+  next.status = 'cancelled';
+  appendLifecycle(next, {
+    ...eventBase(next, dependencies, cancelledAt),
+    event_kind: 'request_cancelled',
+    data: { error },
+  });
+  return next;
+}
+
+export function failCoordination(
+  state: CoordinatorState,
+  error: StructuredError,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  if (state.status !== 'running') return state;
+  const next = cloneState(state);
+  const failedAt = iso(dependencies.clock.now());
+  next.infrastructure_error = error;
+  for (const attempt of next.attempts) {
+    if (TERMINAL_ATTEMPT_STATUSES.has(attempt.status)) continue;
+    if (
+      canHaveRemoteAcceptanceUncertainty(attempt.profile) &&
+      (attempt.status === 'submitting' ||
+        attempt.status === 'acceptance_unknown')
+    ) {
+      rememberUnresolvedAcceptance(
+        next,
+        attempt,
+        failedAt,
+        'infrastructure_failure_while_acceptance_unknown',
+      );
+    }
+    attempt.status = 'failed';
+    attempt.finished_at = failedAt;
+    attempt.error = error;
+    appendAttemptFinished(next, attempt, dependencies);
+  }
+  for (const slot of next.slots) {
+    if (slot.status === 'succeeded') continue;
+    slot.status = 'failed';
+    slot.error = error;
+    slot.fallback_exhausted = true;
+  }
+  next.pending_fallbacks = [];
+  next.status = 'failed';
+  appendLifecycle(next, {
+    ...eventBase(next, dependencies, failedAt),
+    event_kind: 'request_failed',
+    data: { error },
+  });
+  return next;
+}
+
+export function mapCoordinatorOutcome(
+  state: CoordinatorState,
+): CoordinatorTerminalOutcome | undefined {
+  if (state.cancellation || state.status === 'cancelled') return 'cancelled';
+  if (state.infrastructure_error || state.status === 'failed') return 'failed';
+  if (state.slots.some((slot) => !TERMINAL_SLOT_STATUSES.has(slot.status))) {
+    return undefined;
+  }
+  const succeeded = state.slots.filter(
+    (slot) => slot.status === 'succeeded',
+  ).length;
+  if (succeeded === state.slots.length) return 'succeeded';
+  if (succeeded > 0) return 'partial';
+  return 'unsuccessful';
+}
+
+/**
+ * Applies absolute request and attempt deadlines inside the reducer. Submission
+ * expiry becomes acceptance uncertainty because a lost submit response cannot
+ * prove the provider rejected the work. Request expiry ends local execution,
+ * prohibits fallback, and retains an unresolved marker for such attempts.
+ */
+export function advanceDeadlines(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  if (state.status !== 'running') return state;
+  const nowMs = dependencies.clock.now();
+  const now = iso(nowMs);
+
+  if (nowMs >= Date.parse(state.request_deadline_at)) {
+    const next = cloneState(state);
+    const error = requestDeadlineError();
+    for (const attempt of next.attempts) {
+      if (TERMINAL_ATTEMPT_STATUSES.has(attempt.status)) continue;
+      if (
+        canHaveRemoteAcceptanceUncertainty(attempt.profile) &&
+        (attempt.status === 'submitting' ||
+          attempt.status === 'acceptance_unknown')
+      ) {
+        rememberUnresolvedAcceptance(
+          next,
+          attempt,
+          now,
+          'request_deadline_exceeded',
+        );
+      }
+      attempt.status = 'timed_out';
+      attempt.finished_at = now;
+      attempt.error = error;
+      attempt.transient_poll_error = undefined;
+      const slot = slotFor(next, attempt.slot_id);
+      slot.status = 'timed_out';
+      slot.error = error;
+      slot.fallback_exhausted = true;
+      appendAttemptFinished(next, attempt, dependencies);
+    }
+    for (const slot of next.slots) {
+      if (slot.status === 'succeeded') continue;
+      if (!slot.latest_attempt_id) slot.status = 'cancelled';
+      slot.error = error;
+      slot.fallback_exhausted = true;
+    }
+    next.pending_fallbacks = [];
+    const succeeded = next.slots.filter(
+      (slot) => slot.status === 'succeeded',
+    ).length;
+    const outcome: Exclude<CoordinatorTerminalOutcome, 'cancelled' | 'failed'> =
+      succeeded === next.slots.length
+        ? 'succeeded'
+        : succeeded > 0
+          ? 'partial'
+          : 'unsuccessful';
+    next.status = outcome;
+    appendLifecycle(next, {
+      ...eventBase(next, dependencies, now),
+      event_kind: 'request_completed',
+      data: { outcome },
+    });
+    return next;
+  }
+
+  let next = state;
+  for (const current of state.attempts) {
+    if (
+      nowMs < Date.parse(current.deadline_at) ||
+      TERMINAL_ATTEMPT_STATUSES.has(current.status) ||
+      current.status === 'acceptance_unknown'
+    ) {
+      continue;
+    }
+    if (current.status === 'submitting') {
+      next = recordAcceptanceUnknown(
+        next,
+        current.attempt_id,
+        dependencies,
+        current.adapter_state_ref,
+        'submission_deadline_exceeded',
+      );
+    } else {
+      next = recordAttemptFinished(
+        next,
+        current.attempt_id,
+        { outcome: 'timed_out', error: attemptDeadlineError() },
+        dependencies,
+      );
+    }
+  }
+  return next;
+}
+
+function hasFallbackOpportunity(state: CoordinatorState): boolean {
+  return state.slots.some((slot) => {
+    const attempt = latestAttempt(state, slot);
+    if (
+      slot.fallback_exhausted ||
+      !attempt ||
+      (attempt.status !== 'failed' && attempt.status !== 'timed_out') ||
+      attempt.error?.fallback_allowed !== true
+    ) {
+      return false;
+    }
+    return state.reserve.some(
+      (candidate) =>
+        candidate.claimed_by_slot_id === undefined &&
+        candidate.eligible_slot_ids.includes(slot.slot_id) &&
+        !state.used_profile_keys.includes(
+          profileIdentityKey(candidate.profile.identity),
+        ),
+    );
+  });
+}
+
+export function finalizeCoordination(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): CoordinatorState {
+  if (state.status !== 'running') return state;
+  if (
+    hasAcceptanceUnknown(state) ||
+    state.pending_fallbacks.length > 0 ||
+    state.attempts.some((attempt) =>
+      ACTIVE_ATTEMPT_STATUSES.has(attempt.status),
+    ) ||
+    state.slots.some((slot) => slot.status === 'unstarted') ||
+    hasFallbackOpportunity(state)
+  ) {
+    return state;
+  }
+  const outcome = mapCoordinatorOutcome(state);
+  if (!outcome || outcome === 'cancelled' || outcome === 'failed') return state;
+  const next = cloneState(state);
+  next.status = outcome;
+  appendLifecycle(next, {
+    ...eventBase(next, dependencies, iso(dependencies.clock.now())),
+    event_kind: 'request_completed',
+    data: { outcome },
+  });
+  return next;
+}
+
+export function advanceCoordination(
+  state: CoordinatorState,
+  dependencies: CoordinatorDependencies,
+): CoordinatorAdvanceResult {
+  let next = advanceDeadlines(state, dependencies);
+  if (next.status !== 'running') return { state: next, launches: [] };
+  if (
+    next.status === 'running' &&
+    !hasAcceptanceUnknown(next) &&
+    next.pending_fallbacks.length === 0 &&
+    next.slots.every((slot) => slot.status !== 'unstarted') &&
+    !next.attempts.some((attempt) =>
+      ACTIVE_ATTEMPT_STATUSES.has(attempt.status),
+    )
+  ) {
+    next = claimFallbackRound(next, dependencies).state;
+  }
+  const started = startLaunchableAttempts(next, dependencies);
+  if (started.launches.length > 0) return started;
+  return {
+    state: finalizeCoordination(started.state, dependencies),
+    launches: [],
+  };
+}
+
+export async function resumeCoordination(
+  store: CoordinationStateStore,
+  requestId: string,
+  dependencies: CoordinatorDependencies,
+  maxAttempts = 16,
+): Promise<
+  VersionedCoordinationState & { readonly launches: readonly AttemptLaunch[] }
+> {
+  assertCompareAndSwapAttemptBudget(maxAttempts);
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const current = await store.load(requestId);
+    if (!current) {
+      throw new Error(`Coordination state not found: ${requestId}`);
+    }
+    const advanced = advanceCoordination(current.state, dependencies);
+    if (advanced.state === current.state) {
+      return { ...current, launches: advanced.launches };
+    }
+    const swapped = await store.compareAndSwap(
+      requestId,
+      current.version,
+      advanced.state,
+    );
+    if (swapped.ok) {
+      return { ...swapped.value, launches: advanced.launches };
+    }
+  }
+  throw new Error(
+    `Coordination resume exceeded ${maxAttempts} compare-and-swap attempts.`,
+  );
+}
+
+export function acceptedDurableHandles(
+  state: CoordinatorState,
+): readonly DurableHandle[] {
+  return state.attempts.flatMap((attempt) =>
+    attempt.durable_handle ? [structuredClone(attempt.durable_handle)] : [],
+  );
+}

--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -661,6 +661,35 @@ function validatePlanningMetadata(
   }
 }
 
+function validateCatalogIdentity(
+  catalog: FrozenPlanningCatalog,
+  issues: PreparationIssue[],
+): { readonly revision: string; readonly digest: string } | undefined {
+  const revision = OpaqueIdSchema.safeParse(catalog.revision);
+  if (!revision.success) {
+    issues.push({
+      code: 'invalid_catalog_revision',
+      phase: 'validation',
+      path: '/catalog/revision',
+      message:
+        'Catalog revision must be a bounded, trimmed, control-free opaque identifier.',
+    });
+  }
+  const digest = OpaqueIdSchema.safeParse(catalog.digest);
+  if (!digest.success) {
+    issues.push({
+      code: 'invalid_catalog_digest',
+      phase: 'validation',
+      path: '/catalog/digest',
+      message:
+        'Catalog digest must be a bounded, trimmed, control-free opaque identifier.',
+    });
+  }
+  return revision.success && digest.success
+    ? { revision: revision.data, digest: digest.data }
+    : undefined;
+}
+
 function resolveReserve(
   request: CanonicalResearchRequest,
   catalog: FrozenPlanningCatalog,
@@ -777,6 +806,46 @@ function profilePlan(entry: PlanningProfile): PreparedProfilePlan {
   };
 }
 
+function validatePrimaryBudgetAdmission(
+  request: CanonicalResearchRequest,
+  primaries: readonly SelectedProfile[],
+  reserve: readonly SelectedProfile[],
+  issues: PreparationIssue[],
+): void {
+  if (!request.budgets) return;
+  let total = 0n;
+  for (const selection of [...primaries, ...reserve]) {
+    const estimate = selection.entry.estimate?.estimated_cost_microusd;
+    if (estimate === undefined) {
+      issues.push({
+        code: 'budget_estimate_required',
+        phase: 'validation',
+        path: selection.path,
+        message:
+          'A hard request budget requires a bounded network-free estimate for every planned profile.',
+        profile_key: profileIdentityKey(selection.entry.profile.identity),
+      });
+      continue;
+    }
+    if (primaries.includes(selection)) total += BigInt(estimate);
+  }
+  if (issues.some((issue) => issue.code === 'budget_estimate_required')) {
+    return;
+  }
+  const totalText = total.toString();
+  for (const [field, limit] of Object.entries(request.budgets)) {
+    if (limit !== undefined && BigInt(totalText) > BigInt(limit)) {
+      issues.push({
+        code: 'primary_plan_budget_exceeded',
+        phase: 'validation',
+        path: `/budgets/${field}`,
+        message:
+          'The complete primary plan exceeds this hard budget before execution.',
+      });
+    }
+  }
+}
+
 export function prepareResearchExecution(
   input: unknown,
   catalog: FrozenPlanningCatalog,
@@ -811,6 +880,7 @@ export function prepareResearchExecution(
       notices: sortDiagnostics(notices),
     };
   }
+  const catalogIdentity = validateCatalogIdentity(catalog, issues);
   validatePlanningMetadata(catalog.profiles, issues);
   if (issues.length > 0) {
     return {
@@ -818,6 +888,9 @@ export function prepareResearchExecution(
       issues: sortDiagnostics(issues),
       notices: sortDiagnostics(notices),
     };
+  }
+  if (!catalogIdentity) {
+    throw new Error('Catalog identity validation did not produce metadata.');
   }
   const byKey = new Map(
     catalog.profiles.map((entry) => [
@@ -844,6 +917,8 @@ export function prepareResearchExecution(
     issues,
     notices,
   );
+
+  validatePrimaryBudgetAdmission(request, primaries, reserve, issues);
 
   if (issues.length > 0) {
     return {
@@ -907,7 +982,7 @@ export function prepareResearchExecution(
       refinement: request.refinement,
     },
     profile_plans_by_identity: profilePlans,
-    catalog: { revision: catalog.revision, digest: catalog.digest },
+    catalog: catalogIdentity,
     notices: sortedNotices,
   };
   return { ok: true, prepared, notices: sortedNotices };

--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -1,0 +1,916 @@
+import {
+  CONTRACT_LIMITS,
+  OpaqueIdSchema,
+  SnakeCaseNameSchema,
+} from '../contracts/common.js';
+import {
+  type ExecutionProfile,
+  ExecutionProfileSchema,
+  type ProviderIdentity,
+} from '../contracts/domain/index.js';
+import {
+  compatibilityIssues,
+  fallbackCompatibilityIssues,
+  profileKey,
+} from '../contracts/interchange/compatibility.js';
+/*
+ * Keep the schema import above at runtime: a typed catalog port is not a trust
+ * boundary, and every catalog profile is validated before selection.
+ */
+import type {
+  EvidenceRequirements,
+  InterchangeRequest,
+  RequestSlot,
+} from '../contracts/interchange/request.js';
+import {
+  INTERCHANGE_VERSION,
+  InterchangeRequestSchema,
+} from '../contracts/interchange/request.js';
+import {
+  type CanonicalResearchRequest,
+  CanonicalResearchRequestSchema,
+  migrateLegacyResearchRequest,
+  type PreparationIssue,
+  type PreparationNotice,
+  type ProfileTarget,
+  RESEARCH_REQUEST_LIMITS,
+} from './research-request.js';
+
+export interface AdapterBindingIdentity {
+  readonly adapter_id: string;
+  readonly binding_id: string;
+}
+
+export interface NetworkFreeEstimate {
+  readonly estimated_cost_microusd?: string;
+  readonly billable_units?: readonly {
+    readonly unit: string;
+    readonly quantity: string;
+  }[];
+}
+
+export interface PlanningProfile {
+  readonly profile: ExecutionProfile;
+  readonly binding: AdapterBindingIdentity;
+  readonly estimate?: NetworkFreeEstimate;
+  readonly enabled: boolean;
+  readonly credentialed: boolean;
+  readonly configuration_valid: boolean;
+}
+
+/**
+ * A frozen, network-free view of profiles and selection policy. Production
+ * catalog population belongs to #2556. Implementations must not perform
+ * Librarium-controlled network calls. Building a snapshot from an explicitly
+ * trusted npm or script provider may execute user code before this port exists.
+ */
+export interface FrozenPlanningCatalog<
+  TProfile extends PlanningProfile = PlanningProfile,
+> {
+  readonly revision: string;
+  readonly digest: string;
+  readonly profiles: readonly TProfile[];
+  resolveGroup(groupId: string): readonly ProviderIdentity[] | undefined;
+  resolveDefault(): readonly ProviderIdentity[];
+  resolveConfiguredReserve(
+    primaries: readonly ProviderIdentity[],
+  ): readonly ProviderIdentity[];
+}
+
+export interface PreparationClock {
+  now(): number;
+}
+
+export interface PreparationIdGenerator {
+  next(scope: 'request' | 'slot' | 'fallback_candidate'): string;
+}
+
+export interface PreparationDependencies {
+  readonly clock: PreparationClock;
+  readonly ids: PreparationIdGenerator;
+}
+
+export interface PreparedProfilePlan {
+  readonly profile_key: string;
+  readonly identity: ProviderIdentity;
+  readonly binding: AdapterBindingIdentity;
+  readonly estimate?: NetworkFreeEstimate;
+}
+
+export interface PrivateExecutionPolicy {
+  readonly limits: CanonicalResearchRequest['limits'];
+  readonly budgets?: CanonicalResearchRequest['budgets'];
+  readonly fallback: CanonicalResearchRequest['fallback'];
+  readonly exclusions: readonly ProfileTarget[];
+  readonly refinement: CanonicalResearchRequest['refinement'];
+}
+
+export interface PreparedResearchExecution {
+  readonly request: InterchangeRequest;
+  readonly policy: PrivateExecutionPolicy;
+  readonly profile_plans_by_identity: Readonly<
+    Record<string, PreparedProfilePlan>
+  >;
+  readonly catalog: {
+    readonly revision: string;
+    readonly digest: string;
+  };
+  readonly notices: readonly PreparationNotice[];
+}
+
+export type PreparationResult =
+  | {
+      readonly ok: true;
+      readonly prepared: PreparedResearchExecution;
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+interface SelectedProfile {
+  readonly entry: PlanningProfile;
+  readonly path: string;
+  readonly requirements?: EvidenceRequirements;
+}
+
+const PHASE_ORDER = {
+  transport: 0,
+  migration: 1,
+  canonicalization: 2,
+  selection: 3,
+  validation: 4,
+  compilation: 5,
+} as const;
+
+function escapeJsonPointerToken(token: string): string {
+  return token.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function jsonPointer(path: readonly PropertyKey[]): string {
+  return path.length === 0
+    ? ''
+    : `/${path.map((part) => escapeJsonPointerToken(String(part))).join('/')}`;
+}
+
+function canonicalIssueCode(path: string, message: string): string {
+  if (
+    message === 'Inline attempt deadline cannot exceed the request deadline'
+  ) {
+    return 'inline_attempt_deadline_exceeds_request_deadline';
+  }
+  if (
+    message === 'Background attempt deadline cannot exceed the request deadline'
+  ) {
+    return 'background_attempt_deadline_exceeds_request_deadline';
+  }
+  if (
+    message === 'Poll interval cannot exceed the background attempt deadline'
+  ) {
+    return 'poll_interval_exceeds_background_attempt_deadline';
+  }
+  if (path === '/query' || path.startsWith('/query/')) return 'invalid_query';
+  if (path === '/mode' || path.startsWith('/mode/')) return 'invalid_mode';
+  if (path === '/selector' || path.startsWith('/selector/')) {
+    return 'invalid_selector';
+  }
+  if (path === '/fallback' || path.startsWith('/fallback/')) {
+    return 'invalid_fallback_intent';
+  }
+  if (path === '/limits/max_concurrency') {
+    return 'concurrency_out_of_bounds';
+  }
+  if (
+    path === '/limits/request_deadline_ms' ||
+    path === '/limits/inline_attempt_deadline_ms' ||
+    path === '/limits/background_attempt_deadline_ms'
+  ) {
+    return 'deadline_out_of_bounds';
+  }
+  if (path === '/limits/poll_interval_ms') {
+    return 'poll_interval_out_of_bounds';
+  }
+  if (path === '/budgets' || path.startsWith('/budgets/')) {
+    return 'invalid_exact_budget';
+  }
+  if (path === '/exclusions' || path.startsWith('/exclusions/')) {
+    return 'invalid_exclusion';
+  }
+  if (path === '/refinement' || path.startsWith('/refinement/')) {
+    return 'invalid_refinement_intent';
+  }
+  return 'invalid_canonical_request';
+}
+
+function sortDiagnostics<T extends PreparationIssue | PreparationNotice>(
+  diagnostics: readonly T[],
+): T[] {
+  const compareText = (left: string, right: string): number =>
+    left < right ? -1 : left > right ? 1 : 0;
+  return [...diagnostics].sort(
+    (left, right) =>
+      PHASE_ORDER[left.phase] - PHASE_ORDER[right.phase] ||
+      compareText(left.path, right.path) ||
+      compareText(left.code, right.code) ||
+      compareText(left.profile_key ?? '', right.profile_key ?? ''),
+  );
+}
+
+function profileIdentityKey(identity: ProviderIdentity): string {
+  return JSON.stringify([identity.provider_id, identity.profile_id]);
+}
+
+function targetKey(target: ProfileTarget): string {
+  return JSON.stringify([target.provider_id, target.profile_id ?? null]);
+}
+
+function duplicateTargetIssues(
+  targets: readonly ProfileTarget[],
+  path: string,
+  code: string,
+  message: string,
+): PreparationIssue[] {
+  const issues: PreparationIssue[] = [];
+  const seen = new Set<string>();
+  for (const [index, target] of targets.entries()) {
+    const key = targetKey(target);
+    if (seen.has(key)) {
+      issues.push({
+        code,
+        phase: 'validation',
+        path: `${path}/${index}`,
+        message,
+      });
+    }
+    seen.add(key);
+  }
+  return issues;
+}
+
+function canonicalSetIssues(
+  request: CanonicalResearchRequest,
+): PreparationIssue[] {
+  const issues = duplicateTargetIssues(
+    request.exclusions,
+    '/exclusions',
+    'duplicate_exclusion',
+    'Each exclusion may be declared only once.',
+  );
+  if (request.selector.kind === 'targets') {
+    issues.push(
+      ...duplicateTargetIssues(
+        request.selector.targets,
+        '/selector/targets',
+        'duplicate_explicit_target',
+        'Each explicit provider/profile target may be declared only once.',
+      ),
+    );
+  }
+  if (request.fallback.kind === 'explicit') {
+    issues.push(
+      ...duplicateTargetIssues(
+        request.fallback.reserve,
+        '/fallback/reserve',
+        'duplicate_explicit_reserve_target',
+        'Each explicit reserve target may be declared only once.',
+      ),
+    );
+  }
+  return issues;
+}
+
+function identityMatchesTarget(
+  identity: ProviderIdentity,
+  target: ProfileTarget,
+): boolean {
+  return (
+    identity.provider_id === target.provider_id &&
+    (target.profile_id === undefined ||
+      identity.profile_id === target.profile_id)
+  );
+}
+
+function requirementsForProfile(
+  profile: ExecutionProfile,
+): EvidenceRequirements {
+  return {
+    result_kind: profile.result_kind,
+    grounding_policy:
+      profile.result_kind === 'search_results'
+        ? undefined
+        : profile.grounding_policy,
+    observation_mode: profile.observation_mode,
+    corpora: [...profile.corpora],
+    retrieval_methods: [profile.retrieval_method],
+    surface_id: profile.surface_id,
+  };
+}
+
+function isExcluded(
+  identity: ProviderIdentity,
+  exclusions: readonly ProfileTarget[],
+): boolean {
+  return exclusions.some((target) => identityMatchesTarget(identity, target));
+}
+
+function findCatalogEntry(
+  byKey: ReadonlyMap<string, PlanningProfile>,
+  identity: ProviderIdentity,
+): PlanningProfile | undefined {
+  return byKey.get(profileIdentityKey(identity));
+}
+
+function resolveTargets(
+  targets: readonly ProfileTarget[],
+  catalog: FrozenPlanningCatalog,
+  basePath: string,
+  issues: PreparationIssue[],
+): SelectedProfile[] {
+  const selected: SelectedProfile[] = [];
+  for (const [index, target] of targets.entries()) {
+    const path = `${basePath}/${index}`;
+    const matches = catalog.profiles.filter(({ profile }) =>
+      identityMatchesTarget(profile.identity, target),
+    );
+    if (matches.length === 0) {
+      issues.push({
+        code: 'profile_not_found',
+        phase: 'selection',
+        path,
+        message: `No catalog profile matches provider ${target.provider_id}${target.profile_id ? ` and profile ${target.profile_id}` : ''}.`,
+      });
+      continue;
+    }
+    selected.push(...matches.map((entry) => ({ entry, path })));
+  }
+  return selected;
+}
+
+function resolveIdentities(
+  identities: readonly ProviderIdentity[],
+  byKey: ReadonlyMap<string, PlanningProfile>,
+  path: string,
+  issues: PreparationIssue[],
+): SelectedProfile[] {
+  const selected: SelectedProfile[] = [];
+  for (const identity of identities) {
+    const entry = findCatalogEntry(byKey, identity);
+    if (!entry) {
+      issues.push({
+        code: 'catalog_profile_not_found',
+        phase: 'selection',
+        path,
+        message: `Catalog selection references an unknown profile ${identity.provider_id}/${identity.profile_id}.`,
+        profile_key: profileIdentityKey(identity),
+      });
+      continue;
+    }
+    selected.push({ entry, path });
+  }
+  return selected;
+}
+
+function profileAvailabilityIssues(
+  selection: SelectedProfile,
+  mode: CanonicalResearchRequest['mode'],
+): PreparationIssue[] {
+  const { entry, path } = selection;
+  const key = profileIdentityKey(entry.profile.identity);
+  const issues: PreparationIssue[] = [];
+  if (!entry.enabled) {
+    issues.push({
+      code: 'profile_disabled',
+      phase: 'validation',
+      path,
+      message: 'The selected profile is disabled.',
+      profile_key: key,
+    });
+  }
+  if (!entry.credentialed) {
+    issues.push({
+      code: 'profile_uncredentialed',
+      phase: 'validation',
+      path,
+      message: 'The selected profile has no usable credentials.',
+      profile_key: key,
+    });
+  }
+  if (!entry.configuration_valid) {
+    issues.push({
+      code: 'profile_misconfigured',
+      phase: 'validation',
+      path,
+      message: 'The selected profile configuration is invalid.',
+      profile_key: key,
+    });
+  }
+  if (mode === 'async' && entry.profile.resumability !== 'durable') {
+    issues.push({
+      code: 'async_requires_durable_profile',
+      phase: 'validation',
+      path,
+      message: 'Async execution requires a durable profile.',
+      profile_key: key,
+    });
+  }
+  return issues;
+}
+
+function isUsableCapabilityMatch(
+  entry: PlanningProfile,
+  request: CanonicalResearchRequest,
+  requirements: EvidenceRequirements,
+): boolean {
+  return (
+    entry.enabled &&
+    entry.credentialed &&
+    entry.configuration_valid &&
+    (request.mode !== 'async' || entry.profile.resumability === 'durable') &&
+    !isExcluded(entry.profile.identity, request.exclusions) &&
+    compatibilityIssues(requirements, entry.profile).length === 0
+  );
+}
+
+function selectPrimaries(
+  request: CanonicalResearchRequest,
+  catalog: FrozenPlanningCatalog,
+  byKey: ReadonlyMap<string, PlanningProfile>,
+  issues: PreparationIssue[],
+): SelectedProfile[] {
+  let selected: SelectedProfile[];
+  switch (request.selector.kind) {
+    case 'targets':
+      selected = resolveTargets(
+        request.selector.targets,
+        catalog,
+        '/selector/targets',
+        issues,
+      );
+      break;
+    case 'group': {
+      const identities = catalog.resolveGroup(request.selector.group_id);
+      if (!identities) {
+        issues.push({
+          code: 'group_not_found',
+          phase: 'selection',
+          path: '/selector/group_id',
+          message: `Unknown profile group ${request.selector.group_id}.`,
+        });
+        return [];
+      }
+      selected = resolveIdentities(identities, byKey, '/selector', issues);
+      break;
+    }
+    case 'capabilities': {
+      const selector = request.selector;
+      selected = catalog.profiles
+        .filter((entry) =>
+          isUsableCapabilityMatch(entry, request, selector.requirements),
+        )
+        .map((entry) => ({
+          entry,
+          path: '/selector/requirements',
+          requirements: selector.requirements,
+        }));
+      if (
+        selector.result_count !== undefined &&
+        selected.length < selector.result_count
+      ) {
+        issues.push({
+          code: 'capability_result_count_unavailable',
+          phase: 'selection',
+          path: '/selector/result_count',
+          message: `Capability selection requested ${selector.result_count} profiles but only ${selected.length} are eligible.`,
+        });
+      } else if (selector.result_count !== undefined) {
+        selected = selected.slice(0, selector.result_count);
+      }
+      break;
+    }
+    case 'default':
+      selected = resolveIdentities(
+        catalog.resolveDefault(),
+        byKey,
+        '/selector',
+        issues,
+      );
+      break;
+  }
+
+  if (request.selector.kind !== 'capabilities') {
+    const retained: SelectedProfile[] = [];
+    for (const selection of selected) {
+      if (isExcluded(selection.entry.profile.identity, request.exclusions)) {
+        if (request.selector.kind === 'targets') {
+          issues.push({
+            code: 'explicit_profile_excluded',
+            phase: 'validation',
+            path: selection.path,
+            message: 'An explicitly selected profile is also excluded.',
+            profile_key: profileIdentityKey(selection.entry.profile.identity),
+          });
+        }
+        continue;
+      }
+      retained.push(selection);
+      issues.push(...profileAvailabilityIssues(selection, request.mode));
+    }
+    selected = retained;
+  }
+
+  if (selected.length === 0 && issues.length === 0) {
+    issues.push({
+      code: 'selection_empty',
+      phase: 'selection',
+      path: '/selector',
+      message: 'The selector did not resolve any usable profiles.',
+    });
+  }
+
+  const seen = new Set<string>();
+  for (const selection of selected) {
+    const key = profileKey(selection.entry.profile);
+    if (seen.has(key)) {
+      issues.push({
+        code: 'profile_selected_more_than_once',
+        phase: 'validation',
+        path: selection.path,
+        message: 'Each provider profile may be selected only once.',
+        profile_key: profileIdentityKey(selection.entry.profile.identity),
+      });
+    }
+    seen.add(key);
+  }
+  return selected;
+}
+
+const EXACT_INTEGER_STRING_PATTERN = /^(?:0|[1-9]\d*)$/;
+const BILLABLE_QUANTITY_PATTERN = /^(?:0|[1-9]\d*)(?:\.\d{1,18})?$/;
+// Mirrors the UsageSchema billable_units bound; also caps validation work per
+// catalog entry so a hostile catalog cannot amplify iteration.
+const MAX_BILLABLE_UNITS = 32;
+
+function isExactBoundedIntegerString(value: string): boolean {
+  return (
+    value.length <= RESEARCH_REQUEST_LIMITS.exactIntegerLength &&
+    EXACT_INTEGER_STRING_PATTERN.test(value)
+  );
+}
+
+/**
+ * Hardens runtime catalog metadata before any BigInt conversion or budget
+ * arithmetic. Every diagnostic is stable and index-addressed so a broken
+ * catalog entry can be located without positional guessing.
+ */
+function validatePlanningMetadata(
+  entries: readonly PlanningProfile[],
+  issues: PreparationIssue[],
+): void {
+  const keys = new Set<string>();
+  for (const [index, entry] of entries.entries()) {
+    const entryPath = `/catalog/profiles/${index}`;
+    const parsedProfile = ExecutionProfileSchema.safeParse(entry.profile);
+    if (!parsedProfile.success) {
+      for (const issue of parsedProfile.error.issues) {
+        issues.push({
+          code: 'invalid_catalog_execution_profile',
+          phase: 'validation',
+          path: `${entryPath}/profile${jsonPointer(issue.path)}`,
+          message: issue.message,
+        });
+      }
+      continue;
+    }
+    const key = profileIdentityKey(entry.profile.identity);
+    if (keys.has(key)) {
+      issues.push({
+        code: 'catalog_profile_duplicate',
+        phase: 'validation',
+        path: `${entryPath}/profile/identity`,
+        message: 'The frozen catalog contains a duplicate provider profile.',
+        profile_key: key,
+      });
+    }
+    keys.add(key);
+    const bindingFields = [
+      ['adapter_id', entry.binding.adapter_id],
+      ['binding_id', entry.binding.binding_id],
+    ] as const;
+    for (const [field, value] of bindingFields) {
+      if (!OpaqueIdSchema.safeParse(value).success) {
+        issues.push({
+          code: 'invalid_adapter_binding_identity',
+          phase: 'validation',
+          path: `${entryPath}/binding/${field}`,
+          message: `Adapter binding identities must be non-empty, trimmed, control-free opaque identifiers of at most ${CONTRACT_LIMITS.identifierLength} characters.`,
+          profile_key: key,
+        });
+      }
+    }
+    const estimatedCost = entry.estimate?.estimated_cost_microusd;
+    if (
+      estimatedCost !== undefined &&
+      !isExactBoundedIntegerString(estimatedCost)
+    ) {
+      issues.push({
+        code: 'invalid_network_free_estimate',
+        phase: 'validation',
+        path: `${entryPath}/estimate/estimated_cost_microusd`,
+        message: `Estimated cost must be an exact non-negative integer string of at most ${RESEARCH_REQUEST_LIMITS.exactIntegerLength} characters.`,
+        profile_key: key,
+      });
+    }
+    const billableUnits = entry.estimate?.billable_units ?? [];
+    if (billableUnits.length > MAX_BILLABLE_UNITS) {
+      issues.push({
+        code: 'invalid_billable_unit_estimate',
+        phase: 'validation',
+        path: `${entryPath}/estimate/billable_units`,
+        message: `At most ${MAX_BILLABLE_UNITS} billable units may be declared per estimate.`,
+        profile_key: key,
+      });
+      continue;
+    }
+    for (const [unitIndex, unit] of billableUnits.entries()) {
+      const unitPath = `${entryPath}/estimate/billable_units/${unitIndex}`;
+      if (!SnakeCaseNameSchema.safeParse(unit.unit).success) {
+        issues.push({
+          code: 'invalid_billable_unit_estimate',
+          phase: 'validation',
+          path: `${unitPath}/unit`,
+          message: 'Billable units must use bounded snake_case unit names.',
+          profile_key: key,
+        });
+      }
+      if (
+        unit.quantity.length > CONTRACT_LIMITS.decimalStringLength ||
+        !BILLABLE_QUANTITY_PATTERN.test(unit.quantity)
+      ) {
+        issues.push({
+          code: 'invalid_billable_unit_estimate',
+          phase: 'validation',
+          path: `${unitPath}/quantity`,
+          message:
+            'Billable unit quantities must be bounded non-negative decimal strings.',
+          profile_key: key,
+        });
+      }
+    }
+  }
+}
+
+function resolveReserve(
+  request: CanonicalResearchRequest,
+  catalog: FrozenPlanningCatalog,
+  byKey: ReadonlyMap<string, PlanningProfile>,
+  primaries: readonly SelectedProfile[],
+  slots: readonly RequestSlot[],
+  issues: PreparationIssue[],
+  notices: PreparationNotice[],
+): SelectedProfile[] {
+  if (request.fallback.kind === 'disabled') return [];
+
+  const fallback = request.fallback;
+  const explicit = fallback.kind === 'explicit';
+  const reserve =
+    fallback.kind === 'explicit'
+      ? resolveTargets(fallback.reserve, catalog, '/fallback/reserve', issues)
+      : resolveIdentities(
+          catalog.resolveConfiguredReserve(
+            primaries.map(({ entry }) => entry.profile.identity),
+          ),
+          byKey,
+          '/fallback',
+          issues,
+        );
+
+  const used = new Set(primaries.map(({ entry }) => profileKey(entry.profile)));
+  const retained: SelectedProfile[] = [];
+  for (const selection of reserve) {
+    const key = profileKey(selection.entry.profile);
+    const diagnosticKey = profileIdentityKey(selection.entry.profile.identity);
+    if (used.has(key)) {
+      issues.push({
+        code: 'profile_reused_in_fallback',
+        phase: 'validation',
+        path: selection.path,
+        message:
+          'A provider profile may appear only once in the primary and reserve plan.',
+        profile_key: diagnosticKey,
+      });
+      continue;
+    }
+    used.add(key);
+
+    if (isExcluded(selection.entry.profile.identity, request.exclusions)) {
+      if (explicit) {
+        issues.push({
+          code: 'explicit_fallback_excluded',
+          phase: 'validation',
+          path: selection.path,
+          message: 'An explicit fallback profile is also excluded.',
+          profile_key: diagnosticKey,
+        });
+      }
+      continue;
+    }
+
+    const availability = profileAvailabilityIssues(selection, request.mode);
+    if (availability.length > 0) {
+      if (explicit) {
+        issues.push(...availability);
+      } else {
+        notices.push({
+          code: 'configured_fallback_unavailable',
+          phase: 'validation',
+          path: selection.path,
+          message: 'An unavailable configured fallback was omitted.',
+          profile_key: diagnosticKey,
+        });
+      }
+      continue;
+    }
+
+    const eligible = slots.filter(
+      (slot) =>
+        fallbackCompatibilityIssues(slot, selection.entry.profile).length === 0,
+    );
+    if (eligible.length === 0) {
+      const diagnostic = {
+        code: explicit
+          ? 'fallback_profile_incompatible'
+          : 'configured_fallback_incompatible',
+        phase: 'validation' as const,
+        path: selection.path,
+        message:
+          'The fallback profile is incompatible with every selected evidence lane.',
+        profile_key: diagnosticKey,
+      };
+      if (explicit) issues.push(diagnostic);
+      else notices.push(diagnostic);
+      continue;
+    }
+    retained.push(selection);
+  }
+  return retained;
+}
+
+function profilePlan(entry: PlanningProfile): PreparedProfilePlan {
+  return {
+    profile_key: profileIdentityKey(entry.profile.identity),
+    identity: { ...entry.profile.identity },
+    binding: {
+      adapter_id: entry.binding.adapter_id,
+      binding_id: entry.binding.binding_id,
+    },
+    estimate: entry.estimate
+      ? {
+          estimated_cost_microusd: entry.estimate.estimated_cost_microusd,
+          billable_units: entry.estimate.billable_units?.map((unit) => ({
+            unit: unit.unit,
+            quantity: unit.quantity,
+          })),
+        }
+      : undefined,
+  };
+}
+
+export function prepareResearchExecution(
+  input: unknown,
+  catalog: FrozenPlanningCatalog,
+  dependencies: PreparationDependencies,
+): PreparationResult {
+  const migration = migrateLegacyResearchRequest(input);
+  const notices: PreparationNotice[] = [...migration.notices];
+  const canonical = CanonicalResearchRequestSchema.safeParse(migration.input);
+  if (!canonical.success) {
+    const issues = canonical.error.issues.map((issue) => {
+      const path = jsonPointer(issue.path);
+      return {
+        code: canonicalIssueCode(path, issue.message),
+        phase: 'canonicalization' as const,
+        path,
+        message: issue.message,
+      };
+    });
+    return {
+      ok: false,
+      issues: sortDiagnostics(issues),
+      notices: sortDiagnostics(notices),
+    };
+  }
+
+  const request = canonical.data;
+  const issues = canonicalSetIssues(request);
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(issues),
+      notices: sortDiagnostics(notices),
+    };
+  }
+  validatePlanningMetadata(catalog.profiles, issues);
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(issues),
+      notices: sortDiagnostics(notices),
+    };
+  }
+  const byKey = new Map(
+    catalog.profiles.map((entry) => [
+      profileIdentityKey(entry.profile.identity),
+      entry,
+    ]),
+  );
+  const primaries = selectPrimaries(request, catalog, byKey, issues);
+
+  const requestedAt = new Date(dependencies.clock.now()).toISOString();
+  const slots: RequestSlot[] = primaries.map((selection, position) => ({
+    slot_id: dependencies.ids.next('slot'),
+    position,
+    requirements:
+      selection.requirements ?? requirementsForProfile(selection.entry.profile),
+    primary: selection.entry.profile,
+  }));
+  const reserve = resolveReserve(
+    request,
+    catalog,
+    byKey,
+    primaries,
+    slots,
+    issues,
+    notices,
+  );
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(issues),
+      notices: sortDiagnostics(notices),
+    };
+  }
+
+  const fallbackReserve = reserve.map((selection, position) => ({
+    candidate_id: dependencies.ids.next('fallback_candidate'),
+    position,
+    profile: selection.entry.profile,
+    eligible_slot_ids: slots
+      .filter(
+        (slot) =>
+          fallbackCompatibilityIssues(slot, selection.entry.profile).length ===
+          0,
+      )
+      .map((slot) => slot.slot_id),
+  }));
+  const compiled = InterchangeRequestSchema.safeParse({
+    interchange_version: INTERCHANGE_VERSION,
+    message_type: 'request',
+    request_id: dependencies.ids.next('request'),
+    requested_at: requestedAt,
+    mode: request.mode,
+    query: request.query,
+    slots,
+    fallback_reserve: fallbackReserve,
+  });
+  if (!compiled.success) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(
+        compiled.error.issues.map((issue) => ({
+          code: 'compiled_request_invalid',
+          phase: 'compilation' as const,
+          path: jsonPointer(issue.path),
+          message: issue.message,
+        })),
+      ),
+      notices: sortDiagnostics(notices),
+    };
+  }
+
+  const profilePlans = Object.fromEntries(
+    [...primaries, ...reserve].map(({ entry }) => {
+      const plan = profilePlan(entry);
+      return [plan.profile_key, plan];
+    }),
+  );
+  const sortedNotices = sortDiagnostics(notices);
+  const prepared: PreparedResearchExecution = {
+    request: compiled.data,
+    policy: {
+      limits: request.limits,
+      budgets: request.budgets,
+      fallback: request.fallback,
+      exclusions: request.exclusions,
+      refinement: request.refinement,
+    },
+    profile_plans_by_identity: profilePlans,
+    catalog: { revision: catalog.revision, digest: catalog.digest },
+    notices: sortedNotices,
+  };
+  return { ok: true, prepared, notices: sortedNotices };
+}
+
+export { profileIdentityKey };

--- a/src/core/research-request.ts
+++ b/src/core/research-request.ts
@@ -15,7 +15,7 @@ export const RESEARCH_REQUEST_LIMITS = {
   maxPollIntervalMs: 5 * 60 * 1_000,
 } as const;
 
-const ExactIntegerStringSchema = z
+export const ExactMicrousdSchema = z
   .string()
   .max(RESEARCH_REQUEST_LIMITS.exactIntegerLength)
   .regex(/^(?:0|[1-9]\d*)$/, 'Expected an exact non-negative integer string');
@@ -119,8 +119,8 @@ export const ExactBudgetLimitsSchema = z
   .strictObject({
     // Zero is intentional: it is a fail-closed ceiling that permits only work
     // whose network-free reservation is exactly zero.
-    max_estimated_cost_microusd: ExactIntegerStringSchema.optional(),
-    max_actual_cost_microusd: ExactIntegerStringSchema.optional(),
+    max_estimated_cost_microusd: ExactMicrousdSchema.optional(),
+    max_actual_cost_microusd: ExactMicrousdSchema.optional(),
   })
   .superRefine((budgets, ctx) => {
     if (

--- a/src/core/research-request.ts
+++ b/src/core/research-request.ts
@@ -1,0 +1,223 @@
+import { z } from 'zod/v4';
+import { OpaqueIdSchema } from '../contracts/common.js';
+import { EvidenceRequirementsSchema } from '../contracts/interchange/request.js';
+
+export const RESEARCH_REQUEST_LIMITS = {
+  queryLength: 100_000,
+  exactIntegerLength: 64,
+  profiles: 64,
+  exclusions: 128,
+  minConcurrency: 1,
+  maxConcurrency: 64,
+  minDeadlineMs: 1_000,
+  maxDeadlineMs: 7 * 24 * 60 * 60 * 1_000,
+  minPollIntervalMs: 100,
+  maxPollIntervalMs: 5 * 60 * 1_000,
+} as const;
+
+const ExactIntegerStringSchema = z
+  .string()
+  .max(RESEARCH_REQUEST_LIMITS.exactIntegerLength)
+  .regex(/^(?:0|[1-9]\d*)$/, 'Expected an exact non-negative integer string');
+
+export const ProfileTargetSchema = z.strictObject({
+  provider_id: OpaqueIdSchema,
+  profile_id: OpaqueIdSchema.optional(),
+});
+
+export const ResearchSelectorSchema = z.discriminatedUnion('kind', [
+  z.strictObject({
+    kind: z.literal('targets'),
+    targets: z
+      .array(ProfileTargetSchema)
+      .min(1)
+      .max(RESEARCH_REQUEST_LIMITS.profiles),
+  }),
+  z.strictObject({
+    kind: z.literal('group'),
+    group_id: OpaqueIdSchema,
+  }),
+  z.strictObject({
+    kind: z.literal('capabilities'),
+    requirements: EvidenceRequirementsSchema,
+    result_count: z
+      .number()
+      .int()
+      .min(1)
+      .max(RESEARCH_REQUEST_LIMITS.profiles)
+      .optional(),
+  }),
+  z.strictObject({ kind: z.literal('default') }),
+]);
+
+export const FallbackIntentSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('disabled') }),
+  z.strictObject({ kind: z.literal('configured') }),
+  z.strictObject({
+    kind: z.literal('explicit'),
+    reserve: z
+      .array(ProfileTargetSchema)
+      .min(1)
+      .max(RESEARCH_REQUEST_LIMITS.profiles),
+  }),
+]);
+
+export const ResearchExecutionLimitsSchema = z
+  .strictObject({
+    max_concurrency: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minConcurrency)
+      .max(RESEARCH_REQUEST_LIMITS.maxConcurrency),
+    request_deadline_ms: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minDeadlineMs)
+      .max(RESEARCH_REQUEST_LIMITS.maxDeadlineMs),
+    inline_attempt_deadline_ms: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minDeadlineMs)
+      .max(RESEARCH_REQUEST_LIMITS.maxDeadlineMs),
+    background_attempt_deadline_ms: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minDeadlineMs)
+      .max(RESEARCH_REQUEST_LIMITS.maxDeadlineMs),
+    poll_interval_ms: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minPollIntervalMs)
+      .max(RESEARCH_REQUEST_LIMITS.maxPollIntervalMs),
+  })
+  .superRefine((limits, ctx) => {
+    if (limits.inline_attempt_deadline_ms > limits.request_deadline_ms) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Inline attempt deadline cannot exceed the request deadline',
+        path: ['inline_attempt_deadline_ms'],
+      });
+    }
+    if (limits.background_attempt_deadline_ms > limits.request_deadline_ms) {
+      ctx.addIssue({
+        code: 'custom',
+        message:
+          'Background attempt deadline cannot exceed the request deadline',
+        path: ['background_attempt_deadline_ms'],
+      });
+    }
+    if (limits.poll_interval_ms > limits.background_attempt_deadline_ms) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Poll interval cannot exceed the background attempt deadline',
+        path: ['poll_interval_ms'],
+      });
+    }
+  });
+
+export const ExactBudgetLimitsSchema = z
+  .strictObject({
+    // Zero is intentional: it is a fail-closed ceiling that permits only work
+    // whose network-free reservation is exactly zero.
+    max_estimated_cost_microusd: ExactIntegerStringSchema.optional(),
+    max_actual_cost_microusd: ExactIntegerStringSchema.optional(),
+  })
+  .superRefine((budgets, ctx) => {
+    if (
+      budgets.max_estimated_cost_microusd === undefined &&
+      budgets.max_actual_cost_microusd === undefined
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'At least one exact budget limit is required',
+      });
+    }
+  });
+
+export const RefinementIntentSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('disabled') }),
+  z.strictObject({
+    kind: z.literal('requested'),
+    strategy_id: OpaqueIdSchema.optional(),
+  }),
+]);
+
+export const CanonicalResearchRequestSchema = z.strictObject({
+  query: z.string().trim().min(1).max(RESEARCH_REQUEST_LIMITS.queryLength),
+  mode: z.enum(['sync', 'async']),
+  selector: ResearchSelectorSchema,
+  fallback: FallbackIntentSchema,
+  limits: ResearchExecutionLimitsSchema,
+  budgets: ExactBudgetLimitsSchema.optional(),
+  exclusions: z
+    .array(ProfileTargetSchema)
+    .max(RESEARCH_REQUEST_LIMITS.exclusions)
+    .default([]),
+  refinement: RefinementIntentSchema.default({ kind: 'disabled' }),
+});
+
+export type CanonicalResearchRequest = z.infer<
+  typeof CanonicalResearchRequestSchema
+>;
+export type ExactBudgetLimits = z.infer<typeof ExactBudgetLimitsSchema>;
+export type FallbackIntent = z.infer<typeof FallbackIntentSchema>;
+export type ProfileTarget = z.infer<typeof ProfileTargetSchema>;
+export type RefinementIntent = z.infer<typeof RefinementIntentSchema>;
+export type ResearchExecutionLimits = z.infer<
+  typeof ResearchExecutionLimitsSchema
+>;
+export type ResearchSelector = z.infer<typeof ResearchSelectorSchema>;
+
+export type PreparationPhase =
+  | 'transport'
+  | 'migration'
+  | 'canonicalization'
+  | 'selection'
+  | 'validation'
+  | 'compilation';
+
+export interface PreparationDiagnostic {
+  readonly code: string;
+  readonly phase: PreparationPhase;
+  readonly path: string;
+  readonly message: string;
+  readonly profile_key?: string;
+}
+
+export type PreparationIssue = PreparationDiagnostic;
+export type PreparationNotice = PreparationDiagnostic;
+
+export interface LegacyMigrationResult {
+  readonly input: unknown;
+  readonly notices: readonly PreparationNotice[];
+}
+
+/**
+ * Runs before canonical validation. Canonical schemas deliberately never accept
+ * `mixed`; only this compatibility boundary can translate it.
+ */
+export function migrateLegacyResearchRequest(
+  input: unknown,
+): LegacyMigrationResult {
+  if (
+    typeof input !== 'object' ||
+    input === null ||
+    Array.isArray(input) ||
+    (input as { mode?: unknown }).mode !== 'mixed'
+  ) {
+    return { input, notices: [] };
+  }
+
+  return {
+    input: { ...(input as Record<string, unknown>), mode: 'async' },
+    notices: [
+      {
+        code: 'legacy_mixed_mode_migrated',
+        phase: 'migration',
+        path: '/mode',
+        message:
+          'Legacy mixed mode is deprecated and was migrated to async mode.',
+      },
+    ],
+  };
+}

--- a/src/core/transport-normalization.ts
+++ b/src/core/transport-normalization.ts
@@ -1,0 +1,598 @@
+import type { EvidenceRequirements } from '../contracts/interchange/request.js';
+import {
+  type FrozenPlanningCatalog,
+  type PreparationDependencies,
+  type PreparedResearchExecution,
+  prepareResearchExecution,
+} from './execution-plan.js';
+import type {
+  ExactBudgetLimits,
+  FallbackIntent,
+  PreparationIssue,
+  PreparationNotice,
+  ProfileTarget,
+  RefinementIntent,
+  ResearchExecutionLimits,
+} from './research-request.js';
+
+/**
+ * Shadow-only transport normalization for the v2 request pipeline
+ * (Checkpoint A). Nothing in this module is wired into the production CLI,
+ * MCP, or configuration surfaces, and it is not exported from any package
+ * entrypoint: it exists so semantically equivalent raw inputs from every
+ * transport provably compile to identical PreparedResearchExecution values.
+ *
+ * One common normalizer rejects conflicting selectors; each source contributes only a thin
+ * projection of the Checkpoint A semantic fields (query, mode including
+ * legacy mixed, exactly one selector, fallback intent, limits, exact budgets,
+ * exclusions, refinement). Presentation, output, and filesystem fields are
+ * deliberately out of scope.
+ *
+ * Canonical defaults are NOT chosen here: no default policy values have been
+ * approved, so every normalizer requires an injected
+ * CanonicalTransportDefaults context. Selecting the built-in canonical values
+ * is an explicit maintainer decision that remains open.
+ *
+ * Shadow-mapper decision: the v1 runtime resolves competing `providers` and
+ * `group` selections by letting explicit providers win (see
+ * resolveProviderSelection in src/core/provider-selection.ts). The approved v2
+ * rule is that a canonical request has exactly one selector, so every raw
+ * adapter rejects ambiguity with the same stable issue. Production v1
+ * behavior is untouched.
+ */
+
+export type TransportSource =
+  | 'library'
+  | 'cli'
+  | 'mcp'
+  | 'configuration'
+  | 'silent_mcp';
+
+/** Injected per-caller context; this module ships no default policy values. */
+export interface CanonicalTransportDefaults {
+  readonly mode: 'sync' | 'async';
+  readonly limits: ResearchExecutionLimits;
+  readonly fallback: FallbackIntent;
+  readonly refinement: RefinementIntent;
+}
+
+export type TransportNormalizationResult =
+  | {
+      readonly ok: true;
+      readonly request: Record<string, unknown>;
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+interface CapabilitySelection {
+  readonly requirements: EvidenceRequirements;
+  readonly result_count?: number;
+}
+
+/** A selector value plus the raw-input path it came from on this transport. */
+interface SelectorCandidateInput<TValue> {
+  readonly value: TValue;
+  readonly raw_path: string;
+}
+
+interface SelectorCandidates {
+  readonly targets?: SelectorCandidateInput<readonly ProfileTarget[]>;
+  readonly group?: SelectorCandidateInput<string>;
+  readonly capabilities?: SelectorCandidateInput<CapabilitySelection>;
+  readonly use_default?: SelectorCandidateInput<boolean>;
+}
+
+interface SemanticTransportFields {
+  readonly query?: string;
+  readonly mode?: string;
+  readonly selector: SelectorCandidates;
+  readonly fallback?: FallbackIntent;
+  readonly limits?: Partial<ResearchExecutionLimits>;
+  readonly budgets?: ExactBudgetLimits;
+  readonly exclusions?: readonly ProfileTarget[];
+  readonly refinement?: RefinementIntent;
+}
+
+interface TransportProjection {
+  readonly fields: SemanticTransportFields;
+  readonly issues?: readonly PreparationIssue[];
+}
+
+interface SelectorCandidate {
+  readonly name: 'targets' | 'group' | 'capabilities' | 'default';
+  readonly rawPath: string;
+  readonly selector: Record<string, unknown>;
+}
+
+function presentSelectorCandidates(
+  candidates: SelectorCandidates,
+): SelectorCandidate[] {
+  const present: SelectorCandidate[] = [];
+  if (candidates.targets !== undefined) {
+    present.push({
+      name: 'targets',
+      rawPath: candidates.targets.raw_path,
+      selector: { kind: 'targets', targets: candidates.targets.value },
+    });
+  }
+  if (candidates.group !== undefined) {
+    present.push({
+      name: 'group',
+      rawPath: candidates.group.raw_path,
+      selector: { kind: 'group', group_id: candidates.group.value },
+    });
+  }
+  if (candidates.capabilities !== undefined) {
+    const capability = candidates.capabilities.value;
+    const selector: Record<string, unknown> = {
+      kind: 'capabilities',
+      requirements: capability.requirements,
+    };
+    if (capability.result_count !== undefined) {
+      selector.result_count = capability.result_count;
+    }
+    present.push({
+      name: 'capabilities',
+      rawPath: candidates.capabilities.raw_path,
+      selector,
+    });
+  }
+  if (candidates.use_default?.value) {
+    present.push({
+      name: 'default',
+      rawPath: candidates.use_default.raw_path,
+      selector: { kind: 'default' },
+    });
+  }
+  return present;
+}
+
+function mergeLimits(
+  defaults: ResearchExecutionLimits,
+  overrides: Partial<ResearchExecutionLimits> | undefined,
+): ResearchExecutionLimits {
+  const merged = { ...defaults };
+  if (!overrides) return merged;
+  for (const field of [
+    'max_concurrency',
+    'request_deadline_ms',
+    'inline_attempt_deadline_ms',
+    'background_attempt_deadline_ms',
+    'poll_interval_ms',
+  ] as const) {
+    const value = overrides[field];
+    if (value !== undefined) merged[field] = value;
+  }
+  return merged;
+}
+
+function normalizeTransportRequest(
+  source: TransportSource,
+  projection: TransportProjection,
+  defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  const issues: PreparationIssue[] = [...(projection.issues ?? [])];
+  const notices: PreparationNotice[] = [];
+  const fields = projection.fields;
+
+  const present = presentSelectorCandidates(fields.selector);
+  let selector: Record<string, unknown>;
+  if (present.length === 0) {
+    selector = { kind: 'default' };
+  } else {
+    const [chosen, ...competing] = present;
+    selector = chosen.selector;
+    for (const candidate of competing) {
+      issues.push({
+        code: 'transport_selector_conflict',
+        phase: 'transport',
+        path: candidate.rawPath,
+        message: `The ${candidate.name} selection competes with ${chosen.name}; a canonical request has exactly one selector. Remove one of them from the ${source} input.`,
+      });
+    }
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues, notices };
+  }
+
+  const request: Record<string, unknown> = {
+    query: fields.query,
+    mode: fields.mode ?? defaults.mode,
+    selector,
+    fallback: fields.fallback ?? defaults.fallback,
+    limits: mergeLimits(defaults.limits, fields.limits),
+    exclusions: fields.exclusions ?? [],
+    refinement: fields.refinement ?? defaults.refinement,
+  };
+  if (fields.budgets !== undefined) request.budgets = fields.budgets;
+  return { ok: true, request, notices };
+}
+
+/**
+ * Shadow orchestration helper: compiles a normalized transport request and
+ * merges the transport notices with the preparation notices so migration
+ * information never disappears between normalization and compilation. The
+ * PreparedResearchExecution itself is untouched, which keeps byte-for-byte
+ * plan equality independent of transport-specific notices.
+ */
+export type ShadowTransportCompilation =
+  | {
+      readonly ok: true;
+      readonly prepared: PreparedResearchExecution;
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+export function compileNormalizedTransportRequest(
+  normalized: TransportNormalizationResult,
+  catalog: FrozenPlanningCatalog,
+  dependencies: PreparationDependencies,
+): ShadowTransportCompilation {
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      issues: normalized.issues,
+      notices: normalized.notices,
+    };
+  }
+  const result = prepareResearchExecution(
+    normalized.request,
+    catalog,
+    dependencies,
+  );
+  const notices = [...normalized.notices, ...result.notices];
+  return result.ok
+    ? { ok: true, prepared: result.prepared, notices }
+    : { ok: false, issues: result.issues, notices };
+}
+
+/**
+ * Exact USD → micro-USD conversion with no floating-point arithmetic: the
+ * decimal rendering of the number is shifted six places. Values that cannot be
+ * represented exactly (exponent renderings, more than six decimal places,
+ * negatives, non-finite) are rejected with a stable issue instead of rounded.
+ */
+function exactMicrousdFromUsd(
+  value: number,
+  path: string,
+): { readonly value: string } | { readonly issue: PreparationIssue } {
+  const reject = (reason: string): { readonly issue: PreparationIssue } => ({
+    issue: {
+      code: 'transport_budget_not_exact',
+      phase: 'transport',
+      path,
+      message: `USD budgets must convert exactly to micro-USD: ${reason}`,
+    },
+  });
+  if (!Number.isFinite(value) || value < 0) {
+    return reject('the value must be a finite non-negative number.');
+  }
+  const text = String(value);
+  if (text.includes('e') || text.includes('E')) {
+    return reject('the value is too large or small for exact conversion.');
+  }
+  const [whole, fraction = ''] = text.split('.');
+  if (fraction.length > 6) {
+    return reject('at most six decimal places (one micro-USD) are supported.');
+  }
+  const shifted = `${whole}${fraction.padEnd(6, '0')}`.replace(/^0+(?=\d)/, '');
+  return { value: shifted };
+}
+
+function targetsFromProviderIds(
+  providerIds: readonly string[] | undefined,
+  path: string,
+  issues: PreparationIssue[],
+): SelectorCandidateInput<readonly ProfileTarget[]> | undefined {
+  if (providerIds === undefined) return undefined;
+  const targets = providerIds
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .map((token) => ({ provider_id: token }));
+  if (targets.length === 0) {
+    // Mirrors v1: provided-but-empty is a caller mistake, not a fallthrough
+    // to the default selection (see resolveProviderSelection).
+    issues.push({
+      code: 'transport_empty_provider_selection',
+      phase: 'transport',
+      path,
+      message:
+        'A provider selection was given but contains no usable provider ids. Omit it to use the default selection or pass at least one id.',
+    });
+    return undefined;
+  }
+  return { value: targets, raw_path: path };
+}
+
+function usdBudgets(
+  maxCostUsd: number | undefined,
+  maxEstimatedCostUsd: number | undefined,
+  pathPrefix: string,
+  issues: PreparationIssue[],
+): ExactBudgetLimits | undefined {
+  const budgets: {
+    max_estimated_cost_microusd?: string;
+    max_actual_cost_microusd?: string;
+  } = {};
+  if (maxEstimatedCostUsd !== undefined) {
+    const converted = exactMicrousdFromUsd(
+      maxEstimatedCostUsd,
+      `${pathPrefix}/maxEstimatedCostUsd`,
+    );
+    if ('issue' in converted) issues.push(converted.issue);
+    else budgets.max_estimated_cost_microusd = converted.value;
+  }
+  if (maxCostUsd !== undefined) {
+    const converted = exactMicrousdFromUsd(
+      maxCostUsd,
+      `${pathPrefix}/maxCostUsd`,
+    );
+    if ('issue' in converted) issues.push(converted.issue);
+    else budgets.max_actual_cost_microusd = converted.value;
+  }
+  return budgets.max_estimated_cost_microusd !== undefined ||
+    budgets.max_actual_cost_microusd !== undefined
+    ? budgets
+    : undefined;
+}
+
+function toggleIntent<TIntent>(
+  flag: boolean | undefined,
+  enabled: TIntent,
+  disabled: TIntent,
+): TIntent | undefined {
+  if (flag === undefined) return undefined;
+  return flag ? enabled : disabled;
+}
+
+/** Programmatic (library) callers submit near-canonical semantic fields. */
+export interface LibraryTransportInput {
+  readonly query?: string;
+  readonly mode?: string;
+  readonly targets?: readonly ProfileTarget[];
+  readonly group?: string;
+  readonly capabilities?: CapabilitySelection;
+  readonly useDefaultSelection?: boolean;
+  readonly fallback?: FallbackIntent;
+  readonly limits?: Partial<ResearchExecutionLimits>;
+  readonly budgets?: ExactBudgetLimits;
+  readonly exclusions?: readonly ProfileTarget[];
+  readonly refinement?: RefinementIntent;
+}
+
+export function normalizeLibraryRequest(
+  input: LibraryTransportInput,
+  defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  return normalizeTransportRequest(
+    'library',
+    {
+      fields: {
+        query: input.query,
+        mode: input.mode,
+        selector: {
+          targets:
+            input.targets === undefined
+              ? undefined
+              : { value: input.targets, raw_path: '/targets' },
+          group:
+            input.group === undefined
+              ? undefined
+              : { value: input.group, raw_path: '/group' },
+          capabilities:
+            input.capabilities === undefined
+              ? undefined
+              : { value: input.capabilities, raw_path: '/capabilities' },
+          use_default:
+            input.useDefaultSelection === undefined
+              ? undefined
+              : {
+                  value: input.useDefaultSelection,
+                  raw_path: '/useDefaultSelection',
+                },
+        },
+        fallback: input.fallback,
+        limits: input.limits,
+        budgets: input.budgets,
+        exclusions: input.exclusions,
+        refinement: input.refinement,
+      },
+    },
+    defaults,
+  );
+}
+
+/** Mirrors the `librarium run` flag vocabulary (comma-split -p, seconds, USD). */
+export interface CliTransportInput {
+  readonly query?: string;
+  readonly providers?: readonly string[];
+  readonly group?: string;
+  readonly mode?: string;
+  readonly parallel?: number;
+  readonly timeoutSeconds?: number;
+  readonly maxCostUsd?: number;
+  readonly maxEstimatedCostUsd?: number;
+  readonly fallback?: boolean;
+  readonly refine?: boolean;
+}
+
+export function normalizeCliRequest(
+  input: CliTransportInput,
+  defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  const issues: PreparationIssue[] = [];
+  const limits: Partial<ResearchExecutionLimits> = {};
+  if (input.parallel !== undefined) limits.max_concurrency = input.parallel;
+  if (input.timeoutSeconds !== undefined) {
+    limits.inline_attempt_deadline_ms = input.timeoutSeconds * 1_000;
+  }
+  return normalizeTransportRequest(
+    'cli',
+    {
+      fields: {
+        query: input.query,
+        mode: input.mode,
+        selector: {
+          targets: targetsFromProviderIds(
+            input.providers,
+            '/providers',
+            issues,
+          ),
+          group:
+            input.group === undefined
+              ? undefined
+              : { value: input.group, raw_path: '/group' },
+        },
+        fallback: toggleIntent<FallbackIntent>(
+          input.fallback,
+          { kind: 'configured' },
+          { kind: 'disabled' },
+        ),
+        limits,
+        budgets: usdBudgets(
+          input.maxCostUsd,
+          input.maxEstimatedCostUsd,
+          '',
+          issues,
+        ),
+        refinement: toggleIntent<RefinementIntent>(
+          input.refine,
+          { kind: 'requested' },
+          { kind: 'disabled' },
+        ),
+      },
+      issues,
+    },
+    defaults,
+  );
+}
+
+/** Mirrors the MCP `research` tool arguments (and the silent pipeline args). */
+export interface McpTransportInput {
+  readonly query?: string;
+  readonly providers?: readonly string[];
+  readonly group?: string;
+  readonly mode?: string;
+  readonly refine?: boolean;
+}
+
+function mcpProjection(input: McpTransportInput): TransportProjection {
+  const issues: PreparationIssue[] = [];
+  return {
+    fields: {
+      query: input.query,
+      mode: input.mode,
+      selector: {
+        targets: targetsFromProviderIds(input.providers, '/providers', issues),
+        group:
+          input.group === undefined
+            ? undefined
+            : { value: input.group, raw_path: '/group' },
+      },
+      refinement: toggleIntent<RefinementIntent>(
+        input.refine,
+        { kind: 'requested' },
+        { kind: 'disabled' },
+      ),
+    },
+    issues,
+  };
+}
+
+export function normalizeMcpRequest(
+  input: McpTransportInput,
+  defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  return normalizeTransportRequest('mcp', mcpProjection(input), defaults);
+}
+
+export function normalizeSilentMcpRequest(
+  input: McpTransportInput,
+  defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  return normalizeTransportRequest(
+    'silent_mcp',
+    mcpProjection(input),
+    defaults,
+  );
+}
+
+/** Mirrors the config-file `defaults` block plus a declarative selection. */
+export interface ConfigurationTransportInput {
+  readonly query?: string;
+  readonly providers?: readonly string[];
+  readonly group?: string;
+  readonly defaults?: {
+    readonly mode?: string;
+    readonly maxParallel?: number;
+    readonly timeoutSeconds?: number;
+    readonly backgroundTimeoutSeconds?: number;
+    readonly requestTimeoutSeconds?: number;
+    readonly pollIntervalSeconds?: number;
+    readonly maxCostUsd?: number;
+    readonly maxEstimatedCostUsd?: number;
+  };
+}
+
+export function normalizeConfigurationRequest(
+  input: ConfigurationTransportInput,
+  defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  const issues: PreparationIssue[] = [];
+  const configured = input.defaults ?? {};
+  const limits: Partial<ResearchExecutionLimits> = {};
+  if (configured.maxParallel !== undefined) {
+    limits.max_concurrency = configured.maxParallel;
+  }
+  if (configured.timeoutSeconds !== undefined) {
+    limits.inline_attempt_deadline_ms = configured.timeoutSeconds * 1_000;
+  }
+  if (configured.backgroundTimeoutSeconds !== undefined) {
+    limits.background_attempt_deadline_ms =
+      configured.backgroundTimeoutSeconds * 1_000;
+  }
+  if (configured.requestTimeoutSeconds !== undefined) {
+    limits.request_deadline_ms = configured.requestTimeoutSeconds * 1_000;
+  }
+  if (configured.pollIntervalSeconds !== undefined) {
+    limits.poll_interval_ms = configured.pollIntervalSeconds * 1_000;
+  }
+  return normalizeTransportRequest(
+    'configuration',
+    {
+      fields: {
+        query: input.query,
+        mode: configured.mode,
+        selector: {
+          targets: targetsFromProviderIds(
+            input.providers,
+            '/providers',
+            issues,
+          ),
+          group:
+            input.group === undefined
+              ? undefined
+              : { value: input.group, raw_path: '/group' },
+        },
+        limits,
+        budgets: usdBudgets(
+          configured.maxCostUsd,
+          configured.maxEstimatedCostUsd,
+          '/defaults',
+          issues,
+        ),
+      },
+      issues,
+    },
+    defaults,
+  );
+}

--- a/tests/coordinator.test.ts
+++ b/tests/coordinator.test.ts
@@ -1,0 +1,846 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  DurableHandle,
+  ExecutionProfile,
+  StructuredError,
+} from '../src/contracts/domain/index.js';
+import { LifecycleTraceSchema } from '../src/contracts/interchange/lifecycle.js';
+import {
+  acceptedDurableHandles,
+  advanceCoordination,
+  type CoordinatorState,
+  cancelCoordination,
+  claimFallbackRound,
+  createCoordinatorState,
+  failCoordination,
+  finalizeCoordination,
+  mapCoordinatorOutcome,
+  recordAcceptanceUnknown,
+  recordAttemptFinished,
+  recordSubmissionAccepted,
+  recordTransientPollFailure,
+  resumeCoordination,
+  setRefinedSlotQuery,
+  startLaunchableAttempts,
+} from '../src/core/coordinator.js';
+import {
+  InMemoryCoordinationStateStore,
+  updateCoordinationState,
+} from '../src/core/coordinator-store.js';
+import {
+  type PreparedResearchExecution,
+  profileIdentityKey,
+} from '../src/core/execution-plan.js';
+
+function inlineProfile(providerId: string): ExecutionProfile {
+  return {
+    identity: { provider_id: providerId, profile_id: 'grounded-web' },
+    result_kind: 'grounded_answer',
+    grounding_policy: 'required',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'model_search_tool',
+    access_mode: 'direct',
+    operator_id: providerId,
+    invocation: 'inline',
+    resumability: 'none',
+  };
+}
+
+function durableProfile(providerId: string): ExecutionProfile {
+  return {
+    ...inlineProfile(providerId),
+    invocation: 'background',
+    resumability: 'durable',
+  };
+}
+
+function processLocalProfile(providerId: string): ExecutionProfile {
+  return {
+    ...inlineProfile(providerId),
+    invocation: 'background',
+    resumability: 'process_local',
+  };
+}
+
+interface PreparedOptions {
+  primaries: readonly ExecutionProfile[];
+  reserve?: readonly {
+    profile: ExecutionProfile;
+    eligibleSlots: readonly number[];
+  }[];
+  maxConcurrency?: number;
+  inlineAttemptDeadlineMs?: number;
+  backgroundAttemptDeadlineMs?: number;
+  requestDeadlineMs?: number;
+  estimates?: Readonly<Record<string, string | undefined>>;
+  budgets?: {
+    max_estimated_cost_microusd?: string;
+    max_actual_cost_microusd?: string;
+  };
+  mode?: 'sync' | 'async';
+}
+
+function preparedExecution(
+  options: PreparedOptions,
+): PreparedResearchExecution {
+  const reserve = options.reserve ?? [];
+  const profiles = [
+    ...options.primaries,
+    ...reserve.map((candidate) => candidate.profile),
+  ];
+  const profilePlans = Object.fromEntries(
+    profiles.map((profile) => {
+      const key = profileIdentityKey(profile.identity);
+      const estimate = options.estimates?.[profile.identity.provider_id];
+      return [
+        key,
+        {
+          profile_key: key,
+          identity: profile.identity,
+          binding: {
+            adapter_id: `adapter-${profile.identity.provider_id}`,
+            binding_id: `binding-${profile.identity.profile_id}`,
+          },
+          estimate:
+            estimate === undefined
+              ? undefined
+              : { estimated_cost_microusd: estimate },
+        },
+      ];
+    }),
+  );
+  const fallback =
+    reserve.length === 0
+      ? ({ kind: 'disabled' } as const)
+      : ({
+          kind: 'explicit',
+          reserve: reserve.map(({ profile }) => ({
+            provider_id: profile.identity.provider_id,
+            profile_id: profile.identity.profile_id,
+          })),
+        } as const);
+  return {
+    request: {
+      interchange_version: '1.0.0',
+      message_type: 'request',
+      request_id: 'request-1',
+      requested_at: '2026-08-08T12:00:00.000Z',
+      mode: options.mode ?? 'sync',
+      query: 'original query',
+      slots: options.primaries.map((profile, position) => ({
+        slot_id: `slot-${position}`,
+        position,
+        requirements: {
+          result_kind: 'grounded_answer',
+          grounding_policy: 'required',
+          observation_mode: 'api_output',
+          corpora: ['web'],
+          retrieval_methods: ['model_search_tool'],
+        },
+        primary: profile,
+      })),
+      fallback_reserve: reserve.map((candidate, position) => ({
+        candidate_id: `candidate-${position}`,
+        position,
+        profile: candidate.profile,
+        eligible_slot_ids: candidate.eligibleSlots.map(
+          (slot) => `slot-${slot}`,
+        ),
+      })),
+    },
+    policy: {
+      limits: {
+        max_concurrency: options.maxConcurrency ?? options.primaries.length,
+        request_deadline_ms: options.requestDeadlineMs ?? 60_000,
+        inline_attempt_deadline_ms: options.inlineAttemptDeadlineMs ?? 30_000,
+        background_attempt_deadline_ms:
+          options.backgroundAttemptDeadlineMs ?? 30_000,
+        poll_interval_ms: 1_000,
+      },
+      budgets: options.budgets,
+      fallback,
+      exclusions: [],
+      refinement: { kind: 'disabled' },
+    },
+    profile_plans_by_identity: profilePlans,
+    catalog: { revision: 'fixture-r1', digest: 'fixture-digest' },
+    notices: [],
+  };
+}
+
+function dependencies(start = Date.parse('2026-08-08T12:00:00Z')) {
+  let now = start;
+  const counts = new Map<string, number>();
+  return {
+    clock: { now: () => now },
+    ids: {
+      next: (scope: 'attempt' | 'event') => {
+        const count = (counts.get(scope) ?? 0) + 1;
+        counts.set(scope, count);
+        return `${scope}-${count}`;
+      },
+    },
+    setNow(value: number) {
+      now = value;
+    },
+  };
+}
+
+function providerFailure(
+  fallbackAllowed: boolean,
+  code = 'provider_failed',
+): StructuredError {
+  return {
+    code,
+    message: 'The provider failed.',
+    category: 'provider',
+    retryable: true,
+    fallback_allowed: fallbackAllowed,
+  };
+}
+
+function internalFailure(): StructuredError {
+  return {
+    code: 'coordinator_failed',
+    message: 'The coordinator infrastructure failed.',
+    category: 'internal',
+    retryable: true,
+    fallback_allowed: false,
+  };
+}
+
+function handle(
+  profile: ExecutionProfile,
+  status: DurableHandle['status'],
+): DurableHandle {
+  return {
+    handle_id: `handle-${profile.identity.provider_id}`,
+    provider_task_id: `task-${profile.identity.provider_id}`,
+    provider: profile.identity,
+    submitted_at: '2026-08-08T12:00:00.000Z',
+    last_observed_at: '2026-08-08T12:00:01.000Z',
+    status,
+  };
+}
+
+function startAll(
+  prepared: PreparedResearchExecution,
+  deps: ReturnType<typeof dependencies>,
+): CoordinatorState {
+  return startLaunchableAttempts(createCoordinatorState(prepared, deps), deps)
+    .state;
+}
+
+describe('deterministic coordinator rounds', () => {
+  it('allocates a shared reserve by failed slot position with eligibility holes', () => {
+    const deps = dependencies();
+    const prepared = preparedExecution({
+      primaries: [inlineProfile('primary-a'), inlineProfile('primary-b')],
+      reserve: [
+        { profile: inlineProfile('reserve-b-first'), eligibleSlots: [1] },
+        { profile: inlineProfile('reserve-shared'), eligibleSlots: [0, 1] },
+        { profile: inlineProfile('reserve-last'), eligibleSlots: [0, 1] },
+      ],
+    });
+    let state = startAll(prepared, deps);
+    for (const attempt of [...state.attempts]) {
+      state = recordAttemptFinished(
+        state,
+        attempt.attempt_id,
+        { outcome: 'failed', error: providerFailure(true) },
+        deps,
+      );
+    }
+
+    const round = claimFallbackRound(state, deps);
+    expect(
+      round.claims.map(({ slot_id, candidate_id }) => [slot_id, candidate_id]),
+    ).toEqual([
+      ['slot-0', 'candidate-1'],
+      ['slot-1', 'candidate-0'],
+    ]);
+    expect(round.state.claimed_candidate_ids).toEqual([
+      'candidate-1',
+      'candidate-0',
+    ]);
+
+    const replacement = startLaunchableAttempts(round.state, deps);
+    expect(
+      replacement.launches.map((launch) => launch.profile.identity.provider_id),
+    ).toEqual(['reserve-shared', 'reserve-b-first']);
+    state = replacement.state;
+    for (const attempt of state.attempts.filter(
+      (candidate) => candidate.round === 1,
+    )) {
+      state = recordAttemptFinished(
+        state,
+        attempt.attempt_id,
+        { outcome: 'succeeded', result_id: `result-${attempt.slot_id}` },
+        deps,
+      );
+    }
+    state = finalizeCoordination(state, deps);
+
+    const eventKinds = state.lifecycle.map((event) => event.event_kind);
+    expect(eventKinds[0]).toBe('request_started');
+    expect(eventKinds.at(-1)).toBe('request_completed');
+    const primaryAttemptIds = new Set(
+      state.attempts
+        .filter((attempt) => attempt.round === 0)
+        .map((attempt) => attempt.attempt_id),
+    );
+    const primaryFinishIndexes = state.lifecycle.flatMap((event, index) =>
+      event.event_kind === 'attempt_finished' &&
+      primaryAttemptIds.has(event.attempt_id)
+        ? [index]
+        : [],
+    );
+    const fallbackIndexes = state.lifecycle.flatMap((event, index) =>
+      event.event_kind === 'fallback_selected' ? [index] : [],
+    );
+    expect(Math.max(...primaryFinishIndexes)).toBeLessThan(
+      Math.min(...fallbackIndexes),
+    );
+    for (const [index, event] of state.lifecycle.entries()) {
+      if (event.event_kind !== 'fallback_selected') continue;
+      const replacementStart = state.lifecycle.findIndex(
+        (candidate) =>
+          candidate.event_kind === 'attempt_started' &&
+          candidate.attempt_id === event.data.replacement_attempt_id,
+      );
+      expect(index).toBeLessThan(replacementStart);
+    }
+    expect(() => LifecycleTraceSchema.parse(state.lifecycle)).not.toThrow();
+  });
+
+  it('allows only the concurrent CAS winner to receive launches', async () => {
+    const deps = dependencies();
+    const prepared = preparedExecution({
+      primaries: [inlineProfile('primary-a'), inlineProfile('primary-b')],
+      reserve: [
+        { profile: inlineProfile('reserve-a'), eligibleSlots: [0, 1] },
+        { profile: inlineProfile('reserve-b'), eligibleSlots: [0, 1] },
+      ],
+    });
+    let state = startAll(prepared, deps);
+    for (const attempt of [...state.attempts]) {
+      state = recordAttemptFinished(
+        state,
+        attempt.attempt_id,
+        { outcome: 'failed', error: providerFailure(true) },
+        deps,
+      );
+    }
+    const store = new InMemoryCoordinationStateStore();
+    await store.create(state);
+
+    const resumes = await Promise.all([
+      resumeCoordination(store, state.request_id, deps),
+      resumeCoordination(store, state.request_id, deps),
+    ]);
+    expect(resumes.map((result) => result.launches.length).sort()).toEqual([
+      0, 2,
+    ]);
+
+    const persisted = await store.load(state.request_id);
+    expect(persisted?.version).toBe(2);
+    expect(persisted?.state.claimed_candidate_ids).toHaveLength(2);
+    expect(new Set(persisted?.state.claimed_candidate_ids).size).toBe(2);
+    const replacementAttempts =
+      persisted?.state.attempts.filter((attempt) => attempt.round === 1) ?? [];
+    expect(replacementAttempts).toHaveLength(2);
+    expect(
+      new Set(
+        replacementAttempts.map((attempt) =>
+          profileIdentityKey(attempt.profile.identity),
+        ),
+      ).size,
+    ).toBe(2);
+  });
+
+  it('keeps refined queries private and inherits them across replacements', () => {
+    const deps = dependencies();
+    const prepared = preparedExecution({
+      primaries: [inlineProfile('primary')],
+      reserve: [{ profile: inlineProfile('reserve'), eligibleSlots: [0] }],
+    });
+    let state = createCoordinatorState(prepared, deps);
+    state = setRefinedSlotQuery(state, 'slot-0', '  refined private query  ');
+    let advanced = startLaunchableAttempts(state, deps);
+    expect(advanced.launches[0]?.query).toBe('refined private query');
+    state = recordAttemptFinished(
+      advanced.state,
+      advanced.launches[0]?.attempt_id ?? '',
+      { outcome: 'failed', error: providerFailure(true) },
+      deps,
+    );
+    advanced = advanceCoordination(state, deps);
+    expect(advanced.launches[0]?.query).toBe('refined private query');
+    expect(prepared.request.query).toBe('original query');
+    expect(advanced.state.original_query).toBe('original query');
+  });
+});
+
+describe('acceptance, deadlines, cancellation, and budgets', () => {
+  it('assigns separate inline and background attempt deadlines', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    const state = startAll(
+      preparedExecution({
+        primaries: [inlineProfile('inline'), durableProfile('durable')],
+        inlineAttemptDeadlineMs: 10_000,
+        backgroundAttemptDeadlineMs: 20_000,
+      }),
+      deps,
+    );
+
+    expect(state.attempts.map((attempt) => attempt.deadline_at)).toEqual([
+      new Date(start + 10_000).toISOString(),
+      new Date(start + 20_000).toISOString(),
+    ]);
+  });
+
+  it('turns durable submission expiry into acceptance_unknown and halts all work', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    const prepared = preparedExecution({
+      primaries: [durableProfile('durable'), inlineProfile('inline')],
+      reserve: [{ profile: inlineProfile('reserve'), eligibleSlots: [0] }],
+      maxConcurrency: 1,
+      backgroundAttemptDeadlineMs: 10_000,
+    });
+    let state = startAll(prepared, deps);
+    expect(state.attempts[0]?.status).toBe('submitting');
+    deps.setNow(start + 10_000);
+    const advanced = advanceCoordination(state, deps);
+    state = advanced.state;
+
+    expect(advanced.launches).toEqual([]);
+    expect(state.attempts[0]).toMatchObject({
+      status: 'acceptance_unknown',
+    });
+    expect(state.unresolved_acceptances).toEqual([
+      expect.objectContaining({
+        attempt_id: state.attempts[0]?.attempt_id,
+        reason: 'submission_deadline_exceeded',
+      }),
+    ]);
+    expect(state.slots[1]?.status).toBe('unstarted');
+    expect(state.claimed_candidate_ids).toEqual([]);
+    expect(claimFallbackRound(state, deps).claims).toEqual([]);
+    expect(state.used_profile_keys).toContain(
+      profileIdentityKey(durableProfile('durable').identity),
+    );
+  });
+
+  it('times out inline work and launches an eligible fallback without acceptance uncertainty', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    const prepared = preparedExecution({
+      primaries: [inlineProfile('inline-primary')],
+      reserve: [
+        { profile: inlineProfile('inline-reserve'), eligibleSlots: [0] },
+      ],
+      inlineAttemptDeadlineMs: 10_000,
+    });
+    const state = startAll(prepared, deps);
+    expect(state.attempts[0]?.status).toBe('running');
+    deps.setNow(start + 10_000);
+    const advanced = advanceCoordination(state, deps);
+
+    expect(advanced.state.attempts[0]).toMatchObject({
+      status: 'timed_out',
+      error: {
+        code: 'attempt_deadline_exceeded',
+        fallback_allowed: true,
+      },
+    });
+    expect(advanced.state.unresolved_acceptances).toEqual([]);
+    expect(advanced.launches).toHaveLength(1);
+    expect(advanced.launches[0]?.profile.identity.provider_id).toBe(
+      'inline-reserve',
+    );
+  });
+
+  it('starts process-local work as running and never permits acceptance uncertainty', () => {
+    const deps = dependencies();
+    const state = startAll(
+      preparedExecution({ primaries: [processLocalProfile('local')] }),
+      deps,
+    );
+    expect(state.attempts[0]?.status).toBe('running');
+    expect(() =>
+      recordAcceptanceUnknown(state, state.attempts[0]?.attempt_id ?? '', deps),
+    ).toThrow('Only durable background profiles');
+  });
+
+  it('keeps remote uncertainty observable after request deadline and cancellation', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deadlineDeps = dependencies(start);
+    const prepared = preparedExecution({
+      primaries: [durableProfile('durable')],
+      reserve: [{ profile: inlineProfile('reserve'), eligibleSlots: [0] }],
+      requestDeadlineMs: 20_000,
+      backgroundAttemptDeadlineMs: 10_000,
+    });
+    let deadlineState = startAll(prepared, deadlineDeps);
+    deadlineDeps.setNow(start + 20_000);
+    deadlineState = advanceCoordination(deadlineState, deadlineDeps).state;
+    expect(deadlineState.status).toBe('unsuccessful');
+    expect(deadlineState.unresolved_acceptances).toEqual([
+      expect.objectContaining({ reason: 'request_deadline_exceeded' }),
+    ]);
+    expect(deadlineState.lifecycle.at(-1)?.event_kind).toBe(
+      'request_completed',
+    );
+
+    const cancelDeps = dependencies(start);
+    let cancelled = startAll(prepared, cancelDeps);
+    cancelled = recordAcceptanceUnknown(
+      cancelled,
+      cancelled.attempts[0]?.attempt_id ?? '',
+      cancelDeps,
+      'adapter-state-ref-1',
+    );
+    cancelled = cancelCoordination(cancelled, cancelDeps);
+    expect(cancelled.status).toBe('cancelled');
+    expect(cancelled.unresolved_acceptances).toEqual([
+      expect.objectContaining({
+        reason: 'cancelled_while_acceptance_unknown',
+        adapter_state_ref: 'adapter-state-ref-1',
+      }),
+    ]);
+    expect(cancelled.attempts[0]).toMatchObject({
+      status: 'cancelled',
+      adapter_state_ref: 'adapter-state-ref-1',
+    });
+    expect(cancelled.claimed_candidate_ids).toEqual([]);
+  });
+
+  it('keeps transient poll failures private and nonterminal', () => {
+    const deps = dependencies();
+    const profile = durableProfile('durable');
+    let state = startAll(preparedExecution({ primaries: [profile] }), deps);
+    state = recordSubmissionAccepted(
+      state,
+      state.attempts[0]?.attempt_id ?? '',
+      handle(profile, 'pending'),
+      deps,
+    );
+    const lifecycleLength = state.lifecycle.length;
+    const pollError: StructuredError = {
+      code: 'poll_temporarily_unavailable',
+      message: 'The provider status endpoint was temporarily unavailable.',
+      category: 'network',
+      retryable: true,
+      fallback_allowed: false,
+    };
+    state = recordTransientPollFailure(
+      state,
+      state.attempts[0]?.attempt_id ?? '',
+      pollError,
+    );
+
+    expect(state.attempts[0]).toMatchObject({
+      status: 'submitted',
+      transient_poll_error: pollError,
+    });
+    expect(state.lifecycle).toHaveLength(lifecycleLength);
+    expect(state.status).toBe('running');
+  });
+
+  it('uses a zero ceiling to suppress paid slots while permitting zero reservations', () => {
+    const deps = dependencies();
+    const prepared = preparedExecution({
+      primaries: [inlineProfile('free'), inlineProfile('paid')],
+      estimates: { free: '0', paid: '1' },
+      budgets: { max_estimated_cost_microusd: '0' },
+    });
+    const started = startLaunchableAttempts(
+      createCoordinatorState(prepared, deps),
+      deps,
+    );
+
+    expect(
+      started.launches.map((launch) => launch.profile.identity.provider_id),
+    ).toEqual(['free']);
+    expect(started.state.slots[1]).toMatchObject({
+      status: 'cancelled',
+      error: {
+        code: 'budget_reservation_exceeded',
+        category: 'budget',
+        fallback_allowed: false,
+      },
+    });
+    expect(started.state.budget.reserved_estimated_cost_microusd).toBe('0');
+  });
+});
+
+describe('durable handles and terminal mapping', () => {
+  it('validates handle identity/status and permits succeeded-handle retrieval failure', () => {
+    const deps = dependencies();
+    const profile = durableProfile('durable');
+    let state = startAll(preparedExecution({ primaries: [profile] }), deps);
+    const attemptId = state.attempts[0]?.attempt_id ?? '';
+
+    expect(() =>
+      recordSubmissionAccepted(
+        state,
+        attemptId,
+        handle(profile, 'succeeded'),
+        deps,
+      ),
+    ).toThrow('must be pending or running');
+    state = recordSubmissionAccepted(
+      state,
+      attemptId,
+      handle(profile, 'pending'),
+      deps,
+      'adapter-state-ref',
+    );
+    const wrongProfileHandle = handle(durableProfile('other'), 'failed');
+    expect(() =>
+      recordAttemptFinished(
+        state,
+        attemptId,
+        {
+          outcome: 'failed',
+          error: providerFailure(false),
+          durable_handle: wrongProfileHandle,
+        },
+        deps,
+      ),
+    ).toThrow('provider must match');
+
+    const succeededHandle = handle(profile, 'succeeded');
+    state = recordAttemptFinished(
+      state,
+      attemptId,
+      {
+        outcome: 'failed',
+        error: providerFailure(false, 'retrieve_normalization_failed'),
+        durable_handle: succeededHandle,
+      },
+      deps,
+    );
+    expect(state.attempts[0]).toMatchObject({
+      status: 'failed',
+      durable_handle: succeededHandle,
+      error: { code: 'retrieve_normalization_failed' },
+    });
+  });
+
+  it('preserves an accepted durable handle when sync execution is later cancelled', () => {
+    const deps = dependencies();
+    const profile = durableProfile('durable');
+    let state = startAll(preparedExecution({ primaries: [profile] }), deps);
+    const accepted = handle(profile, 'pending');
+    state = recordSubmissionAccepted(
+      state,
+      state.attempts[0]?.attempt_id ?? '',
+      accepted,
+      deps,
+      'adapter-state-ref',
+    );
+    state = cancelCoordination(state, deps);
+
+    expect(state.status).toBe('cancelled');
+    expect(state.attempts[0]?.durable_handle).toEqual(accepted);
+    expect(acceptedDurableHandles(state)).toEqual([accepted]);
+    expect(state.lifecycle.at(-1)?.event_kind).toBe('request_cancelled');
+    expect(() => LifecycleTraceSchema.parse(state.lifecycle)).not.toThrow();
+  });
+
+  it('maps all success, partial success, settled no-success, cancellation, and infrastructure failure', () => {
+    const settle = (outcomes: readonly ('succeeded' | 'failed')[]) => {
+      const deps = dependencies();
+      let state = startAll(
+        preparedExecution({
+          primaries: outcomes.map((_, index) => inlineProfile(`p-${index}`)),
+        }),
+        deps,
+      );
+      for (const [index, attempt] of [...state.attempts].entries()) {
+        state = recordAttemptFinished(
+          state,
+          attempt.attempt_id,
+          outcomes[index] === 'succeeded'
+            ? { outcome: 'succeeded', result_id: `result-${index}` }
+            : { outcome: 'failed', error: providerFailure(false) },
+          deps,
+        );
+      }
+      return { state, deps };
+    };
+
+    const all = settle(['succeeded', 'succeeded']);
+    expect(mapCoordinatorOutcome(all.state)).toBe('succeeded');
+    expect(finalizeCoordination(all.state, all.deps).status).toBe('succeeded');
+
+    const partial = settle(['succeeded', 'failed']);
+    expect(mapCoordinatorOutcome(partial.state)).toBe('partial');
+    expect(finalizeCoordination(partial.state, partial.deps).status).toBe(
+      'partial',
+    );
+
+    const none = settle(['failed', 'failed']);
+    expect(mapCoordinatorOutcome(none.state)).toBe('unsuccessful');
+    expect(finalizeCoordination(none.state, none.deps).status).toBe(
+      'unsuccessful',
+    );
+
+    const cancelDeps = dependencies();
+    const cancelled = cancelCoordination(
+      startAll(
+        preparedExecution({ primaries: [inlineProfile('cancelled')] }),
+        cancelDeps,
+      ),
+      cancelDeps,
+    );
+    expect(mapCoordinatorOutcome(cancelled)).toBe('cancelled');
+
+    const failureDeps = dependencies();
+    const failed = failCoordination(
+      startAll(
+        preparedExecution({ primaries: [inlineProfile('infra')] }),
+        failureDeps,
+      ),
+      internalFailure(),
+      failureDeps,
+    );
+    expect(mapCoordinatorOutcome(failed)).toBe('failed');
+  });
+
+  it('rejects durable handles on inline and process-local attempts', () => {
+    for (const profile of [
+      inlineProfile('inline-only'),
+      processLocalProfile('process-local'),
+    ]) {
+      const deps = dependencies();
+      const state = startAll(preparedExecution({ primaries: [profile] }), deps);
+      expect(() =>
+        recordAttemptFinished(
+          state,
+          state.attempts[0]?.attempt_id ?? '',
+          {
+            outcome: 'succeeded',
+            result_id: 'result-1',
+            durable_handle: handle(profile, 'succeeded'),
+          },
+          deps,
+        ),
+      ).toThrow('durable background attempts');
+    }
+  });
+
+  it('rejects durable success while the effective accepted handle is still pending', () => {
+    const deps = dependencies();
+    const profile = durableProfile('durable');
+    let state = startAll(preparedExecution({ primaries: [profile] }), deps);
+    const attemptId = state.attempts[0]?.attempt_id ?? '';
+    state = recordSubmissionAccepted(
+      state,
+      attemptId,
+      handle(profile, 'pending'),
+      deps,
+    );
+
+    expect(() =>
+      recordAttemptFinished(
+        state,
+        attemptId,
+        { outcome: 'succeeded', result_id: 'result-1' },
+        deps,
+      ),
+    ).toThrow('effective handle must be succeeded');
+    expect(() =>
+      recordAttemptFinished(
+        state,
+        attemptId,
+        {
+          outcome: 'succeeded',
+          result_id: 'result-1',
+          durable_handle: handle(profile, 'running'),
+        },
+        deps,
+      ),
+    ).toThrow('incoherent');
+
+    const succeeded = recordAttemptFinished(
+      state,
+      attemptId,
+      {
+        outcome: 'succeeded',
+        result_id: 'result-1',
+        durable_handle: handle(profile, 'succeeded'),
+      },
+      deps,
+    );
+    expect(succeeded.attempts[0]).toMatchObject({
+      status: 'succeeded',
+      durable_handle: { status: 'succeeded' },
+    });
+  });
+
+  it('rejects non-retryable transient poll failures', () => {
+    const deps = dependencies();
+    const profile = durableProfile('durable');
+    let state = startAll(preparedExecution({ primaries: [profile] }), deps);
+    state = recordSubmissionAccepted(
+      state,
+      state.attempts[0]?.attempt_id ?? '',
+      handle(profile, 'pending'),
+      deps,
+    );
+    expect(() =>
+      recordTransientPollFailure(state, state.attempts[0]?.attempt_id ?? '', {
+        code: 'poll_permanently_broken',
+        message: 'The provider status endpoint rejected the handle.',
+        category: 'provider',
+        retryable: false,
+        fallback_allowed: false,
+      }),
+    ).toThrow('retryable');
+  });
+
+  it('applies the canonical 100k character bound to refined slot queries', () => {
+    const deps = dependencies();
+    const state = createCoordinatorState(
+      preparedExecution({ primaries: [inlineProfile('bounded')] }),
+      deps,
+    );
+    const maxQuery = 'q'.repeat(100_000);
+    const refined = setRefinedSlotQuery(state, 'slot-0', `  ${maxQuery}  `);
+    expect(refined.slots[0]?.refined_query).toHaveLength(100_000);
+    expect(() => setRefinedSlotQuery(state, 'slot-0', `${maxQuery}q`)).toThrow(
+      'cannot exceed 100000 characters',
+    );
+    expect(() => setRefinedSlotQuery(state, 'slot-0', '   ')).toThrow(
+      'cannot be empty',
+    );
+  });
+
+  it('rejects zero, negative, and non-integer compare-and-swap attempt budgets immediately', async () => {
+    const deps = dependencies();
+    const state = startAll(
+      preparedExecution({ primaries: [inlineProfile('cas')] }),
+      deps,
+    );
+    const store = new InMemoryCoordinationStateStore();
+    await store.create(state);
+    for (const invalid of [0, -1, 1.5]) {
+      await expect(
+        resumeCoordination(store, state.request_id, deps, invalid),
+      ).rejects.toThrow('positive integer');
+      await expect(
+        updateCoordinationState(
+          store,
+          state.request_id,
+          (current) => current,
+          invalid,
+        ),
+      ).rejects.toThrow('positive integer');
+    }
+  });
+});

--- a/tests/coordinator.test.ts
+++ b/tests/coordinator.test.ts
@@ -15,8 +15,10 @@ import {
   failCoordination,
   finalizeCoordination,
   mapCoordinatorOutcome,
+  recordAcceptanceRejected,
   recordAcceptanceUnknown,
   recordAttemptFinished,
+  recordLaunchDispatched,
   recordSubmissionAccepted,
   recordTransientPollFailure,
   resumeCoordination,
@@ -73,6 +75,7 @@ interface PreparedOptions {
   inlineAttemptDeadlineMs?: number;
   backgroundAttemptDeadlineMs?: number;
   requestDeadlineMs?: number;
+  pollIntervalMs?: number;
   estimates?: Readonly<Record<string, string | undefined>>;
   budgets?: {
     max_estimated_cost_microusd?: string;
@@ -156,7 +159,7 @@ function preparedExecution(
         inline_attempt_deadline_ms: options.inlineAttemptDeadlineMs ?? 30_000,
         background_attempt_deadline_ms:
           options.backgroundAttemptDeadlineMs ?? 30_000,
-        poll_interval_ms: 1_000,
+        poll_interval_ms: options.pollIntervalMs ?? 1_000,
       },
       budgets: options.budgets,
       fallback,
@@ -175,7 +178,7 @@ function dependencies(start = Date.parse('2026-08-08T12:00:00Z')) {
   return {
     clock: { now: () => now },
     ids: {
-      next: (scope: 'attempt' | 'event') => {
+      next: (scope: 'attempt' | 'event' | 'delivery_lease') => {
         const count = (counts.get(scope) ?? 0) + 1;
         counts.set(scope, count);
         return `${scope}-${count}`;
@@ -228,8 +231,28 @@ function startAll(
   prepared: PreparedResearchExecution,
   deps: ReturnType<typeof dependencies>,
 ): CoordinatorState {
-  return startLaunchableAttempts(createCoordinatorState(prepared, deps), deps)
-    .state;
+  const started = startLaunchableAttempts(
+    createCoordinatorState(prepared, deps),
+    deps,
+  );
+  return dispatchLaunches(started.state, started.launches, deps);
+}
+
+function dispatchLaunches(
+  state: CoordinatorState,
+  launches: ReturnType<typeof startLaunchableAttempts>['launches'],
+  deps: ReturnType<typeof dependencies>,
+): CoordinatorState {
+  return launches.reduce(
+    (state, launch) =>
+      recordLaunchDispatched(
+        state,
+        launch.attempt_id,
+        launch.delivery_lease_id,
+        deps,
+      ),
+    state,
+  );
 }
 
 describe('deterministic coordinator rounds', () => {
@@ -260,16 +283,17 @@ describe('deterministic coordinator rounds', () => {
       ['slot-0', 'candidate-1'],
       ['slot-1', 'candidate-0'],
     ]);
-    expect(round.state.claimed_candidate_ids).toEqual([
-      'candidate-1',
-      'candidate-0',
-    ]);
+    expect(
+      round.state.reserve
+        .filter((candidate) => candidate.claimed_by_slot_id)
+        .map((candidate) => candidate.candidate_id),
+    ).toEqual(['candidate-0', 'candidate-1']);
 
     const replacement = startLaunchableAttempts(round.state, deps);
     expect(
       replacement.launches.map((launch) => launch.profile.identity.provider_id),
     ).toEqual(['reserve-shared', 'reserve-b-first']);
-    state = replacement.state;
+    state = dispatchLaunches(replacement.state, replacement.launches, deps);
     for (const attempt of state.attempts.filter(
       (candidate) => candidate.round === 1,
     )) {
@@ -314,6 +338,44 @@ describe('deterministic coordinator rounds', () => {
     expect(() => LifecycleTraceSchema.parse(state.lifecycle)).not.toThrow();
   });
 
+  it('accounts for earlier same-round fallback reservations when choosing later candidates', () => {
+    const deps = dependencies();
+    const prepared = preparedExecution({
+      primaries: [inlineProfile('primary-a'), inlineProfile('primary-b')],
+      reserve: [
+        { profile: inlineProfile('reserve-six-a'), eligibleSlots: [0] },
+        { profile: inlineProfile('reserve-six-b'), eligibleSlots: [1] },
+        { profile: inlineProfile('reserve-four-b'), eligibleSlots: [1] },
+      ],
+      estimates: {
+        'primary-a': '0',
+        'primary-b': '0',
+        'reserve-six-a': '6',
+        'reserve-six-b': '6',
+        'reserve-four-b': '4',
+      },
+      budgets: { max_estimated_cost_microusd: '10' },
+    });
+    let state = startAll(prepared, deps);
+    for (const attempt of [...state.attempts]) {
+      state = recordAttemptFinished(
+        state,
+        attempt.attempt_id,
+        { outcome: 'failed', error: providerFailure(true) },
+        deps,
+      );
+    }
+    const round = claimFallbackRound(state, deps);
+    expect(round.claims.map((claim) => claim.candidate_id)).toEqual([
+      'candidate-0',
+      'candidate-2',
+    ]);
+    const started = startLaunchableAttempts(round.state, deps);
+    expect(
+      started.launches.map((launch) => launch.profile.identity.provider_id),
+    ).toEqual(['reserve-six-a', 'reserve-four-b']);
+  });
+
   it('allows only the concurrent CAS winner to receive launches', async () => {
     const deps = dependencies();
     const prepared = preparedExecution({
@@ -345,8 +407,15 @@ describe('deterministic coordinator rounds', () => {
 
     const persisted = await store.load(state.request_id);
     expect(persisted?.version).toBe(2);
-    expect(persisted?.state.claimed_candidate_ids).toHaveLength(2);
-    expect(new Set(persisted?.state.claimed_candidate_ids).size).toBe(2);
+    const claimedCandidates =
+      persisted?.state.reserve.filter(
+        (candidate) => candidate.claimed_by_slot_id,
+      ) ?? [];
+    expect(claimedCandidates).toHaveLength(2);
+    expect(
+      new Set(claimedCandidates.map((candidate) => candidate.candidate_id))
+        .size,
+    ).toBe(2);
     const replacementAttempts =
       persisted?.state.attempts.filter((attempt) => attempt.round === 1) ?? [];
     expect(replacementAttempts).toHaveLength(2);
@@ -357,6 +426,94 @@ describe('deterministic coordinator rounds', () => {
         ),
       ).size,
     ).toBe(2);
+  });
+
+  it('replays an undispatched launch only after its delivery lease expires', async () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    const state = createCoordinatorState(
+      preparedExecution({ primaries: [inlineProfile('primary')] }),
+      deps,
+    );
+    const store = new InMemoryCoordinationStateStore();
+    await store.create(state);
+
+    const first = await resumeCoordination(store, state.request_id, deps);
+    expect(first.launches).toHaveLength(1);
+    expect(first.state.attempts[0]?.status).toBe('dispatch_pending');
+
+    deps.setNow(start + 500);
+    const leased = await resumeCoordination(store, state.request_id, deps);
+    expect(leased.launches).toEqual([]);
+
+    deps.setNow(start + 1_000);
+    const replayed = await resumeCoordination(store, state.request_id, deps);
+    expect(replayed.launches).toHaveLength(1);
+    expect(replayed.launches[0]?.attempt_id).toBe(
+      first.launches[0]?.attempt_id,
+    );
+    expect(replayed.launches[0]?.idempotency_key).toBe(
+      first.launches[0]?.attempt_id,
+    );
+    expect(replayed.launches[0]?.delivery_lease_id).not.toBe(
+      first.launches[0]?.delivery_lease_id,
+    );
+    expect({
+      profile: replayed.launches[0]?.profile,
+      binding: replayed.launches[0]?.binding,
+      query: replayed.launches[0]?.query,
+      idempotency_key: replayed.launches[0]?.idempotency_key,
+    }).toEqual({
+      profile: first.launches[0]?.profile,
+      binding: first.launches[0]?.binding,
+      query: first.launches[0]?.query,
+      idempotency_key: first.launches[0]?.idempotency_key,
+    });
+
+    const dispatched = recordLaunchDispatched(
+      replayed.state,
+      replayed.launches[0]?.attempt_id ?? '',
+      replayed.launches[0]?.delivery_lease_id ?? '',
+      deps,
+    );
+    expect(dispatched.attempts[0]?.status).toBe('running');
+    expect(dispatched.lifecycle.map((event) => event.event_kind)).toEqual([
+      'request_started',
+      'attempt_started',
+    ]);
+  });
+
+  it('never permits a delivery lease to outlive the pending attempt deadline', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    const started = startLaunchableAttempts(
+      createCoordinatorState(
+        preparedExecution({
+          primaries: [inlineProfile('inline')],
+          inlineAttemptDeadlineMs: 1_000,
+          backgroundAttemptDeadlineMs: 10_000,
+          requestDeadlineMs: 10_000,
+          pollIntervalMs: 5_000,
+        }),
+        deps,
+      ),
+      deps,
+    );
+    expect(started.state.attempts[0]?.delivery_lease_expires_at).toBe(
+      new Date(start + 1_000).toISOString(),
+    );
+    deps.setNow(start + 1_000);
+    expect(() =>
+      recordLaunchDispatched(
+        started.state,
+        started.launches[0]?.attempt_id ?? '',
+        started.launches[0]?.delivery_lease_id ?? '',
+        deps,
+      ),
+    ).toThrow('delivery lease has expired');
+    expect(started.state.lifecycle.map((event) => event.event_kind)).toEqual([
+      'request_started',
+    ]);
   });
 
   it('keeps refined queries private and inherits them across replacements', () => {
@@ -370,7 +527,7 @@ describe('deterministic coordinator rounds', () => {
     let advanced = startLaunchableAttempts(state, deps);
     expect(advanced.launches[0]?.query).toBe('refined private query');
     state = recordAttemptFinished(
-      advanced.state,
+      dispatchLaunches(advanced.state, advanced.launches, deps),
       advanced.launches[0]?.attempt_id ?? '',
       { outcome: 'failed', error: providerFailure(true) },
       deps,
@@ -427,11 +584,133 @@ describe('acceptance, deadlines, cancellation, and budgets', () => {
       }),
     ]);
     expect(state.slots[1]?.status).toBe('unstarted');
-    expect(state.claimed_candidate_ids).toEqual([]);
+    expect(
+      state.reserve.every((candidate) => !candidate.claimed_by_slot_id),
+    ).toBe(true);
     expect(claimFallbackRound(state, deps).claims).toEqual([]);
     expect(state.used_profile_keys).toContain(
       profileIdentityKey(durableProfile('durable').identity),
     );
+  });
+
+  it('applies attempt deadlines before late completion or acceptance callbacks', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const inlineDeps = dependencies(start);
+    let inline = startAll(
+      preparedExecution({
+        primaries: [inlineProfile('inline')],
+        inlineAttemptDeadlineMs: 10_000,
+      }),
+      inlineDeps,
+    );
+    inlineDeps.setNow(start + 10_000);
+    inline = recordAttemptFinished(
+      inline,
+      inline.attempts[0]?.attempt_id ?? '',
+      { outcome: 'succeeded', result_id: 'late-result' },
+      inlineDeps,
+    );
+    expect(inline.attempts[0]?.status).toBe('timed_out');
+    expect(inline.slots[0]?.result_id).toBeUndefined();
+
+    const durableDeps = dependencies(start);
+    let durable = startAll(
+      preparedExecution({
+        primaries: [durableProfile('durable')],
+        backgroundAttemptDeadlineMs: 10_000,
+      }),
+      durableDeps,
+    );
+    durableDeps.setNow(start + 10_000);
+    durable = recordSubmissionAccepted(
+      durable,
+      durable.attempts[0]?.attempt_id ?? '',
+      handle(durableProfile('durable'), 'pending'),
+      durableDeps,
+    );
+    expect(durable.attempts[0]?.status).toBe('acceptance_unknown');
+    expect(durable.attempts[0]?.durable_handle).toBeUndefined();
+  });
+
+  it('retains a timely target callback while advancing an overdue sibling', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    const durable = durableProfile('durable');
+    let state = startAll(
+      preparedExecution({
+        primaries: [inlineProfile('inline'), durable],
+        inlineAttemptDeadlineMs: 10_000,
+        backgroundAttemptDeadlineMs: 20_000,
+      }),
+      deps,
+    );
+    const durableAttempt = state.attempts.find(
+      (attempt) => attempt.profile.identity.provider_id === 'durable',
+    );
+    deps.setNow(start + 10_000);
+    state = recordSubmissionAccepted(
+      state,
+      durableAttempt?.attempt_id ?? '',
+      handle(durable, 'pending'),
+      deps,
+    );
+    expect(state.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          profile: expect.objectContaining({
+            identity: expect.objectContaining({ provider_id: 'inline' }),
+          }),
+          status: 'timed_out',
+        }),
+        expect.objectContaining({
+          profile: expect.objectContaining({
+            identity: expect.objectContaining({ provider_id: 'durable' }),
+          }),
+          status: 'submitted',
+        }),
+      ]),
+    );
+  });
+
+  it('terminalizes fallback-pending slots at the request deadline without overwriting settled failures', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    let state = startAll(
+      preparedExecution({
+        primaries: [inlineProfile('failed'), inlineProfile('active')],
+        reserve: [{ profile: inlineProfile('reserve'), eligibleSlots: [1] }],
+        requestDeadlineMs: 10_000,
+      }),
+      deps,
+    );
+    const failure = providerFailure(false, 'settled_failure');
+    state = recordAttemptFinished(
+      state,
+      state.attempts[0]?.attempt_id ?? '',
+      { outcome: 'failed', error: failure },
+      deps,
+    );
+    state = recordAttemptFinished(
+      state,
+      state.attempts[1]?.attempt_id ?? '',
+      { outcome: 'failed', error: providerFailure(true) },
+      deps,
+    );
+    state = claimFallbackRound(state, deps).state;
+    expect(state.slots[1]?.status).toBe('fallback_pending');
+
+    deps.setNow(start + 10_000);
+    state = advanceCoordination(state, deps).state;
+    expect(state.status).toBe('unsuccessful');
+    expect(state.slots[0]).toMatchObject({
+      status: 'failed',
+      error: { code: 'settled_failure' },
+    });
+    expect(state.slots[1]).toMatchObject({
+      status: 'failed',
+      error: { code: 'provider_failed' },
+    });
+    expect(mapCoordinatorOutcome(state)).toBe('unsuccessful');
   });
 
   it('times out inline work and launches an eligible fallback without acceptance uncertainty', () => {
@@ -460,6 +739,30 @@ describe('acceptance, deadlines, cancellation, and budgets', () => {
     expect(advanced.launches).toHaveLength(1);
     expect(advanced.launches[0]?.profile.identity.provider_id).toBe(
       'inline-reserve',
+    );
+  });
+
+  it('clamps a late fallback launch to the remaining request deadline', () => {
+    const start = Date.parse('2026-08-08T12:00:00Z');
+    const deps = dependencies(start);
+    let state = startAll(
+      preparedExecution({
+        primaries: [inlineProfile('primary')],
+        reserve: [{ profile: inlineProfile('reserve'), eligibleSlots: [0] }],
+        inlineAttemptDeadlineMs: 10_000,
+        requestDeadlineMs: 15_000,
+      }),
+      deps,
+    );
+    deps.setNow(start + 10_000);
+    const advanced = advanceCoordination(state, deps);
+    expect(advanced.launches).toHaveLength(1);
+    expect(advanced.launches[0]?.deadline_at).toBe(
+      new Date(start + 15_000).toISOString(),
+    );
+    state = dispatchLaunches(advanced.state, advanced.launches, deps);
+    expect(state.attempts.at(-1)?.deadline_at).toBe(
+      new Date(start + 15_000).toISOString(),
     );
   });
 
@@ -515,7 +818,9 @@ describe('acceptance, deadlines, cancellation, and budgets', () => {
       status: 'cancelled',
       adapter_state_ref: 'adapter-state-ref-1',
     });
-    expect(cancelled.claimed_candidate_ids).toEqual([]);
+    expect(
+      cancelled.reserve.every((candidate) => !candidate.claimed_by_slot_id),
+    ).toBe(true);
   });
 
   it('keeps transient poll failures private and nonterminal', () => {
@@ -540,6 +845,7 @@ describe('acceptance, deadlines, cancellation, and budgets', () => {
       state,
       state.attempts[0]?.attempt_id ?? '',
       pollError,
+      deps,
     );
 
     expect(state.attempts[0]).toMatchObject({
@@ -574,6 +880,45 @@ describe('acceptance, deadlines, cancellation, and budgets', () => {
       },
     });
     expect(started.state.budget.reserved_estimated_cost_microusd).toBe('0');
+  });
+
+  it('treats the actual-cost ceiling as a projected hard launch budget', () => {
+    const deps = dependencies();
+    const started = startLaunchableAttempts(
+      createCoordinatorState(
+        preparedExecution({
+          primaries: [inlineProfile('free'), inlineProfile('paid')],
+          estimates: { free: '0', paid: '1' },
+          budgets: { max_actual_cost_microusd: '0' },
+        }),
+        deps,
+      ),
+      deps,
+    );
+    expect(
+      started.launches.map((launch) => launch.profile.identity.provider_id),
+    ).toEqual(['free']);
+    expect(started.state.slots[1]?.error?.code).toBe(
+      'budget_reservation_exceeded',
+    );
+
+    const concurrent = startLaunchableAttempts(
+      createCoordinatorState(
+        preparedExecution({
+          primaries: [inlineProfile('first'), inlineProfile('second')],
+          estimates: { first: '6', second: '6' },
+          budgets: { max_actual_cost_microusd: '10' },
+        }),
+        deps,
+      ),
+      deps,
+    );
+    expect(
+      concurrent.launches.map((launch) => launch.profile.identity.provider_id),
+    ).toEqual(['first']);
+    expect(concurrent.state.slots[1]?.error?.code).toBe(
+      'budget_reservation_exceeded',
+    );
   });
 });
 
@@ -794,14 +1139,66 @@ describe('durable handles and terminal mapping', () => {
       deps,
     );
     expect(() =>
-      recordTransientPollFailure(state, state.attempts[0]?.attempt_id ?? '', {
-        code: 'poll_permanently_broken',
-        message: 'The provider status endpoint rejected the handle.',
-        category: 'provider',
-        retryable: false,
-        fallback_allowed: false,
-      }),
+      recordTransientPollFailure(
+        state,
+        state.attempts[0]?.attempt_id ?? '',
+        {
+          code: 'poll_permanently_broken',
+          message: 'The provider status endpoint rejected the handle.',
+          category: 'provider',
+          retryable: false,
+          fallback_allowed: false,
+        },
+        deps,
+      ),
     ).toThrow('retryable');
+  });
+
+  it('validates adapter payloads before persistence and resolves definitive rejection', () => {
+    const deps = dependencies();
+    const profile = durableProfile('durable');
+    let state = startAll(
+      preparedExecution({
+        primaries: [profile],
+        reserve: [{ profile: durableProfile('reserve'), eligibleSlots: [0] }],
+      }),
+      deps,
+    );
+    const attemptId = state.attempts[0]?.attempt_id ?? '';
+    expect(() =>
+      recordSubmissionAccepted(
+        state,
+        attemptId,
+        { ...handle(profile, 'pending'), apiKey: 'must-not-persist' },
+        deps,
+      ),
+    ).toThrow();
+    expect(() =>
+      recordAttemptFinished(
+        state,
+        attemptId,
+        {
+          outcome: 'failed',
+          error: providerFailure(true),
+          actual_cost_microusd: '9'.repeat(65),
+        },
+        deps,
+      ),
+    ).toThrow();
+
+    state = recordAcceptanceUnknown(state, attemptId, deps, 'state-ref');
+    state = recordAcceptanceRejected(
+      state,
+      attemptId,
+      providerFailure(true, 'definitively_rejected'),
+      deps,
+    );
+    expect(state.unresolved_acceptances).toEqual([]);
+    expect(state.attempts[0]).toMatchObject({
+      status: 'failed',
+      error: { code: 'definitively_rejected' },
+    });
+    expect(advanceCoordination(state, deps).launches).toHaveLength(1);
   });
 
   it('applies the canonical 100k character bound to refined slot queries', () => {

--- a/tests/execution-plan.test.ts
+++ b/tests/execution-plan.test.ts
@@ -77,19 +77,18 @@ function planningProfile(
 }
 
 class FixtureCatalog implements FrozenPlanningCatalog {
-  readonly revision = 'fixture-r1';
-  readonly digest = 'fixture-digest';
   readonly profiles: readonly PlanningProfile[];
   readonly groupCalls = vi.fn();
   readonly defaultCalls = vi.fn();
   readonly reserveCalls = vi.fn();
-  readonly executor = vi.fn();
 
   constructor(
     profiles: readonly PlanningProfile[],
     readonly groups: Readonly<Record<string, readonly ProviderIdentity[]>> = {},
     readonly defaults: readonly ProviderIdentity[] = [],
     readonly configuredReserve: readonly ProviderIdentity[] = [],
+    readonly revision = 'fixture-r1',
+    readonly digest = 'fixture-digest',
   ) {
     this.profiles = Object.freeze([...profiles]);
   }
@@ -407,6 +406,71 @@ describe('research execution preparation', () => {
     ]);
   });
 
+  it('rejects unbounded catalog identity metadata without reflecting it', () => {
+    const result = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog(
+        [planningProfile(groundedProfile('alpha'))],
+        {},
+        [],
+        [],
+        ' padded ',
+        'x'.repeat(256),
+      ),
+      dependencies(),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues.map(({ code, path }) => [code, path])).toEqual([
+      ['invalid_catalog_digest', '/catalog/digest'],
+      ['invalid_catalog_revision', '/catalog/revision'],
+    ]);
+    expect(JSON.stringify(result.issues)).not.toContain('x'.repeat(256));
+  });
+
+  it('rejects over-budget or unestimated primary plans before execution', () => {
+    const alpha = planningProfile(groundedProfile('alpha'), {
+      estimate: { estimated_cost_microusd: '10' },
+    });
+    const beta = planningProfile(groundedProfile('beta'), {
+      estimate: { estimated_cost_microusd: '10' },
+    });
+    const selector = {
+      kind: 'targets' as const,
+      targets: [alpha.profile.identity, beta.profile.identity],
+    };
+    const exceeded = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        selector,
+        budgets: { max_actual_cost_microusd: '15' },
+      },
+      new FixtureCatalog([alpha, beta]),
+      dependencies(),
+    );
+    expect(exceeded.ok).toBe(false);
+    if (exceeded.ok) return;
+    expect(exceeded.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'primary_plan_budget_exceeded',
+        path: '/budgets/max_actual_cost_microusd',
+      }),
+    );
+
+    const unestimated = prepareResearchExecution(
+      { ...targetRequest(), budgets: { max_estimated_cost_microusd: '10' } },
+      new FixtureCatalog([
+        planningProfile(groundedProfile('alpha'), { estimate: undefined }),
+      ]),
+      dependencies(),
+    );
+    expect(unestimated.ok).toBe(false);
+    if (unestimated.ok) return;
+    expect(unestimated.issues).toContainEqual(
+      expect.objectContaining({ code: 'budget_estimate_required' }),
+    );
+  });
+
   it('bounds billable unit arrays and addresses duplicate catalog profiles by index', () => {
     const alpha = planningProfile(groundedProfile('alpha'));
     const duplicated = prepareResearchExecution(
@@ -538,7 +602,7 @@ describe('research execution preparation', () => {
     );
   });
 
-  it('rejects every explicit non-durable async profile before executor calls', () => {
+  it('rejects every explicit non-durable async profile during preparation', () => {
     const catalog = new FixtureCatalog([
       planningProfile(groundedProfile('alpha')),
       planningProfile(groundedProfile('beta', 'process_local')),
@@ -571,7 +635,6 @@ describe('research execution preparation', () => {
         path: '/selector/targets/1',
       }),
     ]);
-    expect(catalog.executor).not.toHaveBeenCalled();
   });
 
   it('enforces profile uniqueness across primaries and the global reserve', () => {

--- a/tests/execution-plan.test.ts
+++ b/tests/execution-plan.test.ts
@@ -1,0 +1,657 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ExecutionProfile,
+  ProviderIdentity,
+} from '../src/contracts/domain/index.js';
+import {
+  type FrozenPlanningCatalog,
+  type PlanningProfile,
+  prepareResearchExecution,
+} from '../src/core/execution-plan.js';
+import {
+  CanonicalResearchRequestSchema,
+  migrateLegacyResearchRequest,
+} from '../src/core/research-request.js';
+
+function groundedProfile(
+  providerId: string,
+  resumability: 'none' | 'process_local' | 'durable' = 'none',
+): ExecutionProfile {
+  return {
+    identity: {
+      provider_id: providerId,
+      profile_id: 'grounded-web',
+    },
+    result_kind: 'grounded_answer',
+    grounding_policy: 'required',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'model_search_tool',
+    access_mode: 'direct',
+    operator_id: providerId,
+    invocation: resumability === 'none' ? 'inline' : 'background',
+    resumability,
+  };
+}
+
+function surfaceProfile(
+  providerId: string,
+  observationMode: 'api_output' | 'surface_snapshot',
+): ExecutionProfile {
+  const snapshot = observationMode === 'surface_snapshot';
+  return {
+    identity: {
+      provider_id: providerId,
+      profile_id: 'google-ai-mode',
+    },
+    result_kind: 'surface_observation',
+    grounding_policy: 'optional',
+    observation_mode: observationMode,
+    corpora: ['web'],
+    retrieval_method: snapshot ? 'surface_collector' : 'model_only',
+    access_mode: snapshot ? 'collected' : 'direct',
+    operator_id: 'google',
+    collector_id: snapshot ? providerId : undefined,
+    surface_id: 'google_ai_mode',
+    invocation: 'inline',
+    resumability: 'none',
+  };
+}
+
+function planningProfile(
+  profile: ExecutionProfile,
+  overrides: Partial<PlanningProfile> = {},
+): PlanningProfile {
+  return {
+    profile,
+    binding: {
+      adapter_id: `adapter-${profile.identity.provider_id}`,
+      binding_id: `binding-${profile.identity.profile_id}`,
+    },
+    estimate: { estimated_cost_microusd: '10' },
+    enabled: true,
+    credentialed: true,
+    configuration_valid: true,
+    ...overrides,
+  };
+}
+
+class FixtureCatalog implements FrozenPlanningCatalog {
+  readonly revision = 'fixture-r1';
+  readonly digest = 'fixture-digest';
+  readonly profiles: readonly PlanningProfile[];
+  readonly groupCalls = vi.fn();
+  readonly defaultCalls = vi.fn();
+  readonly reserveCalls = vi.fn();
+  readonly executor = vi.fn();
+
+  constructor(
+    profiles: readonly PlanningProfile[],
+    readonly groups: Readonly<Record<string, readonly ProviderIdentity[]>> = {},
+    readonly defaults: readonly ProviderIdentity[] = [],
+    readonly configuredReserve: readonly ProviderIdentity[] = [],
+  ) {
+    this.profiles = Object.freeze([...profiles]);
+  }
+
+  resolveGroup(groupId: string): readonly ProviderIdentity[] | undefined {
+    this.groupCalls(groupId);
+    return this.groups[groupId];
+  }
+
+  resolveDefault(): readonly ProviderIdentity[] {
+    this.defaultCalls();
+    return this.defaults;
+  }
+
+  resolveConfiguredReserve(
+    primaries: readonly ProviderIdentity[],
+  ): readonly ProviderIdentity[] {
+    this.reserveCalls(primaries);
+    return this.configuredReserve;
+  }
+}
+
+function dependencies() {
+  const counts = new Map<string, number>();
+  return {
+    clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
+    ids: {
+      next: (scope: 'request' | 'slot' | 'fallback_candidate') => {
+        const count = (counts.get(scope) ?? 0) + 1;
+        counts.set(scope, count);
+        return `${scope}-${count}`;
+      },
+    },
+  };
+}
+
+function targetRequest(providerId = 'alpha') {
+  return {
+    query: '  canonical query  ',
+    mode: 'sync',
+    selector: {
+      kind: 'targets',
+      targets: [{ provider_id: providerId, profile_id: 'grounded-web' }],
+    },
+    fallback: { kind: 'disabled' },
+    limits: {
+      max_concurrency: 2,
+      request_deadline_ms: 60_000,
+      inline_attempt_deadline_ms: 30_000,
+      background_attempt_deadline_ms: 60_000,
+      poll_interval_ms: 1_000,
+    },
+  } as const;
+}
+
+describe('canonical research request', () => {
+  it('enforces one strict selector, bounded result counts, and strict limits', () => {
+    const parsed = CanonicalResearchRequestSchema.parse(targetRequest());
+    expect(parsed.query).toBe('canonical query');
+    expect(parsed.refinement).toEqual({ kind: 'disabled' });
+
+    expect(
+      CanonicalResearchRequestSchema.safeParse({
+        ...targetRequest(),
+        selector: {
+          kind: 'targets',
+          targets: [{ provider_id: 'alpha' }],
+          group_id: 'quick',
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      CanonicalResearchRequestSchema.safeParse({
+        ...targetRequest(),
+        selector: {
+          kind: 'capabilities',
+          requirements: {
+            result_kind: 'grounded_answer',
+            grounding_policy: 'required',
+            corpora: ['web'],
+          },
+          result_count: 0,
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      CanonicalResearchRequestSchema.safeParse({
+        ...targetRequest(),
+        limits: { ...targetRequest().limits, max_concurrency: 65 },
+      }).success,
+    ).toBe(false);
+    expect(
+      CanonicalResearchRequestSchema.safeParse({
+        ...targetRequest(),
+        limits: {
+          ...targetRequest().limits,
+          inline_attempt_deadline_ms: 61_000,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('accepts an intentional zero micro-USD ceiling and rejects inexact values', () => {
+    expect(
+      CanonicalResearchRequestSchema.safeParse({
+        ...targetRequest(),
+        budgets: { max_estimated_cost_microusd: '0' },
+      }).success,
+    ).toBe(true);
+    expect(
+      CanonicalResearchRequestSchema.safeParse({
+        ...targetRequest(),
+        budgets: { max_estimated_cost_microusd: '0.1' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('keeps mixed outside canonical schemas and migrates it with a stable notice', () => {
+    const legacy = { ...targetRequest(), mode: 'mixed' };
+    expect(CanonicalResearchRequestSchema.safeParse(legacy).success).toBe(
+      false,
+    );
+    expect(migrateLegacyResearchRequest(legacy)).toEqual({
+      input: { ...legacy, mode: 'async' },
+      notices: [
+        {
+          code: 'legacy_mixed_mode_migrated',
+          phase: 'migration',
+          path: '/mode',
+          message:
+            'Legacy mixed mode is deprecated and was migrated to async mode.',
+        },
+      ],
+    });
+  });
+});
+
+describe('research execution preparation', () => {
+  it('aggregates canonical issues and suppresses selection cascades', () => {
+    const catalog = new FixtureCatalog([]);
+    const result = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        query: '   ',
+        selector: { kind: 'group', group_id: 'quick' },
+        limits: {
+          ...targetRequest().limits,
+          max_concurrency: 0,
+          poll_interval_ms: 999_999,
+        },
+      },
+      catalog,
+      dependencies(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(
+      result.issues.map(({ code, path, phase }) => [code, path, phase]),
+    ).toEqual([
+      [
+        'concurrency_out_of_bounds',
+        '/limits/max_concurrency',
+        'canonicalization',
+      ],
+      [
+        'poll_interval_exceeds_background_attempt_deadline',
+        '/limits/poll_interval_ms',
+        'canonicalization',
+      ],
+      [
+        'poll_interval_out_of_bounds',
+        '/limits/poll_interval_ms',
+        'canonicalization',
+      ],
+      ['invalid_query', '/query', 'canonicalization'],
+    ]);
+    expect(catalog.groupCalls).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate explicit targets, reserve targets, and exclusions at the second path', () => {
+    const duplicate = { provider_id: 'alpha', profile_id: 'grounded-web' };
+    const result = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        selector: { kind: 'targets', targets: [duplicate, duplicate] },
+        fallback: { kind: 'explicit', reserve: [duplicate, duplicate] },
+        exclusions: [duplicate, duplicate],
+      },
+      new FixtureCatalog([planningProfile(groundedProfile('alpha'))]),
+      dependencies(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues.map(({ code, path }) => [code, path])).toEqual([
+      ['duplicate_exclusion', '/exclusions/1'],
+      ['duplicate_explicit_reserve_target', '/fallback/reserve/1'],
+      ['duplicate_explicit_target', '/selector/targets/1'],
+    ]);
+  });
+
+  it('accepts custom group syntax structurally and reports unknown groups during selection', () => {
+    for (const groupId of ['custom:visibility', 'quick']) {
+      const input = {
+        ...targetRequest(),
+        selector: { kind: 'group', group_id: groupId },
+      };
+      expect(CanonicalResearchRequestSchema.safeParse(input).success).toBe(
+        true,
+      );
+      const result = prepareResearchExecution(
+        input,
+        new FixtureCatalog([]),
+        dependencies(),
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) continue;
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'group_not_found',
+          path: '/selector/group_id',
+        }),
+      );
+    }
+  });
+
+  it('reports unknown explicit providers as compiler selection errors', () => {
+    const input = targetRequest('unknown-builtin');
+    expect(CanonicalResearchRequestSchema.safeParse(input).success).toBe(true);
+    const result = prepareResearchExecution(
+      input,
+      new FixtureCatalog([]),
+      dependencies(),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'profile_not_found',
+        phase: 'selection',
+        path: '/selector/targets/0',
+      }),
+    );
+  });
+
+  it('rejects structurally invalid catalog profiles even when they are unused', () => {
+    const valid = planningProfile(groundedProfile('alpha'));
+    const invalid = planningProfile({
+      ...groundedProfile('unused'),
+      result_kind: 'not-a-result-kind',
+    } as unknown as ExecutionProfile);
+    const result = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog([valid, invalid]),
+      dependencies(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'invalid_catalog_execution_profile',
+        phase: 'validation',
+        path: '/catalog/profiles/1/profile/result_kind',
+      }),
+    );
+  });
+
+  it('hardens catalog metadata with stable index-addressed diagnostics', () => {
+    const result = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog([
+        planningProfile(groundedProfile('alpha'), {
+          binding: { adapter_id: ' padded ', binding_id: 'x'.repeat(256) },
+          estimate: {
+            estimated_cost_microusd: '1'.repeat(65),
+            billable_units: [{ unit: 'Not Snake', quantity: '01.2' }],
+          },
+        }),
+        planningProfile(groundedProfile('beta'), {
+          binding: { adapter_id: 'adapter\u0007beta', binding_id: 'ok' },
+        }),
+      ]),
+      dependencies(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues.map(({ code, path }) => [code, path])).toEqual([
+      [
+        'invalid_adapter_binding_identity',
+        '/catalog/profiles/0/binding/adapter_id',
+      ],
+      [
+        'invalid_adapter_binding_identity',
+        '/catalog/profiles/0/binding/binding_id',
+      ],
+      [
+        'invalid_billable_unit_estimate',
+        '/catalog/profiles/0/estimate/billable_units/0/quantity',
+      ],
+      [
+        'invalid_billable_unit_estimate',
+        '/catalog/profiles/0/estimate/billable_units/0/unit',
+      ],
+      [
+        'invalid_network_free_estimate',
+        '/catalog/profiles/0/estimate/estimated_cost_microusd',
+      ],
+      [
+        'invalid_adapter_binding_identity',
+        '/catalog/profiles/1/binding/adapter_id',
+      ],
+    ]);
+  });
+
+  it('bounds billable unit arrays and addresses duplicate catalog profiles by index', () => {
+    const alpha = planningProfile(groundedProfile('alpha'));
+    const duplicated = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog([alpha, alpha]),
+      dependencies(),
+    );
+    expect(duplicated.ok).toBe(false);
+    if (duplicated.ok) return;
+    expect(duplicated.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'catalog_profile_duplicate',
+        path: '/catalog/profiles/1/profile/identity',
+      }),
+    );
+
+    const oversized = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog([
+        planningProfile(groundedProfile('alpha'), {
+          estimate: {
+            estimated_cost_microusd: '10',
+            billable_units: Array.from({ length: 33 }, () => ({
+              unit: 'search_queries',
+              quantity: '1',
+            })),
+          },
+        }),
+      ]),
+      dependencies(),
+    );
+    expect(oversized.ok).toBe(false);
+    if (oversized.ok) return;
+    expect(oversized.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid_billable_unit_estimate',
+        path: '/catalog/profiles/0/estimate/billable_units',
+      }),
+    ]);
+
+    const bounded = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog([
+        planningProfile(groundedProfile('alpha'), {
+          estimate: {
+            estimated_cost_microusd: '9'.repeat(64),
+            billable_units: [{ unit: 'search_queries', quantity: '2.5' }],
+          },
+        }),
+      ]),
+      dependencies(),
+    );
+    expect(bounded.ok).toBe(true);
+  });
+
+  it('compiles equivalent target and group inputs to identical plans with injected clock and ids', () => {
+    const alpha = planningProfile(groundedProfile('alpha'));
+    const catalog = new FixtureCatalog(
+      [alpha],
+      { quick: [alpha.profile.identity] },
+      [alpha.profile.identity],
+    );
+    const target = prepareResearchExecution(
+      targetRequest(),
+      catalog,
+      dependencies(),
+    );
+    const group = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        selector: { kind: 'group', group_id: 'quick' },
+        refinement: { kind: 'disabled' },
+      },
+      catalog,
+      dependencies(),
+    );
+
+    expect(target.ok).toBe(true);
+    expect(group.ok).toBe(true);
+    if (!target.ok || !group.ok) return;
+    expect(group.prepared).toEqual(target.prepared);
+    expect(target.prepared.request.query).toBe('canonical query');
+  });
+
+  it('selects a bounded exact capability result count in frozen catalog order', () => {
+    const profiles = [
+      planningProfile(groundedProfile('alpha')),
+      planningProfile(groundedProfile('beta')),
+    ];
+    const request = {
+      ...targetRequest(),
+      selector: {
+        kind: 'capabilities',
+        requirements: {
+          result_kind: 'grounded_answer',
+          grounding_policy: 'required',
+          corpora: ['web'],
+        },
+        result_count: 1,
+      },
+    } as const;
+    const selected = prepareResearchExecution(
+      request,
+      new FixtureCatalog(profiles),
+      dependencies(),
+    );
+    expect(selected.ok).toBe(true);
+    if (!selected.ok) return;
+    expect(selected.prepared.request.slots).toHaveLength(1);
+    expect(
+      selected.prepared.request.slots[0]?.primary.identity.provider_id,
+    ).toBe('alpha');
+
+    const unavailable = prepareResearchExecution(
+      {
+        ...request,
+        selector: { ...request.selector, result_count: 3 },
+      },
+      new FixtureCatalog(profiles),
+      dependencies(),
+    );
+    expect(unavailable.ok).toBe(false);
+    if (unavailable.ok) return;
+    expect(unavailable.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'capability_result_count_unavailable',
+        path: '/selector/result_count',
+      }),
+    );
+  });
+
+  it('rejects every explicit non-durable async profile before executor calls', () => {
+    const catalog = new FixtureCatalog([
+      planningProfile(groundedProfile('alpha')),
+      planningProfile(groundedProfile('beta', 'process_local')),
+    ]);
+    const result = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        mode: 'async',
+        selector: {
+          kind: 'targets',
+          targets: [
+            { provider_id: 'alpha', profile_id: 'grounded-web' },
+            { provider_id: 'beta', profile_id: 'grounded-web' },
+          ],
+        },
+      },
+      catalog,
+      dependencies(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'async_requires_durable_profile',
+        path: '/selector/targets/0',
+      }),
+      expect.objectContaining({
+        code: 'async_requires_durable_profile',
+        path: '/selector/targets/1',
+      }),
+    ]);
+    expect(catalog.executor).not.toHaveBeenCalled();
+  });
+
+  it('enforces profile uniqueness across primaries and the global reserve', () => {
+    const alpha = planningProfile(groundedProfile('alpha'));
+    const result = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        fallback: {
+          kind: 'explicit',
+          reserve: [{ provider_id: 'alpha', profile_id: 'grounded-web' }],
+        },
+      },
+      new FixtureCatalog([alpha]),
+      dependencies(),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'profile_reused_in_fallback',
+        path: '/fallback/reserve/0',
+      }),
+    );
+  });
+
+  it('rejects fallback lane/surface mismatches and compiles compatible eligibility', () => {
+    const primary = planningProfile(
+      surfaceProfile('collector-a', 'surface_snapshot'),
+    );
+    const incompatible = planningProfile(
+      surfaceProfile('api-proxy', 'api_output'),
+    );
+    const compatible = planningProfile(
+      surfaceProfile('collector-b', 'surface_snapshot'),
+    );
+    const input = {
+      ...targetRequest(),
+      selector: {
+        kind: 'targets',
+        targets: [{ provider_id: 'collector-a', profile_id: 'google-ai-mode' }],
+      },
+    } as const;
+
+    const rejected = prepareResearchExecution(
+      {
+        ...input,
+        fallback: {
+          kind: 'explicit',
+          reserve: [{ provider_id: 'api-proxy', profile_id: 'google-ai-mode' }],
+        },
+      },
+      new FixtureCatalog([primary, incompatible]),
+      dependencies(),
+    );
+    expect(rejected.ok).toBe(false);
+    if (rejected.ok) return;
+    expect(rejected.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'fallback_profile_incompatible',
+        path: '/fallback/reserve/0',
+      }),
+    );
+
+    const accepted = prepareResearchExecution(
+      {
+        ...input,
+        fallback: {
+          kind: 'explicit',
+          reserve: [
+            { provider_id: 'collector-b', profile_id: 'google-ai-mode' },
+          ],
+        },
+      },
+      new FixtureCatalog([primary, compatible]),
+      dependencies(),
+    );
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) return;
+    expect(
+      accepted.prepared.request.fallback_reserve[0]?.eligible_slot_ids,
+    ).toEqual([accepted.prepared.request.slots[0]?.slot_id]);
+  });
+});

--- a/tests/transport-normalization.test.ts
+++ b/tests/transport-normalization.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ExecutionProfile,
+  ProviderIdentity,
+} from '../src/contracts/domain/index.js';
+import {
+  type FrozenPlanningCatalog,
+  type PlanningProfile,
+  prepareResearchExecution,
+} from '../src/core/execution-plan.js';
+import {
+  type CanonicalTransportDefaults,
+  compileNormalizedTransportRequest,
+  normalizeCliRequest,
+  normalizeConfigurationRequest,
+  normalizeLibraryRequest,
+  normalizeMcpRequest,
+  normalizeSilentMcpRequest,
+} from '../src/core/transport-normalization.js';
+
+/**
+ * Test-owned fixture context. The transport module deliberately ships no
+ * built-in default policy values; canonical defaults remain an open
+ * maintainer decision, so these values are arbitrary fixture data only.
+ */
+const FIXTURE_DEFAULTS: CanonicalTransportDefaults = Object.freeze({
+  mode: 'sync',
+  limits: Object.freeze({
+    max_concurrency: 4,
+    request_deadline_ms: 300_000,
+    inline_attempt_deadline_ms: 30_000,
+    background_attempt_deadline_ms: 180_000,
+    poll_interval_ms: 5_000,
+  }),
+  fallback: Object.freeze({ kind: 'configured' as const }),
+  refinement: Object.freeze({ kind: 'disabled' as const }),
+});
+
+function groundedProfile(
+  providerId: string,
+  resumability: 'none' | 'durable' = 'none',
+): ExecutionProfile {
+  return {
+    identity: { provider_id: providerId, profile_id: 'grounded-web' },
+    result_kind: 'grounded_answer',
+    grounding_policy: 'required',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'model_search_tool',
+    access_mode: 'direct',
+    operator_id: providerId,
+    invocation: resumability === 'none' ? 'inline' : 'background',
+    resumability,
+  };
+}
+
+function planningProfile(profile: ExecutionProfile): PlanningProfile {
+  return {
+    profile,
+    binding: {
+      adapter_id: `adapter-${profile.identity.provider_id}`,
+      binding_id: `binding-${profile.identity.profile_id}`,
+    },
+    estimate: { estimated_cost_microusd: '10' },
+    enabled: true,
+    credentialed: true,
+    configuration_valid: true,
+  };
+}
+
+function catalogFor(
+  profiles: readonly PlanningProfile[],
+  groups: Readonly<Record<string, readonly ProviderIdentity[]>> = {},
+): FrozenPlanningCatalog {
+  return {
+    revision: 'transport-r1',
+    digest: 'transport-digest',
+    profiles,
+    resolveGroup: (groupId) => groups[groupId],
+    resolveDefault: () => profiles.map((entry) => entry.profile.identity),
+    resolveConfiguredReserve: () => [],
+  };
+}
+
+function dependencies() {
+  const counts = new Map<string, number>();
+  return {
+    clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
+    ids: {
+      next: (scope: 'request' | 'slot' | 'fallback_candidate') => {
+        const count = (counts.get(scope) ?? 0) + 1;
+        counts.set(scope, count);
+        return `${scope}-${count}`;
+      },
+    },
+  };
+}
+
+describe('shadow transport golden equality', () => {
+  it('compiles semantically equivalent inputs from all five transports to byte-identical prepared executions', () => {
+    const catalog = catalogFor([planningProfile(groundedProfile('alpha'))]);
+    const query = '  transport parity query  ';
+    const normalized = [
+      normalizeLibraryRequest(
+        {
+          query,
+          mode: 'sync',
+          targets: [{ provider_id: 'alpha' }],
+          limits: {
+            max_concurrency: 4,
+            inline_attempt_deadline_ms: 30_000,
+          },
+        },
+        FIXTURE_DEFAULTS,
+      ),
+      normalizeCliRequest(
+        {
+          query,
+          providers: ['alpha'],
+          mode: 'sync',
+          parallel: 4,
+          timeoutSeconds: 30,
+        },
+        FIXTURE_DEFAULTS,
+      ),
+      normalizeMcpRequest(
+        { query, providers: [' alpha '], mode: 'sync' },
+        FIXTURE_DEFAULTS,
+      ),
+      normalizeSilentMcpRequest(
+        { query, providers: ['alpha'] },
+        FIXTURE_DEFAULTS,
+      ),
+      normalizeConfigurationRequest(
+        {
+          query,
+          providers: ['alpha'],
+          defaults: { mode: 'sync', maxParallel: 4, timeoutSeconds: 30 },
+        },
+        FIXTURE_DEFAULTS,
+      ),
+    ];
+
+    const serialized = normalized.map((result) => {
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error('normalization unexpectedly failed');
+      expect(result.notices).toEqual([]);
+      const compiled = prepareResearchExecution(
+        result.request,
+        catalog,
+        dependencies(),
+      );
+      expect(compiled.ok).toBe(true);
+      if (!compiled.ok) throw new Error('compilation unexpectedly failed');
+      expect(compiled.prepared.request.query).toBe('transport parity query');
+      return JSON.stringify(compiled.prepared);
+    });
+
+    const [library, ...others] = serialized;
+    for (const other of others) expect(other).toBe(library);
+  });
+
+  it('converts USD budgets exactly and identically to library-provided micro-USD strings', () => {
+    const catalog = catalogFor([planningProfile(groundedProfile('alpha'))]);
+    const shared = { query: 'budget parity', providers: ['alpha'] } as const;
+    const normalized = [
+      normalizeLibraryRequest(
+        {
+          query: shared.query,
+          targets: [{ provider_id: 'alpha' }],
+          budgets: {
+            max_estimated_cost_microusd: '100000',
+            max_actual_cost_microusd: '250000',
+          },
+        },
+        FIXTURE_DEFAULTS,
+      ),
+      normalizeCliRequest(
+        { ...shared, maxCostUsd: 0.25, maxEstimatedCostUsd: 0.1 },
+        FIXTURE_DEFAULTS,
+      ),
+      normalizeConfigurationRequest(
+        {
+          query: shared.query,
+          providers: [...shared.providers],
+          defaults: { maxCostUsd: 0.25, maxEstimatedCostUsd: 0.1 },
+        },
+        FIXTURE_DEFAULTS,
+      ),
+    ];
+
+    const serialized = normalized.map((result) => {
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error('normalization unexpectedly failed');
+      const compiled = prepareResearchExecution(
+        result.request,
+        catalog,
+        dependencies(),
+      );
+      expect(compiled.ok).toBe(true);
+      if (!compiled.ok) throw new Error('compilation unexpectedly failed');
+      expect(compiled.prepared.policy.budgets).toEqual({
+        max_estimated_cost_microusd: '100000',
+        max_actual_cost_microusd: '250000',
+      });
+      return JSON.stringify(compiled.prepared);
+    });
+    expect(new Set(serialized).size).toBe(1);
+  });
+});
+
+describe('selector conflicts', () => {
+  it('rejects competing selectors consistently across all five transports', () => {
+    const input = { query: 'q', providers: ['alpha'], group: 'quick' };
+    for (const normalize of [
+      normalizeCliRequest,
+      normalizeMcpRequest,
+      normalizeSilentMcpRequest,
+      normalizeConfigurationRequest,
+    ]) {
+      const result = normalize(input, FIXTURE_DEFAULTS);
+      expect(result.ok).toBe(false);
+      if (result.ok) continue;
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: 'transport_selector_conflict',
+          phase: 'transport',
+          path: '/group',
+        }),
+      ]);
+    }
+    const library = normalizeLibraryRequest(
+      {
+        query: 'q',
+        targets: [{ provider_id: 'alpha' }],
+        group: 'quick',
+        capabilities: {
+          requirements: {
+            result_kind: 'grounded_answer',
+            grounding_policy: 'required',
+            corpora: ['web'],
+          },
+        },
+      },
+      FIXTURE_DEFAULTS,
+    );
+    expect(library.ok).toBe(false);
+    if (library.ok) return;
+    expect(library.issues.map(({ code, path }) => [code, path])).toEqual([
+      ['transport_selector_conflict', '/group'],
+      ['transport_selector_conflict', '/capabilities'],
+    ]);
+  });
+
+  it('treats a provided-but-empty provider selection as a caller mistake, mirroring v1', () => {
+    const result = normalizeMcpRequest(
+      { query: 'q', providers: [' '] },
+      FIXTURE_DEFAULTS,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'transport_empty_provider_selection',
+        path: '/providers',
+      }),
+    ]);
+  });
+
+  it('falls back to the default selector when no selection is present', () => {
+    const result = normalizeSilentMcpRequest({ query: 'q' }, FIXTURE_DEFAULTS);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.request.selector).toEqual({ kind: 'default' });
+    expect(result.request.fallback).toEqual(FIXTURE_DEFAULTS.fallback);
+    expect(result.request.limits).toEqual(FIXTURE_DEFAULTS.limits);
+    expect(result.request.refinement).toEqual(FIXTURE_DEFAULTS.refinement);
+  });
+});
+
+describe('transport budgets and legacy mode', () => {
+  it('rejects USD budgets that do not convert exactly to micro-USD', () => {
+    const inexact = normalizeCliRequest(
+      { query: 'q', providers: ['alpha'], maxCostUsd: 0.0000001 },
+      FIXTURE_DEFAULTS,
+    );
+    expect(inexact.ok).toBe(false);
+    if (inexact.ok) return;
+    expect(inexact.issues).toEqual([
+      expect.objectContaining({
+        code: 'transport_budget_not_exact',
+        path: '/maxCostUsd',
+      }),
+    ]);
+
+    const negative = normalizeConfigurationRequest(
+      {
+        query: 'q',
+        providers: ['alpha'],
+        defaults: { maxEstimatedCostUsd: -1 },
+      },
+      FIXTURE_DEFAULTS,
+    );
+    expect(negative.ok).toBe(false);
+    if (negative.ok) return;
+    expect(negative.issues).toEqual([
+      expect.objectContaining({
+        code: 'transport_budget_not_exact',
+        path: '/defaults/maxEstimatedCostUsd',
+      }),
+    ]);
+
+    const zero = normalizeCliRequest(
+      { query: 'q', providers: ['alpha'], maxEstimatedCostUsd: 0 },
+      FIXTURE_DEFAULTS,
+    );
+    expect(zero.ok).toBe(true);
+    if (!zero.ok) return;
+    expect(zero.request.budgets).toEqual({
+      max_estimated_cost_microusd: '0',
+    });
+  });
+
+  it('passes legacy mixed mode through to the migration boundary unchanged (v1 surface preserved in shadow)', () => {
+    const catalog = catalogFor([
+      planningProfile(groundedProfile('alpha', 'durable')),
+    ]);
+    const normalized = normalizeSilentMcpRequest(
+      { query: 'legacy mixed query', providers: ['alpha'], mode: 'mixed' },
+      FIXTURE_DEFAULTS,
+    );
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.request.mode).toBe('mixed');
+
+    const compiled = compileNormalizedTransportRequest(
+      normalized,
+      catalog,
+      dependencies(),
+    );
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    expect(compiled.prepared.request.mode).toBe('async');
+    expect(compiled.notices).toContainEqual(
+      expect.objectContaining({ code: 'legacy_mixed_mode_migrated' }),
+    );
+  });
+
+  it('preserves selector conflicts through compilation via the shadow helper', () => {
+    const catalog = catalogFor([planningProfile(groundedProfile('alpha'))]);
+    const compiled = compileNormalizedTransportRequest(
+      normalizeCliRequest(
+        { query: 'q', providers: ['alpha'], group: 'quick' },
+        FIXTURE_DEFAULTS,
+      ),
+      catalog,
+      dependencies(),
+    );
+    expect(compiled.ok).toBe(false);
+    if (compiled.ok) return;
+    expect(compiled.issues).toEqual([
+      expect.objectContaining({
+        code: 'transport_selector_conflict',
+        path: '/group',
+      }),
+    ]);
+
+    const rejected = compileNormalizedTransportRequest(
+      normalizeLibraryRequest(
+        { query: 'q', targets: [{ provider_id: 'alpha' }], group: 'quick' },
+        FIXTURE_DEFAULTS,
+      ),
+      catalog,
+      dependencies(),
+    );
+    expect(rejected.ok).toBe(false);
+    if (rejected.ok) return;
+    expect(rejected.issues).toEqual([
+      expect.objectContaining({ code: 'transport_selector_conflict' }),
+    ]);
+  });
+
+  it('still compiles an unambiguous selector without transport notices', () => {
+    const catalog = catalogFor([planningProfile(groundedProfile('alpha'))]);
+    const normalized = normalizeCliRequest(
+      { query: 'q', providers: ['alpha'] },
+      FIXTURE_DEFAULTS,
+    );
+    const compiled = compileNormalizedTransportRequest(
+      normalized,
+      catalog,
+      dependencies(),
+    );
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    expect(compiled.notices).toEqual([]);
+  });
+});

--- a/tests/workers/execution-core.test.ts
+++ b/tests/workers/execution-core.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ExecutionProfile } from '../../src/contracts/domain/index.js';
 import {
   createCoordinatorState,
+  recordLaunchDispatched,
   startLaunchableAttempts,
 } from '../../src/core/coordinator.js';
 import { InMemoryCoordinationStateStore } from '../../src/core/coordinator-store.js';
@@ -74,7 +75,7 @@ describe('private execution architecture in workerd', () => {
     const dependencies = {
       clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
       ids: {
-        next: (scope: 'attempt' | 'event') => {
+        next: (scope: 'attempt' | 'event' | 'delivery_lease') => {
           id += 1;
           return `worker-${scope}-${id}`;
         },
@@ -86,13 +87,20 @@ describe('private execution architecture in workerd', () => {
     );
     expect(started.launches).toHaveLength(1);
     expect(started.launches[0]?.query).toBe('worker-safe query');
+    const dispatched = recordLaunchDispatched(
+      started.state,
+      started.launches[0]?.attempt_id ?? '',
+      started.launches[0]?.delivery_lease_id ?? '',
+      dependencies,
+    );
+    expect(dispatched.attempts[0]?.status).toBe('running');
 
     const store = new InMemoryCoordinationStateStore();
-    const created = await store.create(started.state);
+    const created = await store.create(dispatched);
     expect(created.version).toBe(1);
-    await expect(store.load(started.state.request_id)).resolves.toMatchObject({
+    await expect(store.load(dispatched.request_id)).resolves.toMatchObject({
       version: 1,
-      state: { request_id: started.state.request_id },
+      state: { request_id: dispatched.request_id },
     });
   });
 });

--- a/tests/workers/execution-core.test.ts
+++ b/tests/workers/execution-core.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type { ExecutionProfile } from '../../src/contracts/domain/index.js';
+import {
+  createCoordinatorState,
+  startLaunchableAttempts,
+} from '../../src/core/coordinator.js';
+import { InMemoryCoordinationStateStore } from '../../src/core/coordinator-store.js';
+import {
+  type FrozenPlanningCatalog,
+  prepareResearchExecution,
+} from '../../src/core/execution-plan.js';
+import { CanonicalResearchRequestSchema } from '../../src/core/research-request.js';
+
+const profile: ExecutionProfile = {
+  identity: { provider_id: 'worker-fixture', profile_id: 'grounded-web' },
+  result_kind: 'grounded_answer',
+  grounding_policy: 'required',
+  observation_mode: 'api_output',
+  corpora: ['web'],
+  retrieval_method: 'model_search_tool',
+  access_mode: 'direct',
+  operator_id: 'worker-fixture',
+  invocation: 'inline',
+  resumability: 'none',
+};
+
+describe('private execution architecture in workerd', () => {
+  it('prepares, coordinates, and persists without Node APIs', async () => {
+    const catalog: FrozenPlanningCatalog = {
+      revision: 'worker-r1',
+      digest: 'worker-digest',
+      profiles: [
+        {
+          profile,
+          binding: {
+            adapter_id: 'worker-adapter',
+            binding_id: 'worker-binding',
+          },
+          estimate: { estimated_cost_microusd: '0' },
+          enabled: true,
+          credentialed: true,
+          configuration_valid: true,
+        },
+      ],
+      resolveGroup: () => undefined,
+      resolveDefault: () => [profile.identity],
+      resolveConfiguredReserve: () => [],
+    };
+    const preparationIds = {
+      next: (scope: 'request' | 'slot' | 'fallback_candidate') =>
+        `worker-${scope}`,
+    };
+    const request = CanonicalResearchRequestSchema.parse({
+      query: '  worker-safe query  ',
+      mode: 'sync',
+      selector: { kind: 'default' },
+      fallback: { kind: 'disabled' },
+      limits: {
+        max_concurrency: 1,
+        request_deadline_ms: 60_000,
+        inline_attempt_deadline_ms: 30_000,
+        background_attempt_deadline_ms: 60_000,
+        poll_interval_ms: 1_000,
+      },
+    });
+    const prepared = prepareResearchExecution(request, catalog, {
+      clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
+      ids: preparationIds,
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+
+    let id = 0;
+    const dependencies = {
+      clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
+      ids: {
+        next: (scope: 'attempt' | 'event') => {
+          id += 1;
+          return `worker-${scope}-${id}`;
+        },
+      },
+    };
+    const started = startLaunchableAttempts(
+      createCoordinatorState(prepared.prepared, dependencies),
+      dependencies,
+    );
+    expect(started.launches).toHaveLength(1);
+    expect(started.launches[0]?.query).toBe('worker-safe query');
+
+    const store = new InMemoryCoordinationStateStore();
+    const created = await store.create(started.state);
+    expect(created.version).toBe(1);
+    await expect(store.load(started.state.request_id)).resolves.toMatchObject({
+      version: 1,
+      state: { request_id: started.state.request_id },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the private, Worker-safe execution foundation for Librarium v2. It establishes one canonical request and planning path, deterministic coordination, durable launch delivery, and fail-closed execution policy without changing the current public CLI, MCP, library, or dispatcher behavior.

## Changes

- Normalize library, CLI, MCP, silent-MCP, and configuration-shaped inputs into byte-identical canonical plans
- Enforce one selector, strict sync/async semantics, legacy mixed-to-async notices, bounded policies, and complete no-network preflight
- Compile deterministic primary slots and a single ordered global fallback reserve
- Add a CAS-backed coordinator with persisted delivery leases, stable attempt idempotency, deadline-first callbacks, cancellation, acceptance uncertainty, and lifecycle sequencing
- Enforce hard estimated and actual-cost budgets with concurrent reservations and deterministic fallback admission
- Validate adapter-originated handles, errors, identifiers, state references, and costs before persistence
- Keep the new architecture private until the production provider catalog and profile semantics are integrated
- Preserve the generated interchange contract snapshot unchanged

## Design Decisions

**On deadlines:** Inline and background attempts have separate deadlines so the execution policy can represent their materially different latency profiles.

**On launch recovery:** Attempts begin as persisted delivery intent. A renewable lease and stable idempotency key make a pre-dispatch crash replayable without creating a new logical attempt.

**On budgets:** Hard budgets require network-free estimates at preflight and retain reservations until actual cost is known. This intentionally fails closed when a provider does not report cost.

**On transport conflicts:** Equivalent selector conflicts are rejected consistently across every input surface before any network activity.

## Testing

- [x] Typecheck
- [x] Biome lint
- [x] Unit suite: 1,488 tests
- [x] Worker compatibility: 9 tests
- [x] Integration suite: 14 tests
- [x] Contract snapshot generation with no generated changes
- [x] Independent security, quality, and testability review reached unanimous approval
