### PR TITLE
feat: add canonical execution runtime

### DIFF
--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -442,7 +442,12 @@ async function callScriptOperation<T>({
     sourceOptions: source.options ?? {},
   };
 
-  const raw = await runScriptOperation(source, envelope, timeoutSeconds);
+  const raw = await runScriptOperation(
+    source,
+    envelope,
+    timeoutSeconds,
+    options?.signal,
+  );
   const response = SCRIPT_RESPONSE_SCHEMA.parse(raw);
 
   if (!response.ok) {
@@ -468,8 +473,13 @@ function runScriptOperation(
   source: ScriptProviderSource,
   envelope: ScriptRequestEnvelope,
   timeoutSeconds: number,
+  signal?: AbortSignal,
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('Script provider operation was aborted.'));
+      return;
+    }
     const child = spawn(source.command, source.args ?? [], {
       cwd: source.cwd ? resolvePath(process.cwd(), source.cwd) : process.cwd(),
       env: { ...process.env, ...(source.env ?? {}) },
@@ -479,11 +489,18 @@ function runScriptOperation(
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const onAbort = (): void => {
+      child.kill('SIGKILL');
+      finish(new Error('Script provider operation was aborted.'));
+    };
 
     const finish = (error?: Error, value?: unknown): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
+      if (timeout) clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
       if (error) {
         reject(error);
       } else {
@@ -538,7 +555,7 @@ function runScriptOperation(
       }
     });
 
-    const timeout = setTimeout(() => {
+    timeout = setTimeout(() => {
       child.kill('SIGKILL');
       finish(
         new Error(
@@ -546,6 +563,11 @@ function runScriptOperation(
         ),
       );
     }, Math.max(1, timeoutSeconds) * 1000);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
 
     child.stdin.write(JSON.stringify(envelope));
     child.stdin.end();

--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -490,10 +490,15 @@ function runScriptOperation(
     let stderr = '';
     let settled = false;
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let terminationError: Error | undefined;
+
+    const terminate = (error: Error): void => {
+      terminationError = error;
+      if (!child.kill('SIGKILL')) finish(error);
+    };
 
     const onAbort = (): void => {
-      child.kill('SIGKILL');
-      finish(new Error('Script provider operation was aborted.'));
+      terminate(new Error('Script provider operation was aborted.'));
     };
 
     const finish = (error?: Error, value?: unknown): void => {
@@ -523,6 +528,10 @@ function runScriptOperation(
     });
 
     child.on('close', (code, terminationSignal) => {
+      if (terminationError) {
+        finish(terminationError);
+        return;
+      }
       const trimmed = stdout.trim();
       if (!trimmed) {
         const detail = [
@@ -556,8 +565,7 @@ function runScriptOperation(
     });
 
     timeout = setTimeout(() => {
-      child.kill('SIGKILL');
-      finish(
+      terminate(
         new Error(
           `Script provider operation "${envelope.operation}" timed out after ${timeoutSeconds}s`,
         ),

--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -522,12 +522,12 @@ function runScriptOperation(
       );
     });
 
-    child.on('close', (code, signal) => {
+    child.on('close', (code, terminationSignal) => {
       const trimmed = stdout.trim();
       if (!trimmed) {
         const detail = [
           code !== null ? `exit code ${code}` : null,
-          signal ? `signal ${signal}` : null,
+          terminationSignal ? `signal ${terminationSignal}` : null,
           stderr.trim() ? `stderr: ${stderr.trim().slice(0, 300)}` : null,
         ]
           .filter(Boolean)
@@ -564,10 +564,6 @@ function runScriptOperation(
       );
     }, Math.max(1, timeoutSeconds) * 1000);
     signal?.addEventListener('abort', onAbort, { once: true });
-    if (signal?.aborted) {
-      onAbort();
-      return;
-    }
 
     child.stdin.write(JSON.stringify(envelope));
     child.stdin.end();

--- a/src/core/coordinator.ts
+++ b/src/core/coordinator.ts
@@ -358,6 +358,17 @@ function attemptDeadlineError(): StructuredError {
   };
 }
 
+function acceptedDurableDeadlineError(): StructuredError {
+  return {
+    code: 'accepted_durable_attempt_deadline_exceeded',
+    message:
+      'The accepted durable task exceeded the local attempt deadline and may still be running remotely.',
+    category: 'timeout',
+    retryable: true,
+    fallback_allowed: false,
+  };
+}
+
 function requestDeadlineError(): StructuredError {
   return {
     code: 'request_deadline_exceeded',
@@ -1498,10 +1509,17 @@ export function advanceDeadlines(
         'submission_deadline_exceeded',
       );
     } else {
+      const error = current.durable_handle
+        ? acceptedDurableDeadlineError()
+        : attemptDeadlineError();
       next = finishAttemptUnchecked(
         next,
         current.attempt_id,
-        { outcome: 'timed_out', error: attemptDeadlineError() },
+        {
+          outcome: 'timed_out',
+          error,
+          durable_handle: current.durable_handle,
+        },
         dependencies,
       );
     }

--- a/src/core/coordinator.ts
+++ b/src/core/coordinator.ts
@@ -182,6 +182,7 @@ export interface AttemptLaunch {
   readonly slot_id: string;
   readonly profile: ExecutionProfile;
   readonly binding: AdapterBindingIdentity;
+  readonly catalog_digest: string;
   readonly query: string;
   readonly deadline_at: string;
   readonly delivery_lease_id: string;
@@ -736,6 +737,7 @@ function claimDispatchPendingAttempts(
       slot_id: attempt.slot_id,
       profile: attempt.profile,
       binding: profilePlanFor(state, attempt.profile).binding,
+      catalog_digest: state.catalog_digest,
       query: attempt.query,
       deadline_at: attempt.deadline_at,
       delivery_lease_id: deliveryLeaseId,
@@ -892,11 +894,6 @@ export function recordSubmissionAccepted(
     );
   }
   validateHandleProvider(attempt, handle);
-  if (handle.status !== 'pending' && handle.status !== 'running') {
-    throw new Error(
-      'A newly accepted durable handle must be pending or running.',
-    );
-  }
   attempt.status = 'submitted';
   attempt.durable_handle = handle;
   attempt.adapter_state_ref = adapterStateRef ?? attempt.adapter_state_ref;

--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -615,8 +615,10 @@ function validatePlanningMetadata(
       ['adapter_id', entry.binding.adapter_id],
       ['binding_id', entry.binding.binding_id],
     ] as const;
+    let bindingIsValid = true;
     for (const [field, value] of bindingFields) {
       if (!OpaqueIdSchema.safeParse(value).success) {
+        bindingIsValid = false;
         issues.push({
           code: 'invalid_adapter_binding_identity',
           phase: 'validation',
@@ -626,10 +628,7 @@ function validatePlanningMetadata(
         });
       }
     }
-    if (
-      OpaqueIdSchema.safeParse(entry.binding.adapter_id).success &&
-      OpaqueIdSchema.safeParse(entry.binding.binding_id).success
-    ) {
+    if (bindingIsValid) {
       const bindingPair = JSON.stringify([
         entry.binding.adapter_id,
         entry.binding.binding_id,

--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -585,6 +585,7 @@ function validatePlanningMetadata(
   issues: PreparationIssue[],
 ): void {
   const keys = new Set<string>();
+  const bindingPairs = new Set<string>();
   for (const [index, entry] of entries.entries()) {
     const entryPath = `/catalog/profiles/${index}`;
     const parsedProfile = ExecutionProfileSchema.safeParse(entry.profile);
@@ -624,6 +625,26 @@ function validatePlanningMetadata(
           profile_key: key,
         });
       }
+    }
+    if (
+      OpaqueIdSchema.safeParse(entry.binding.adapter_id).success &&
+      OpaqueIdSchema.safeParse(entry.binding.binding_id).success
+    ) {
+      const bindingPair = JSON.stringify([
+        entry.binding.adapter_id,
+        entry.binding.binding_id,
+      ]);
+      if (bindingPairs.has(bindingPair)) {
+        issues.push({
+          code: 'catalog_binding_duplicate',
+          phase: 'validation',
+          path: `${entryPath}/binding`,
+          message:
+            'Each frozen adapter and binding identity pair may describe only one provider profile.',
+          profile_key: key,
+        });
+      }
+      bindingPairs.add(bindingPair);
     }
     const estimatedCost = entry.estimate?.estimated_cost_microusd;
     if (

--- a/src/core/execution-runtime.ts
+++ b/src/core/execution-runtime.ts
@@ -129,29 +129,48 @@ export async function runPreparedExecution(
     launch: AttemptLaunch,
   ): Promise<boolean> => {
     let dispatched = false;
-    await transition(effectiveDependencies, requestId, (state) => {
-      // updateCoordinationState may invoke this callback more than once after
-      // a CAS conflict. Reset the decision on every observation so a stale
-      // delivery never inherits permission from a failed CAS attempt.
-      dispatched = false;
-      const attempt = state.attempts.find(
-        (candidate) => candidate.attempt_id === launch.attempt_id,
-      );
-      if (
-        attempt?.status !== 'dispatch_pending' ||
-        attempt?.delivery_lease_id !== launch.delivery_lease_id
-      ) {
-        return undefined;
-      }
-      dispatched = true;
-      return recordLaunchDispatched(
-        state,
-        launch.attempt_id,
-        launch.delivery_lease_id,
-        effectiveDependencies.coordinator,
-      );
-    });
-    return dispatched;
+    const persisted = await transition(
+      effectiveDependencies,
+      requestId,
+      (state) => {
+        // updateCoordinationState may invoke this callback more than once after
+        // a CAS conflict. Reset the decision on every observation so a stale
+        // delivery never inherits permission from a failed CAS attempt.
+        dispatched = false;
+        const attempt = state.attempts.find(
+          (candidate) => candidate.attempt_id === launch.attempt_id,
+        );
+        if (
+          attempt?.status !== 'dispatch_pending' ||
+          attempt?.delivery_lease_id !== launch.delivery_lease_id
+        ) {
+          return undefined;
+        }
+        const now = effectiveDependencies.coordinator.clock.now();
+        if (
+          now >= Date.parse(state.request_deadline_at) ||
+          !attempt.delivery_lease_expires_at ||
+          now >= Date.parse(attempt.delivery_lease_expires_at)
+        ) {
+          return undefined;
+        }
+        dispatched = true;
+        return recordLaunchDispatched(
+          state,
+          launch.attempt_id,
+          launch.delivery_lease_id,
+          effectiveDependencies.coordinator,
+        );
+      },
+    );
+    const attempt = persisted.state.attempts.find(
+      (candidate) => candidate.attempt_id === launch.attempt_id,
+    );
+    return (
+      dispatched &&
+      (attempt?.status === 'running' || attempt?.status === 'submitting') &&
+      attempt.started_at !== undefined
+    );
   };
 
   const executeLaunch = async (launch: AttemptLaunch): Promise<void> => {
@@ -272,6 +291,31 @@ export async function runPreparedExecution(
         }
       }
     } catch (error) {
+      const current = await effectiveDependencies.store.load(requestId);
+      const attempt = current?.state.attempts.find(
+        (candidate) => candidate.attempt_id === launch.attempt_id,
+      );
+      if (
+        attempt?.durable_handle &&
+        (attempt.status === 'submitted' || attempt.status === 'running')
+      ) {
+        await transition(effectiveDependencies, requestId, (state) =>
+          recordTransientPollFailure(
+            state,
+            launch.attempt_id,
+            {
+              code: 'attempt_execution_interrupted',
+              message:
+                'Local execution was interrupted after durable acceptance.',
+              category: 'internal',
+              retryable: true,
+              fallback_allowed: false,
+            },
+            effectiveDependencies.coordinator,
+          ),
+        );
+        return;
+      }
       await transition(effectiveDependencies, requestId, (state) =>
         recordAttemptFinished(
           state,

--- a/src/core/execution-runtime.ts
+++ b/src/core/execution-runtime.ts
@@ -13,7 +13,9 @@ import {
   recordAttemptRunning,
   recordLaunchDispatched,
   recordSubmissionAccepted,
+  recordTransientPollFailure,
   resumeCoordination,
+  type UnresolvedAcceptance,
 } from './coordinator.js';
 import {
   type CoordinationStateStore,
@@ -39,8 +41,12 @@ export interface AttemptExecutionContext {
   submissionAccepted(
     handle: DurableHandle,
     adapterStateRef?: string,
+  ): Promise<boolean>;
+  submissionAcceptanceUnknown(
+    adapterStateRef?: string,
+    reason?: UnresolvedAcceptance['reason'],
   ): Promise<void>;
-  submissionAcceptanceUnknown(adapterStateRef?: string): Promise<void>;
+  transientPollFailure(error: StructuredError): Promise<void>;
   running(): Promise<void>;
 }
 
@@ -69,9 +75,10 @@ export interface ExecutionRuntimeResult {
 }
 
 function executionFailure(error: unknown): StructuredError {
+  void error;
   return {
     code: 'attempt_execution_failed',
-    message: error instanceof Error ? error.message : String(error),
+    message: 'The attempt execution port failed.',
     category: 'internal',
     retryable: false,
     fallback_allowed: false,
@@ -102,8 +109,19 @@ export async function runPreparedExecution(
   prepared: PreparedResearchExecution,
   dependencies: ExecutionRuntimeDependencies,
 ): Promise<ExecutionRuntimeResult> {
-  const initial = createCoordinatorState(prepared, dependencies.coordinator);
-  await dependencies.store.create(initial);
+  const effectiveDependencies: ExecutionRuntimeDependencies = {
+    ...dependencies,
+    max_compare_and_swap_attempts:
+      dependencies.max_compare_and_swap_attempts ??
+      // A completion can race the remaining dispatch transitions in the same
+      // wave, so one updater may observe roughly two transitions per slot.
+      Math.max(16, prepared.policy.limits.max_concurrency * 2 + 2),
+  };
+  const initial = createCoordinatorState(
+    prepared,
+    effectiveDependencies.coordinator,
+  );
+  await effectiveDependencies.store.create(initial);
   const outputs = new Map<string, unknown>();
   const requestId = initial.request_id;
 
@@ -111,7 +129,11 @@ export async function runPreparedExecution(
     launch: AttemptLaunch,
   ): Promise<boolean> => {
     let dispatched = false;
-    await transition(dependencies, requestId, (state) => {
+    await transition(effectiveDependencies, requestId, (state) => {
+      // updateCoordinationState may invoke this callback more than once after
+      // a CAS conflict. Reset the decision on every observation so a stale
+      // delivery never inherits permission from a failed CAS attempt.
+      dispatched = false;
       const attempt = state.attempts.find(
         (candidate) => candidate.attempt_id === launch.attempt_id,
       );
@@ -126,7 +148,7 @@ export async function runPreparedExecution(
         state,
         launch.attempt_id,
         launch.delivery_lease_id,
-        dependencies.coordinator,
+        effectiveDependencies.coordinator,
       );
     });
     return dispatched;
@@ -138,47 +160,76 @@ export async function runPreparedExecution(
       mode: prepared.request.mode,
       poll_interval_ms: prepared.policy.limits.poll_interval_ms,
       submissionAccepted: async (handle, adapterStateRef) => {
-        await transition(dependencies, requestId, (state) =>
-          recordSubmissionAccepted(
-            state,
-            launch.attempt_id,
-            handle,
-            dependencies.coordinator,
-            adapterStateRef,
-          ),
+        const persisted = await transition(
+          effectiveDependencies,
+          requestId,
+          (state) =>
+            recordSubmissionAccepted(
+              state,
+              launch.attempt_id,
+              handle,
+              effectiveDependencies.coordinator,
+              adapterStateRef,
+            ),
+        );
+        const attempt = persisted.state.attempts.find(
+          (candidate) => candidate.attempt_id === launch.attempt_id,
+        );
+        return (
+          (attempt?.status === 'submitted' || attempt?.status === 'running') &&
+          attempt.durable_handle?.handle_id === handle.handle_id &&
+          attempt.durable_handle.provider_task_id === handle.provider_task_id
         );
       },
-      submissionAcceptanceUnknown: async (adapterStateRef) => {
-        await transition(dependencies, requestId, (state) =>
+      submissionAcceptanceUnknown: async (adapterStateRef, reason) => {
+        await transition(effectiveDependencies, requestId, (state) =>
           recordAcceptanceUnknown(
             state,
             launch.attempt_id,
-            dependencies.coordinator,
+            effectiveDependencies.coordinator,
             adapterStateRef,
+            reason,
+          ),
+        );
+      },
+      transientPollFailure: async (error) => {
+        await transition(effectiveDependencies, requestId, (state) =>
+          recordTransientPollFailure(
+            state,
+            launch.attempt_id,
+            error,
+            effectiveDependencies.coordinator,
           ),
         );
       },
       running: async () => {
-        await transition(dependencies, requestId, (state) =>
-          recordAttemptRunning(
+        await transition(effectiveDependencies, requestId, (state) => {
+          const attempt = state.attempts.find(
+            (candidate) => candidate.attempt_id === launch.attempt_id,
+          );
+          if (attempt?.status === 'running') return undefined;
+          return recordAttemptRunning(
             state,
             launch.attempt_id,
-            dependencies.coordinator,
-          ),
-        );
+            effectiveDependencies.coordinator,
+          );
+        });
       },
     };
 
     try {
       const result = await dependencies.attempts.execute(launch, context);
       if (result.kind === 'finished') {
-        const persisted = await transition(dependencies, requestId, (state) =>
-          recordAttemptFinished(
-            state,
-            launch.attempt_id,
-            result.finished,
-            dependencies.coordinator,
-          ),
+        const persisted = await transition(
+          effectiveDependencies,
+          requestId,
+          (state) =>
+            recordAttemptFinished(
+              state,
+              launch.attempt_id,
+              result.finished,
+              effectiveDependencies.coordinator,
+            ),
         );
         const persistedAttempt = persisted.state.attempts.find(
           (attempt) => attempt.attempt_id === launch.attempt_id,
@@ -191,14 +242,42 @@ export async function runPreparedExecution(
         ) {
           outputs.set(launch.attempt_id, result.output);
         }
+      } else {
+        let persisted = await effectiveDependencies.store.load(requestId);
+        let attempt = persisted?.state.attempts.find(
+          (candidate) => candidate.attempt_id === launch.attempt_id,
+        );
+        if (
+          result.kind === 'acceptance_unknown' &&
+          attempt?.status === 'submitting'
+        ) {
+          await context.submissionAcceptanceUnknown();
+          persisted = await effectiveDependencies.store.load(requestId);
+          attempt = persisted?.state.attempts.find(
+            (candidate) => candidate.attempt_id === launch.attempt_id,
+          );
+        }
+        const coherent =
+          result.kind === 'accepted'
+            ? prepared.request.mode === 'async' &&
+              (attempt?.status === 'submitted' ||
+                attempt?.status === 'running') &&
+              attempt.durable_handle !== undefined
+            : attempt?.status === 'acceptance_unknown' ||
+              persisted?.state.status !== 'running';
+        if (!coherent) {
+          throw new Error(
+            `Attempt port returned ${result.kind} without the matching persisted coordinator state.`,
+          );
+        }
       }
     } catch (error) {
-      await transition(dependencies, requestId, (state) =>
+      await transition(effectiveDependencies, requestId, (state) =>
         recordAttemptFinished(
           state,
           launch.attempt_id,
           { outcome: 'failed', error: executionFailure(error) },
-          dependencies.coordinator,
+          effectiveDependencies.coordinator,
         ),
       );
     }
@@ -206,10 +285,10 @@ export async function runPreparedExecution(
 
   for (;;) {
     const advanced = await resumeCoordination(
-      dependencies.store,
+      effectiveDependencies.store,
       requestId,
-      dependencies.coordinator,
-      dependencies.max_compare_and_swap_attempts,
+      effectiveDependencies.coordinator,
+      effectiveDependencies.max_compare_and_swap_attempts,
     );
     const state = advanced.state;
 
@@ -218,23 +297,9 @@ export async function runPreparedExecution(
       continue;
     }
 
-    // Async acceptance and future durable polling are deliberately held for
-    // B2. The B1 runner returns the persisted state instead of pretending that
-    // it can offer process-resumable status/retrieve semantics.
-    if (
-      state.status !== 'running' ||
-      prepared.request.mode === 'async' ||
-      state.attempts.some((attempt) =>
-        ['submitted', 'running', 'acceptance_unknown'].includes(attempt.status),
-      )
-    ) {
-      return {
-        state,
-        outputs_by_attempt: Object.freeze(Object.fromEntries(outputs)),
-      };
-    }
-
-    // A quiescent synchronous plan should have been finalized by the reducer.
+    // Async acceptance, acceptance uncertainty, and future durable resumption
+    // return the persisted state without pretending B1 is process-resumable.
+    // A coherent sync bridge finishes its durable lifecycle before returning.
     return {
       state,
       outputs_by_attempt: Object.freeze(Object.fromEntries(outputs)),

--- a/src/core/execution-runtime.ts
+++ b/src/core/execution-runtime.ts
@@ -166,10 +166,13 @@ export async function runPreparedExecution(
     const attempt = persisted.state.attempts.find(
       (candidate) => candidate.attempt_id === launch.attempt_id,
     );
+    const now = effectiveDependencies.coordinator.clock.now();
     return (
       dispatched &&
       (attempt?.status === 'running' || attempt?.status === 'submitting') &&
-      attempt.started_at !== undefined
+      attempt.started_at !== undefined &&
+      now < Date.parse(persisted.state.request_deadline_at) &&
+      now < Date.parse(launch.deadline_at)
     );
   };
 
@@ -299,8 +302,17 @@ export async function runPreparedExecution(
         attempt?.durable_handle &&
         (attempt.status === 'submitted' || attempt.status === 'running')
       ) {
-        await transition(effectiveDependencies, requestId, (state) =>
-          recordTransientPollFailure(
+        await transition(effectiveDependencies, requestId, (state) => {
+          const currentAttempt = state.attempts.find(
+            (candidate) => candidate.attempt_id === launch.attempt_id,
+          );
+          if (
+            currentAttempt?.status !== 'submitted' &&
+            currentAttempt?.status !== 'running'
+          ) {
+            return undefined;
+          }
+          return recordTransientPollFailure(
             state,
             launch.attempt_id,
             {
@@ -312,8 +324,8 @@ export async function runPreparedExecution(
               fallback_allowed: false,
             },
             effectiveDependencies.coordinator,
-          ),
-        );
+          );
+        });
         return;
       }
       await transition(effectiveDependencies, requestId, (state) =>
@@ -341,9 +353,10 @@ export async function runPreparedExecution(
       continue;
     }
 
-    // Async acceptance, acceptance uncertainty, and future durable resumption
-    // return the persisted state without pretending B1 is process-resumable.
-    // A coherent sync bridge finishes its durable lifecycle before returning.
+    // Async acceptance, acceptance uncertainty, local interruption after
+    // acceptance, and future durable resumption return persisted nonterminal
+    // state without pretending B1 is process-resumable. A coherent sync bridge
+    // otherwise finishes its durable lifecycle before returning.
     return {
       state,
       outputs_by_attempt: Object.freeze(Object.fromEntries(outputs)),

--- a/src/core/execution-runtime.ts
+++ b/src/core/execution-runtime.ts
@@ -1,0 +1,243 @@
+import type {
+  DurableHandle,
+  StructuredError,
+} from '../contracts/domain/index.js';
+import {
+  type AttemptFinishedInput,
+  type AttemptLaunch,
+  type CoordinatorDependencies,
+  type CoordinatorState,
+  createCoordinatorState,
+  recordAcceptanceUnknown,
+  recordAttemptFinished,
+  recordAttemptRunning,
+  recordLaunchDispatched,
+  recordSubmissionAccepted,
+  resumeCoordination,
+} from './coordinator.js';
+import {
+  type CoordinationStateStore,
+  updateCoordinationState,
+} from './coordinator-store.js';
+import type { PreparedResearchExecution } from './execution-plan.js';
+
+/**
+ * The Worker-safe execution port. It receives a launch that was already
+ * selected and bound by preparation/coordinator code; implementors must never
+ * select a replacement provider or reinterpret its profile.
+ */
+export interface AttemptExecutionPort {
+  execute(
+    launch: AttemptLaunch,
+    context: AttemptExecutionContext,
+  ): Promise<AttemptExecutionResult>;
+}
+
+export interface AttemptExecutionContext {
+  readonly mode: 'sync' | 'async';
+  readonly poll_interval_ms: number;
+  submissionAccepted(
+    handle: DurableHandle,
+    adapterStateRef?: string,
+  ): Promise<void>;
+  submissionAcceptanceUnknown(adapterStateRef?: string): Promise<void>;
+  running(): Promise<void>;
+}
+
+export type AttemptExecutionResult =
+  | {
+      readonly kind: 'finished';
+      readonly finished: AttemptFinishedInput;
+      /** Private, ingress-owned output. Never projected into ResearchResponse. */
+      readonly output?: unknown;
+    }
+  | { readonly kind: 'acceptance_unknown' }
+  | { readonly kind: 'accepted' };
+
+export interface ExecutionRuntimeDependencies {
+  readonly store: CoordinationStateStore;
+  readonly coordinator: CoordinatorDependencies;
+  readonly attempts: AttemptExecutionPort;
+  /** A bounded CAS retry budget for each persisted state transition. */
+  readonly max_compare_and_swap_attempts?: number;
+}
+
+export interface ExecutionRuntimeResult {
+  readonly state: CoordinatorState;
+  /** Private in-process outputs, keyed by attempt id. */
+  readonly outputs_by_attempt: Readonly<Record<string, unknown>>;
+}
+
+function executionFailure(error: unknown): StructuredError {
+  return {
+    code: 'attempt_execution_failed',
+    message: error instanceof Error ? error.message : String(error),
+    category: 'internal',
+    retryable: false,
+    fallback_allowed: false,
+  };
+}
+
+async function transition(
+  dependencies: ExecutionRuntimeDependencies,
+  requestId: string,
+  update: (state: CoordinatorState) => CoordinatorState | undefined,
+) {
+  return updateCoordinationState(
+    dependencies.store,
+    requestId,
+    update,
+    dependencies.max_compare_and_swap_attempts,
+  );
+}
+
+/**
+ * Executes a prepared plan through the injected store and attempt port.
+ *
+ * Preparation is intentionally outside this module: callers must finish the
+ * complete network-free plan before constructing this runner, so no refine,
+ * registry, or adapter operation can occur after a failed preflight.
+ */
+export async function runPreparedExecution(
+  prepared: PreparedResearchExecution,
+  dependencies: ExecutionRuntimeDependencies,
+): Promise<ExecutionRuntimeResult> {
+  const initial = createCoordinatorState(prepared, dependencies.coordinator);
+  await dependencies.store.create(initial);
+  const outputs = new Map<string, unknown>();
+  const requestId = initial.request_id;
+
+  const persistLaunchDispatch = async (
+    launch: AttemptLaunch,
+  ): Promise<boolean> => {
+    let dispatched = false;
+    await transition(dependencies, requestId, (state) => {
+      const attempt = state.attempts.find(
+        (candidate) => candidate.attempt_id === launch.attempt_id,
+      );
+      if (
+        attempt?.status !== 'dispatch_pending' ||
+        attempt?.delivery_lease_id !== launch.delivery_lease_id
+      ) {
+        return undefined;
+      }
+      dispatched = true;
+      return recordLaunchDispatched(
+        state,
+        launch.attempt_id,
+        launch.delivery_lease_id,
+        dependencies.coordinator,
+      );
+    });
+    return dispatched;
+  };
+
+  const executeLaunch = async (launch: AttemptLaunch): Promise<void> => {
+    if (!(await persistLaunchDispatch(launch))) return;
+    const context: AttemptExecutionContext = {
+      mode: prepared.request.mode,
+      poll_interval_ms: prepared.policy.limits.poll_interval_ms,
+      submissionAccepted: async (handle, adapterStateRef) => {
+        await transition(dependencies, requestId, (state) =>
+          recordSubmissionAccepted(
+            state,
+            launch.attempt_id,
+            handle,
+            dependencies.coordinator,
+            adapterStateRef,
+          ),
+        );
+      },
+      submissionAcceptanceUnknown: async (adapterStateRef) => {
+        await transition(dependencies, requestId, (state) =>
+          recordAcceptanceUnknown(
+            state,
+            launch.attempt_id,
+            dependencies.coordinator,
+            adapterStateRef,
+          ),
+        );
+      },
+      running: async () => {
+        await transition(dependencies, requestId, (state) =>
+          recordAttemptRunning(
+            state,
+            launch.attempt_id,
+            dependencies.coordinator,
+          ),
+        );
+      },
+    };
+
+    try {
+      const result = await dependencies.attempts.execute(launch, context);
+      if (result.kind === 'finished') {
+        const persisted = await transition(dependencies, requestId, (state) =>
+          recordAttemptFinished(
+            state,
+            launch.attempt_id,
+            result.finished,
+            dependencies.coordinator,
+          ),
+        );
+        const persistedAttempt = persisted.state.attempts.find(
+          (attempt) => attempt.attempt_id === launch.attempt_id,
+        );
+        if (
+          result.output !== undefined &&
+          result.finished.outcome === 'succeeded' &&
+          persistedAttempt?.status === 'succeeded' &&
+          persistedAttempt.result_id === result.finished.result_id
+        ) {
+          outputs.set(launch.attempt_id, result.output);
+        }
+      }
+    } catch (error) {
+      await transition(dependencies, requestId, (state) =>
+        recordAttemptFinished(
+          state,
+          launch.attempt_id,
+          { outcome: 'failed', error: executionFailure(error) },
+          dependencies.coordinator,
+        ),
+      );
+    }
+  };
+
+  for (;;) {
+    const advanced = await resumeCoordination(
+      dependencies.store,
+      requestId,
+      dependencies.coordinator,
+      dependencies.max_compare_and_swap_attempts,
+    );
+    const state = advanced.state;
+
+    if (advanced.launches.length > 0) {
+      await Promise.all(advanced.launches.map(executeLaunch));
+      continue;
+    }
+
+    // Async acceptance and future durable polling are deliberately held for
+    // B2. The B1 runner returns the persisted state instead of pretending that
+    // it can offer process-resumable status/retrieve semantics.
+    if (
+      state.status !== 'running' ||
+      prepared.request.mode === 'async' ||
+      state.attempts.some((attempt) =>
+        ['submitted', 'running', 'acceptance_unknown'].includes(attempt.status),
+      )
+    ) {
+      return {
+        state,
+        outputs_by_attempt: Object.freeze(Object.fromEntries(outputs)),
+      };
+    }
+
+    // A quiescent synchronous plan should have been finalized by the reducer.
+    return {
+      state,
+      outputs_by_attempt: Object.freeze(Object.fromEntries(outputs)),
+    };
+  }
+}

--- a/src/core/transport-normalization.ts
+++ b/src/core/transport-normalization.ts
@@ -22,7 +22,7 @@ import type {
  * entrypoint: it exists so semantically equivalent raw inputs from every
  * transport provably compile to identical PreparedResearchExecution values.
  *
- * One common normalizer rejects conflicting selectors; each source contributes only a thin
+ * One common normalizer owns selector precedence; each source contributes only a thin
  * projection of the Checkpoint A semantic fields (query, mode including
  * legacy mixed, exactly one selector, fallback intent, limits, exact budgets,
  * exclusions, refinement). Presentation, output, and filesystem fields are
@@ -33,12 +33,10 @@ import type {
  * CanonicalTransportDefaults context. Selecting the built-in canonical values
  * is an explicit maintainer decision that remains open.
  *
- * Shadow-mapper decision: the v1 runtime resolves competing `providers` and
- * `group` selections by letting explicit providers win (see
- * resolveProviderSelection in src/core/provider-selection.ts). The approved v2
- * rule is that a canonical request has exactly one selector, so every raw
- * adapter rejects ambiguity with the same stable issue. Production v1
- * behavior is untouched.
+ * Approved selector policy: CLI/MCP/silent-MCP preserve the v1 compatibility
+ * rule that explicit providers beat a group and emit a deterministic notice.
+ * Library and configuration surfaces reject that ambiguity. A canonical
+ * request still always contains exactly one selector.
  */
 
 export type TransportSource =
@@ -186,13 +184,28 @@ function normalizeTransportRequest(
   } else {
     const [chosen, ...competing] = present;
     selector = chosen.selector;
-    for (const candidate of competing) {
-      issues.push({
-        code: 'transport_selector_conflict',
+    const explicitProvidersWin =
+      (source === 'cli' || source === 'mcp' || source === 'silent_mcp') &&
+      chosen.name === 'targets' &&
+      competing.length === 1 &&
+      competing[0]?.name === 'group';
+    if (explicitProvidersWin) {
+      const group = competing[0];
+      notices.push({
+        code: 'transport_explicit_providers_override_group',
         phase: 'transport',
-        path: candidate.rawPath,
-        message: `The ${candidate.name} selection competes with ${chosen.name}; a canonical request has exactly one selector. Remove one of them from the ${source} input.`,
+        path: group.rawPath,
+        message: `Explicit providers override the competing group selection for ${source}; the group was ignored.`,
       });
+    } else {
+      for (const candidate of competing) {
+        issues.push({
+          code: 'transport_selector_conflict',
+          phase: 'transport',
+          path: candidate.rawPath,
+          message: `The ${candidate.name} selection competes with ${chosen.name}; a canonical request has exactly one selector. Remove one of them from the ${source} input.`,
+        });
+      }
     }
   }
 

--- a/src/node-execution-bridge.ts
+++ b/src/node-execution-bridge.ts
@@ -1,7 +1,9 @@
 import type {
   DurableHandle,
+  ExecutionProfile,
   StructuredError,
 } from './contracts/domain/index.js';
+import { ExecutionProfileSchema } from './contracts/domain/index.js';
 import type { AttemptLaunch } from './core/coordinator.js';
 import type { AdapterBindingIdentity } from './core/execution-plan.js';
 import type {
@@ -11,12 +13,17 @@ import type {
 } from './core/execution-runtime.js';
 import type { AsyncTaskHandle, Provider, ProviderResult } from './types.js';
 
+type BackgroundProvider = Extract<Provider, { execution: 'background' }>;
+
 export interface NodeExecutionBridgeDependencies {
   /** Exact binding lookup only: aliases and selector policy are absent. */
-  resolveExactBinding(
-    binding: AdapterBindingIdentity,
-  ):
-    | { readonly binding: AdapterBindingIdentity; readonly provider: Provider }
+  resolveExactBinding(binding: AdapterBindingIdentity):
+    | {
+        readonly binding: AdapterBindingIdentity;
+        readonly profile: ExecutionProfile;
+        readonly catalog_digest: string;
+        readonly provider: Provider;
+      }
     | undefined;
   now?: () => number;
   wait?: (milliseconds: number) => Promise<void>;
@@ -74,6 +81,23 @@ function timeoutFor(launch: AttemptLaunch, now: () => number): number {
   return Math.max(1, Date.parse(launch.deadline_at) - now());
 }
 
+function providerTimeoutSeconds(remainingMs: number): number {
+  return Math.max(1, Math.ceil(remainingMs / 1_000));
+}
+
+function profilesMatch(
+  expected: ExecutionProfile,
+  actual: ExecutionProfile,
+): boolean {
+  const parsedExpected = ExecutionProfileSchema.safeParse(expected);
+  const parsedActual = ExecutionProfileSchema.safeParse(actual);
+  return (
+    parsedExpected.success &&
+    parsedActual.success &&
+    JSON.stringify(parsedExpected.data) === JSON.stringify(parsedActual.data)
+  );
+}
+
 function resultOutcome(
   launch: AttemptLaunch,
   result: ProviderResult,
@@ -89,6 +113,7 @@ function resultOutcome(
           'The provider returned an error.',
           result.preventFallback !== true,
         ),
+        ...(completedHandle && { durable_handle: completedHandle }),
       },
       output: result,
     };
@@ -109,12 +134,18 @@ function durableHandle(
   task: AsyncTaskHandle,
   now: () => number,
 ): DurableHandle {
+  const status: DurableHandle['status'] =
+    task.status === 'completed'
+      ? 'succeeded'
+      : task.status === 'failed' || task.status === 'cancelled'
+        ? task.status
+        : task.status;
   return {
     handle_id: launch.attempt_id,
     provider_task_id: task.taskId,
     provider: launch.profile.identity,
     submitted_at: new Date(task.submittedAt || now()).toISOString(),
-    status: task.status === 'running' ? 'running' : 'pending',
+    status,
   };
 }
 
@@ -132,6 +163,52 @@ function observedHandle(
 
 function defaultWait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function retrieveCompletedTask(
+  provider: BackgroundProvider,
+  task: AsyncTaskHandle,
+  launch: AttemptLaunch,
+  handle: DurableHandle,
+  now: () => number,
+): Promise<AttemptExecutionResult> {
+  const completedHandle = observedHandle(handle, 'succeeded', now);
+  const retrieved = await beforeDeadline(
+    () => provider.retrieve(task),
+    launch,
+    now,
+  );
+  if (retrieved.kind === 'deadline') {
+    return {
+      kind: 'finished',
+      finished: {
+        outcome: 'timed_out',
+        error: providerFailure(
+          'attempt_deadline_exceeded',
+          'The provider result retrieval exceeded the attempt deadline.',
+          false,
+          true,
+          'timeout',
+        ),
+        durable_handle: completedHandle,
+      },
+    };
+  }
+  if (retrieved.kind === 'error') {
+    return {
+      kind: 'finished',
+      finished: {
+        outcome: 'failed',
+        error: providerFailure(
+          'adapter_retrieve_failed',
+          'The provider result retrieval failed.',
+          true,
+        ),
+        durable_handle: completedHandle,
+      },
+    };
+  }
+  return resultOutcome(launch, retrieved.value, completedHandle);
 }
 
 /**
@@ -155,6 +232,8 @@ export function createNodeAttemptBridge(
         !resolved ||
         resolved.binding.adapter_id !== launch.binding.adapter_id ||
         resolved.binding.binding_id !== launch.binding.binding_id ||
+        resolved.catalog_digest !== launch.catalog_digest ||
+        !profilesMatch(launch.profile, resolved.profile) ||
         !provider ||
         provider.id !== launch.binding.adapter_id
       ) {
@@ -188,7 +267,7 @@ export function createNodeAttemptBridge(
         const executed = await beforeDeadline(
           (signal, remainingMs) =>
             provider.execute(launch.query, {
-              timeout: remainingMs,
+              timeout: providerTimeoutSeconds(remainingMs),
               signal,
             }),
           launch,
@@ -244,7 +323,10 @@ export function createNodeAttemptBridge(
 
       const submitted = await beforeDeadline(
         (signal, remainingMs) =>
-          provider.submit(launch.query, { timeout: remainingMs, signal }),
+          provider.submit(launch.query, {
+            timeout: providerTimeoutSeconds(remainingMs),
+            signal,
+          }),
         launch,
         now,
       );
@@ -274,6 +356,40 @@ export function createNodeAttemptBridge(
         // fallback so the coordinator retains the safe terminal marker.
         await context.submissionAcceptanceUnknown();
         return { kind: 'acceptance_unknown' };
+      }
+
+      if (task.status === 'failed') {
+        return {
+          kind: 'finished',
+          finished: {
+            outcome: 'failed',
+            error: providerFailure(
+              'provider_task_failed',
+              'The durable provider task failed.',
+              true,
+            ),
+            durable_handle: handle,
+          },
+        };
+      }
+      if (task.status === 'cancelled') {
+        return {
+          kind: 'finished',
+          finished: {
+            outcome: 'cancelled',
+            error: providerFailure(
+              'provider_task_cancelled',
+              'The durable provider task was cancelled.',
+              false,
+              false,
+              'cancelled',
+            ),
+            durable_handle: handle,
+          },
+        };
+      }
+      if (task.status === 'completed') {
+        return retrieveCompletedTask(provider, task, launch, handle, now);
       }
       if (context.mode === 'async') return { kind: 'accepted' };
 
@@ -335,47 +451,13 @@ export function createNodeAttemptBridge(
           await context.running();
         }
         if (poll.status === 'completed') {
-          const completedHandle = observedHandle(
-            latestHandle,
-            'succeeded',
-            now,
-          );
-          const retrieved = await beforeDeadline(
-            () => provider.retrieve(task),
+          return retrieveCompletedTask(
+            provider,
+            task,
             launch,
+            latestHandle,
             now,
           );
-          if (retrieved.kind === 'deadline') {
-            return {
-              kind: 'finished',
-              finished: {
-                outcome: 'timed_out',
-                error: providerFailure(
-                  'attempt_deadline_exceeded',
-                  'The provider result retrieval exceeded the attempt deadline.',
-                  false,
-                  true,
-                  'timeout',
-                ),
-                durable_handle: completedHandle,
-              },
-            };
-          }
-          if (retrieved.kind === 'error') {
-            return {
-              kind: 'finished',
-              finished: {
-                outcome: 'failed',
-                error: providerFailure(
-                  'adapter_retrieve_failed',
-                  'The provider result retrieval failed.',
-                  true,
-                ),
-                durable_handle: completedHandle,
-              },
-            };
-          }
-          return resultOutcome(launch, retrieved.value, completedHandle);
         }
         if (poll.status === 'failed') {
           return {

--- a/src/node-execution-bridge.ts
+++ b/src/node-execution-bridge.ts
@@ -1,0 +1,270 @@
+import type {
+  DurableHandle,
+  StructuredError,
+} from './contracts/domain/index.js';
+import type { AttemptLaunch } from './core/coordinator.js';
+import type {
+  AttemptExecutionContext,
+  AttemptExecutionPort,
+  AttemptExecutionResult,
+} from './core/execution-runtime.js';
+import type { AsyncTaskHandle, Provider, ProviderResult } from './types.js';
+
+export interface NodeExecutionBridgeDependencies {
+  /** Exact-id lookup only: aliases and selector policy are deliberately absent. */
+  resolveExactProvider(adapterId: string): Provider | undefined;
+  now?: () => number;
+  wait?: (milliseconds: number) => Promise<void>;
+}
+
+function providerFailure(
+  code: string,
+  message: string,
+  fallbackAllowed: boolean,
+): StructuredError {
+  return {
+    code,
+    message,
+    category: 'provider',
+    retryable: true,
+    fallback_allowed: fallbackAllowed,
+  };
+}
+
+function timeoutFor(launch: AttemptLaunch, now: () => number): number {
+  return Math.max(1, Date.parse(launch.deadline_at) - now());
+}
+
+function resultOutcome(
+  launch: AttemptLaunch,
+  result: ProviderResult,
+  completedHandle?: DurableHandle,
+): AttemptExecutionResult {
+  if (result.error) {
+    return {
+      kind: 'finished',
+      finished: {
+        outcome: 'failed',
+        error: providerFailure(
+          'provider_reported_error',
+          result.error,
+          result.preventFallback !== true,
+        ),
+      },
+      output: result,
+    };
+  }
+  return {
+    kind: 'finished',
+    finished: {
+      outcome: 'succeeded',
+      result_id: `result-${launch.attempt_id}`,
+      ...(completedHandle && { durable_handle: completedHandle }),
+    },
+    output: result,
+  };
+}
+
+function durableHandle(
+  launch: AttemptLaunch,
+  task: AsyncTaskHandle,
+  now: () => number,
+): DurableHandle {
+  return {
+    handle_id: launch.attempt_id,
+    provider_task_id: task.taskId,
+    provider: launch.profile.identity,
+    submitted_at: new Date(task.submittedAt || now()).toISOString(),
+    status: task.status === 'running' ? 'running' : 'pending',
+  };
+}
+
+function defaultWait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * Node-only compatibility bridge. A launch is already frozen to one binding;
+ * this bridge only resolves that exact adapter id and invokes its lifecycle.
+ */
+export function createNodeAttemptBridge(
+  dependencies: NodeExecutionBridgeDependencies,
+): AttemptExecutionPort {
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.wait ?? defaultWait;
+
+  return {
+    async execute(
+      launch: AttemptLaunch,
+      context: AttemptExecutionContext,
+    ): Promise<AttemptExecutionResult> {
+      const provider = dependencies.resolveExactProvider(
+        launch.binding.adapter_id,
+      );
+      if (!provider || provider.id !== launch.binding.adapter_id) {
+        return {
+          kind: 'finished',
+          finished: {
+            outcome: 'failed',
+            error: providerFailure(
+              'frozen_adapter_binding_unavailable',
+              `The frozen adapter binding ${launch.binding.adapter_id} is unavailable.`,
+              false,
+            ),
+          },
+        };
+      }
+
+      if (launch.profile.invocation === 'inline') {
+        if (provider.execution !== 'inline') {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error: providerFailure(
+                'frozen_adapter_execution_mismatch',
+                `The frozen inline binding ${launch.binding.adapter_id} resolved to a non-inline adapter.`,
+                false,
+              ),
+            },
+          };
+        }
+        try {
+          return resultOutcome(
+            launch,
+            await provider.execute(launch.query, {
+              timeout: timeoutFor(launch, now),
+            }),
+          );
+        } catch (error) {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error: providerFailure(
+                'adapter_execute_failed',
+                error instanceof Error ? error.message : String(error),
+                true,
+              ),
+            },
+          };
+        }
+      }
+
+      if (
+        launch.profile.resumability !== 'durable' ||
+        provider.execution !== 'background'
+      ) {
+        return {
+          kind: 'finished',
+          finished: {
+            outcome: 'failed',
+            error: providerFailure(
+              'frozen_adapter_execution_mismatch',
+              `The frozen durable binding ${launch.binding.adapter_id} does not expose a durable lifecycle.`,
+              false,
+            ),
+          },
+        };
+      }
+
+      let task: AsyncTaskHandle;
+      try {
+        task = await provider.submit(launch.query, {
+          timeout: timeoutFor(launch, now),
+        });
+      } catch {
+        // A rejected promise cannot prove that the remote side did not accept
+        // the request. Halt instead of retrying or spending a fallback.
+        await context.submissionAcceptanceUnknown();
+        return { kind: 'acceptance_unknown' };
+      }
+
+      const handle = durableHandle(launch, task, now);
+      // This await is the write-ahead boundary: no poll/retrieve occurs before
+      // the accepted handle has been persisted through the coordinator store.
+      try {
+        await context.submissionAccepted(handle);
+      } catch {
+        // A local persistence failure after submit is acceptance uncertainty,
+        // not a rejected provider request. Stop before any poll, retry, or
+        // fallback so the coordinator retains the safe terminal marker.
+        await context.submissionAcceptanceUnknown();
+        return { kind: 'acceptance_unknown' };
+      }
+      if (context.mode === 'async') return { kind: 'accepted' };
+
+      for (;;) {
+        if (now() >= Date.parse(launch.deadline_at)) {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'timed_out',
+              error: providerFailure(
+                'attempt_deadline_exceeded',
+                'The durable attempt exceeded its absolute deadline.',
+                true,
+              ),
+              durable_handle: handle,
+            },
+          };
+        }
+        let poll;
+        try {
+          poll = await provider.poll(task);
+        } catch (error) {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error: providerFailure(
+                'adapter_poll_failed',
+                error instanceof Error ? error.message : String(error),
+                true,
+              ),
+              durable_handle: handle,
+            },
+          };
+        }
+        if (poll.status === 'running') await context.running();
+        if (poll.status === 'completed') {
+          try {
+            return resultOutcome(launch, await provider.retrieve(task), {
+              ...handle,
+              status: 'succeeded',
+              last_observed_at: new Date(now()).toISOString(),
+            });
+          } catch (error) {
+            return {
+              kind: 'finished',
+              finished: {
+                outcome: 'failed',
+                error: providerFailure(
+                  'adapter_retrieve_failed',
+                  error instanceof Error ? error.message : String(error),
+                  true,
+                ),
+                durable_handle: handle,
+              },
+            };
+          }
+        }
+        if (poll.status === 'failed' || poll.status === 'cancelled') {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error: providerFailure(
+                'provider_task_failed',
+                poll.message ?? `The durable task ${poll.status}.`,
+                true,
+              ),
+              durable_handle: handle,
+            },
+          };
+        }
+        await wait(Math.min(context.poll_interval_ms, timeoutFor(launch, now)));
+      }
+    },
+  };
+}

--- a/src/node-execution-bridge.ts
+++ b/src/node-execution-bridge.ts
@@ -3,6 +3,7 @@ import type {
   StructuredError,
 } from './contracts/domain/index.js';
 import type { AttemptLaunch } from './core/coordinator.js';
+import type { AdapterBindingIdentity } from './core/execution-plan.js';
 import type {
   AttemptExecutionContext,
   AttemptExecutionPort,
@@ -11,8 +12,12 @@ import type {
 import type { AsyncTaskHandle, Provider, ProviderResult } from './types.js';
 
 export interface NodeExecutionBridgeDependencies {
-  /** Exact-id lookup only: aliases and selector policy are deliberately absent. */
-  resolveExactProvider(adapterId: string): Provider | undefined;
+  /** Exact binding lookup only: aliases and selector policy are absent. */
+  resolveExactBinding(
+    binding: AdapterBindingIdentity,
+  ):
+    | { readonly binding: AdapterBindingIdentity; readonly provider: Provider }
+    | undefined;
   now?: () => number;
   wait?: (milliseconds: number) => Promise<void>;
 }
@@ -21,14 +26,48 @@ function providerFailure(
   code: string,
   message: string,
   fallbackAllowed: boolean,
+  retryable = true,
+  category: StructuredError['category'] = 'provider',
 ): StructuredError {
   return {
     code,
     message,
-    category: 'provider',
-    retryable: true,
+    category,
+    retryable,
     fallback_allowed: fallbackAllowed,
   };
+}
+
+type DeadlineResult<T> =
+  | { readonly kind: 'value'; readonly value: T }
+  | { readonly kind: 'error'; readonly error: unknown }
+  | { readonly kind: 'deadline' };
+
+async function beforeDeadline<T>(
+  operation: (signal: AbortSignal, remainingMs: number) => Promise<T>,
+  launch: AttemptLaunch,
+  now: () => number,
+): Promise<DeadlineResult<T>> {
+  const remainingMs = Date.parse(launch.deadline_at) - now();
+  if (remainingMs <= 0) return { kind: 'deadline' };
+  const controller = new AbortController();
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: DeadlineResult<T>) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      controller.abort();
+      finish({ kind: 'deadline' });
+    }, remainingMs);
+    operation(controller.signal, remainingMs).then(
+      (value) => finish({ kind: 'value', value }),
+      (error: unknown) => finish({ kind: 'error', error }),
+    );
+  });
 }
 
 function timeoutFor(launch: AttemptLaunch, now: () => number): number {
@@ -47,7 +86,7 @@ function resultOutcome(
         outcome: 'failed',
         error: providerFailure(
           'provider_reported_error',
-          result.error,
+          'The provider returned an error.',
           result.preventFallback !== true,
         ),
       },
@@ -79,6 +118,18 @@ function durableHandle(
   };
 }
 
+function observedHandle(
+  handle: DurableHandle,
+  status: DurableHandle['status'],
+  now: () => number,
+): DurableHandle {
+  return {
+    ...handle,
+    status,
+    last_observed_at: new Date(now()).toISOString(),
+  };
+}
+
 function defaultWait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
@@ -98,10 +149,15 @@ export function createNodeAttemptBridge(
       launch: AttemptLaunch,
       context: AttemptExecutionContext,
     ): Promise<AttemptExecutionResult> {
-      const provider = dependencies.resolveExactProvider(
-        launch.binding.adapter_id,
-      );
-      if (!provider || provider.id !== launch.binding.adapter_id) {
+      const resolved = dependencies.resolveExactBinding(launch.binding);
+      const provider = resolved?.provider;
+      if (
+        !resolved ||
+        resolved.binding.adapter_id !== launch.binding.adapter_id ||
+        resolved.binding.binding_id !== launch.binding.binding_id ||
+        !provider ||
+        provider.id !== launch.binding.adapter_id
+      ) {
         return {
           kind: 'finished',
           finished: {
@@ -129,26 +185,44 @@ export function createNodeAttemptBridge(
             },
           };
         }
-        try {
-          return resultOutcome(
-            launch,
-            await provider.execute(launch.query, {
-              timeout: timeoutFor(launch, now),
+        const executed = await beforeDeadline(
+          (signal, remainingMs) =>
+            provider.execute(launch.query, {
+              timeout: remainingMs,
+              signal,
             }),
-          );
-        } catch (error) {
+          launch,
+          now,
+        );
+        if (executed.kind === 'deadline') {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'timed_out',
+              error: providerFailure(
+                'attempt_deadline_exceeded',
+                'The provider execution exceeded its absolute deadline.',
+                true,
+                true,
+                'timeout',
+              ),
+            },
+          };
+        }
+        if (executed.kind === 'error') {
           return {
             kind: 'finished',
             finished: {
               outcome: 'failed',
               error: providerFailure(
                 'adapter_execute_failed',
-                error instanceof Error ? error.message : String(error),
+                'The provider execution failed.',
                 true,
               ),
             },
           };
         }
+        return resultOutcome(launch, executed.value);
       }
 
       if (
@@ -168,23 +242,32 @@ export function createNodeAttemptBridge(
         };
       }
 
-      let task: AsyncTaskHandle;
-      try {
-        task = await provider.submit(launch.query, {
-          timeout: timeoutFor(launch, now),
-        });
-      } catch {
+      const submitted = await beforeDeadline(
+        (signal, remainingMs) =>
+          provider.submit(launch.query, { timeout: remainingMs, signal }),
+        launch,
+        now,
+      );
+      if (submitted.kind !== 'value') {
         // A rejected promise cannot prove that the remote side did not accept
         // the request. Halt instead of retrying or spending a fallback.
-        await context.submissionAcceptanceUnknown();
+        await context.submissionAcceptanceUnknown(
+          undefined,
+          submitted.kind === 'deadline'
+            ? 'submission_deadline_exceeded'
+            : 'submission_response_uncertain',
+        );
         return { kind: 'acceptance_unknown' };
       }
+      const task: AsyncTaskHandle = submitted.value;
 
       const handle = durableHandle(launch, task, now);
       // This await is the write-ahead boundary: no poll/retrieve occurs before
       // the accepted handle has been persisted through the coordinator store.
       try {
-        await context.submissionAccepted(handle);
+        if (!(await context.submissionAccepted(handle))) {
+          return { kind: 'acceptance_unknown' };
+        }
       } catch {
         // A local persistence failure after submit is acceptance uncertainty,
         // not a rejected provider request. Stop before any poll, retry, or
@@ -194,6 +277,7 @@ export function createNodeAttemptBridge(
       }
       if (context.mode === 'async') return { kind: 'accepted' };
 
+      let latestHandle = handle;
       for (;;) {
         if (now() >= Date.parse(launch.deadline_at)) {
           return {
@@ -203,63 +287,123 @@ export function createNodeAttemptBridge(
               error: providerFailure(
                 'attempt_deadline_exceeded',
                 'The durable attempt exceeded its absolute deadline.',
+                false,
                 true,
+                'timeout',
               ),
-              durable_handle: handle,
+              durable_handle: latestHandle,
             },
           };
         }
-        let poll;
-        try {
-          poll = await provider.poll(task);
-        } catch (error) {
+        const polled = await beforeDeadline(
+          () => provider.poll(task),
+          launch,
+          now,
+        );
+        if (polled.kind === 'deadline') {
           return {
             kind: 'finished',
             finished: {
-              outcome: 'failed',
+              outcome: 'timed_out',
               error: providerFailure(
-                'adapter_poll_failed',
-                error instanceof Error ? error.message : String(error),
+                'attempt_deadline_exceeded',
+                'The durable status check exceeded the attempt deadline.',
+                false,
                 true,
+                'timeout',
               ),
-              durable_handle: handle,
+              durable_handle: latestHandle,
             },
           };
         }
-        if (poll.status === 'running') await context.running();
+        if (polled.kind === 'error') {
+          await context.transientPollFailure(
+            providerFailure(
+              'adapter_poll_failed',
+              'The durable provider status check failed.',
+              false,
+            ),
+          );
+          await wait(
+            Math.min(context.poll_interval_ms, timeoutFor(launch, now)),
+          );
+          continue;
+        }
+        const poll = polled.value;
+        if (poll.status === 'running') {
+          latestHandle = observedHandle(latestHandle, 'running', now);
+          await context.running();
+        }
         if (poll.status === 'completed') {
-          try {
-            return resultOutcome(launch, await provider.retrieve(task), {
-              ...handle,
-              status: 'succeeded',
-              last_observed_at: new Date(now()).toISOString(),
-            });
-          } catch (error) {
+          const completedHandle = observedHandle(
+            latestHandle,
+            'succeeded',
+            now,
+          );
+          const retrieved = await beforeDeadline(
+            () => provider.retrieve(task),
+            launch,
+            now,
+          );
+          if (retrieved.kind === 'deadline') {
+            return {
+              kind: 'finished',
+              finished: {
+                outcome: 'timed_out',
+                error: providerFailure(
+                  'attempt_deadline_exceeded',
+                  'The provider result retrieval exceeded the attempt deadline.',
+                  false,
+                  true,
+                  'timeout',
+                ),
+                durable_handle: completedHandle,
+              },
+            };
+          }
+          if (retrieved.kind === 'error') {
             return {
               kind: 'finished',
               finished: {
                 outcome: 'failed',
                 error: providerFailure(
                   'adapter_retrieve_failed',
-                  error instanceof Error ? error.message : String(error),
+                  'The provider result retrieval failed.',
                   true,
                 ),
-                durable_handle: handle,
+                durable_handle: completedHandle,
               },
             };
           }
+          return resultOutcome(launch, retrieved.value, completedHandle);
         }
-        if (poll.status === 'failed' || poll.status === 'cancelled') {
+        if (poll.status === 'failed') {
           return {
             kind: 'finished',
             finished: {
               outcome: 'failed',
               error: providerFailure(
                 'provider_task_failed',
-                poll.message ?? `The durable task ${poll.status}.`,
+                'The durable provider task failed.',
                 true,
               ),
-              durable_handle: handle,
+              durable_handle: observedHandle(latestHandle, 'failed', now),
+            },
+          };
+        }
+        if (poll.status === 'cancelled') {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'cancelled',
+              error: providerFailure(
+                'provider_task_cancelled',
+                'The durable provider task was cancelled.',
+                false,
+                false,
+                'cancelled',
+              ),
+              durable_handle: observedHandle(latestHandle, 'cancelled', now),
             },
           };
         }

--- a/src/node-execution-bridge.ts
+++ b/src/node-execution-bridge.ts
@@ -3,7 +3,10 @@ import type {
   ExecutionProfile,
   StructuredError,
 } from './contracts/domain/index.js';
-import { ExecutionProfileSchema } from './contracts/domain/index.js';
+import {
+  ExecutionProfileSchema,
+  executionProfilesEqual,
+} from './contracts/domain/index.js';
 import type { AttemptLaunch } from './core/coordinator.js';
 import type { AdapterBindingIdentity } from './core/execution-plan.js';
 import type {
@@ -94,7 +97,7 @@ function profilesMatch(
   return (
     parsedExpected.success &&
     parsedActual.success &&
-    JSON.stringify(parsedExpected.data) === JSON.stringify(parsedActual.data)
+    executionProfilesEqual(parsedExpected.data, parsedActual.data)
   );
 }
 
@@ -135,11 +138,7 @@ function durableHandle(
   now: () => number,
 ): DurableHandle {
   const status: DurableHandle['status'] =
-    task.status === 'completed'
-      ? 'succeeded'
-      : task.status === 'failed' || task.status === 'cancelled'
-        ? task.status
-        : task.status;
+    task.status === 'completed' ? 'succeeded' : task.status;
   return {
     handle_id: launch.attempt_id,
     provider_task_id: task.taskId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type AsyncTaskStatus =
 
 // Provider options passed to execute/submit
 export interface ProviderOptions {
+  /** Relative operation timeout in seconds. */
   timeout: number;
   signal?: AbortSignal;
 }

--- a/tests/coordinator.test.ts
+++ b/tests/coordinator.test.ts
@@ -939,18 +939,10 @@ describe('durable handles and terminal mapping', () => {
     let state = startAll(preparedExecution({ primaries: [profile] }), deps);
     const attemptId = state.attempts[0]?.attempt_id ?? '';
 
-    expect(() =>
-      recordSubmissionAccepted(
-        state,
-        attemptId,
-        handle(profile, 'succeeded'),
-        deps,
-      ),
-    ).toThrow('must be pending or running');
     state = recordSubmissionAccepted(
       state,
       attemptId,
-      handle(profile, 'pending'),
+      handle(profile, 'succeeded'),
       deps,
       'adapter-state-ref',
     );

--- a/tests/custom-providers.test.ts
+++ b/tests/custom-providers.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -266,6 +266,62 @@ describe('custom providers', () => {
     expect(retrieved.content).toBe('retrieved:task-123');
     const health = await provider!.test!();
     expect(health.ok).toBe(true);
+  });
+
+  it('aborts and kills a hanging script provider operation', async () => {
+    const scriptPath = join(tmpDir, 'abortable-script-provider.mjs');
+    const pidPath = join(tmpDir, 'abortable-script-provider.pid');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { readFileSync, writeFileSync } from 'node:fs';",
+        'const input = JSON.parse(readFileSync(0, "utf-8"));',
+        'if (input.operation === "describe") {',
+        '  process.stdout.write(JSON.stringify({ ok: true, data: {',
+        "    displayName: 'Abortable Script', tier: 'raw-search', execution: 'inline',",
+        '    requiresApiKey: false, capabilities: { execute: true }',
+        '  }}));',
+        '} else {',
+        '  writeFileSync(input.sourceOptions.pidPath, String(process.pid));',
+        '  setInterval(() => {}, 1000);',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const initResult = await initializeProviders({
+      providers: { abortable: { enabled: true } },
+      customProviders: {
+        abortable: {
+          type: 'script',
+          command: 'node',
+          args: [scriptPath],
+          options: { pidPath },
+        },
+      },
+      trustedProviderIds: ['abortable'],
+    });
+    expect(initResult.warnings).toEqual([]);
+
+    const provider = getProvider('abortable');
+    expect(provider?.execution).toBe('inline');
+    const controller = new AbortController();
+    const execution = provider!.execute('hang', {
+      timeout: 30,
+      signal: controller.signal,
+    });
+
+    await vi.waitFor(() => {
+      expect(readFileSync(pidPath, 'utf-8')).toMatch(/^\d+$/);
+    });
+    const childPid = Number(readFileSync(pidPath, 'utf-8'));
+    controller.abort();
+
+    await expect(execution).rejects.toThrow('was aborted');
+    await vi.waitFor(() => {
+      expect(() => process.kill(childPid, 0)).toThrow();
+    });
   });
 
   it('skips malformed script providers', async () => {

--- a/tests/execution-plan.test.ts
+++ b/tests/execution-plan.test.ts
@@ -7,6 +7,7 @@ import {
   type FrozenPlanningCatalog,
   type PlanningProfile,
   prepareResearchExecution,
+  profileIdentityKey,
 } from '../src/core/execution-plan.js';
 import {
   CanonicalResearchRequestSchema,
@@ -417,6 +418,35 @@ describe('research execution preparation', () => {
         '/catalog/profiles/1/binding/adapter_id',
       ],
     ]);
+  });
+
+  it('rejects one adapter binding pair assigned to multiple catalog profiles', () => {
+    const sharedBinding = {
+      adapter_id: 'adapter-shared',
+      binding_id: 'binding-shared',
+    };
+    const result = prepareResearchExecution(
+      targetRequest(),
+      new FixtureCatalog([
+        planningProfile(groundedProfile('alpha'), {
+          binding: sharedBinding,
+        }),
+        planningProfile(groundedProfile('beta'), {
+          binding: sharedBinding,
+        }),
+      ]),
+      dependencies(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'catalog_binding_duplicate',
+        path: '/catalog/profiles/1/binding',
+        profile_key: profileIdentityKey(groundedProfile('beta').identity),
+      }),
+    );
   });
 
   it('rejects unbounded catalog identity metadata without reflecting it', () => {

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ExecutionProfile } from '../src/contracts/domain/index.js';
-import { InMemoryCoordinationStateStore } from '../src/core/coordinator-store.js';
+import type { CoordinatorState } from '../src/core/coordinator.js';
+import {
+  type CoordinationCompareAndSwapResult,
+  type CoordinationStateStore,
+  InMemoryCoordinationStateStore,
+  type VersionedCoordinationState,
+} from '../src/core/coordinator-store.js';
 import type { PreparedResearchExecution } from '../src/core/execution-plan.js';
 import { profileIdentityKey } from '../src/core/execution-plan.js';
 import {
@@ -43,6 +49,7 @@ function profile(
 function prepared(
   primaries: readonly ExecutionProfile[],
   reserve: readonly ExecutionProfile[] = [],
+  mode: 'sync' | 'async' = 'sync',
 ): PreparedResearchExecution {
   const all = [...primaries, ...reserve];
   const plans = Object.fromEntries(
@@ -64,7 +71,7 @@ function prepared(
       message_type: 'request',
       request_id: 'runtime-request',
       requested_at: new Date(start).toISOString(),
-      mode: 'sync',
+      mode,
       query: 'runtime query',
       slots: primaries.map((item, position) => ({
         slot_id: `slot-${position}`,
@@ -114,6 +121,17 @@ function coordinatorDependencies() {
   };
 }
 
+function systemCoordinatorDependencies() {
+  let next = 0;
+  return {
+    clock: { now: Date.now },
+    ids: {
+      next: (scope: 'attempt' | 'event' | 'delivery_lease') =>
+        `${scope}-${++next}`,
+    },
+  };
+}
+
 function mutableCoordinatorDependencies() {
   let now = start;
   let next = 0;
@@ -139,6 +157,56 @@ function successfulResult(provider: string): ProviderResult {
   };
 }
 
+function resolvedBinding(providerId: string, provider: Provider) {
+  return {
+    binding: {
+      adapter_id: `adapter-${providerId}`,
+      binding_id: `binding-${providerId}`,
+    },
+    provider,
+  };
+}
+
+class LoseDispatchLeaseStore implements CoordinationStateStore {
+  readonly inner = new InMemoryCoordinationStateStore();
+  lostDispatch = false;
+
+  load(requestId: string): Promise<VersionedCoordinationState | undefined> {
+    return this.inner.load(requestId);
+  }
+
+  create(state: CoordinatorState): Promise<VersionedCoordinationState> {
+    return this.inner.create(state);
+  }
+
+  async compareAndSwap(
+    requestId: string,
+    expectedVersion: number,
+    state: CoordinatorState,
+  ): Promise<CoordinationCompareAndSwapResult> {
+    if (
+      !this.lostDispatch &&
+      state.attempts.some(
+        (attempt) =>
+          attempt.status === 'running' || attempt.status === 'submitting',
+      )
+    ) {
+      this.lostDispatch = true;
+      const wonElsewhere = await this.inner.compareAndSwap(
+        requestId,
+        expectedVersion,
+        state,
+      );
+      expect(wonElsewhere.ok).toBe(true);
+      return {
+        ok: false,
+        current: await this.inner.load(requestId),
+      };
+    }
+    return this.inner.compareAndSwap(requestId, expectedVersion, state);
+  }
+}
+
 describe('private prepared execution runtime', () => {
   it('executes only the frozen adapter binding and never performs provider selection', async () => {
     const exact: Provider = {
@@ -149,8 +217,10 @@ describe('private prepared execution runtime', () => {
       execution: 'inline',
       execute: vi.fn(async () => successfulResult('adapter-primary')),
     };
-    const resolveExactProvider = vi.fn((id: string) =>
-      id === 'adapter-primary' ? exact : undefined,
+    const resolveExactBinding = vi.fn((binding) =>
+      binding.adapter_id === 'adapter-primary'
+        ? resolvedBinding('primary', exact)
+        : undefined,
     );
     const plan = prepared([profile('primary')]);
     const store = new InMemoryCoordinationStateStore();
@@ -158,17 +228,19 @@ describe('private prepared execution runtime', () => {
       store,
       coordinator: coordinatorDependencies(),
       attempts: createNodeAttemptBridge({
-        resolveExactProvider,
+        resolveExactBinding,
         now: () => start,
       }),
     });
 
-    expect(resolveExactProvider).toHaveBeenCalledExactlyOnceWith(
-      'adapter-primary',
-    );
-    expect(exact.execute).toHaveBeenCalledExactlyOnceWith('runtime query', {
-      timeout: 10_000,
+    expect(resolveExactBinding).toHaveBeenCalledExactlyOnceWith({
+      adapter_id: 'adapter-primary',
+      binding_id: 'binding-primary',
     });
+    expect(exact.execute).toHaveBeenCalledExactlyOnceWith(
+      'runtime query',
+      expect.objectContaining({ timeout: 10_000, signal: expect.anything() }),
+    );
     expect(result.state.status).toBe('succeeded');
     expect(result.outputs_by_attempt).toEqual(
       expect.objectContaining({
@@ -209,16 +281,19 @@ describe('private prepared execution runtime', () => {
         store,
         coordinator: coordinatorDependencies(),
         attempts: createNodeAttemptBridge({
-          resolveExactProvider: (id) =>
-            id === 'adapter-durable' ? durable : undefined,
+          resolveExactBinding: (binding) =>
+            binding.adapter_id === 'adapter-durable'
+              ? resolvedBinding('durable', durable)
+              : undefined,
           now: () => start,
         }),
       },
     );
 
-    expect(durable.submit).toHaveBeenCalledWith('runtime query', {
-      timeout: 20_000,
-    });
+    expect(durable.submit).toHaveBeenCalledWith(
+      'runtime query',
+      expect.objectContaining({ timeout: 20_000, signal: expect.anything() }),
+    );
     expect(durable.poll).toHaveBeenCalledOnce();
     expect(durable.retrieve).toHaveBeenCalledOnce();
     expect(result.state.status).toBe('succeeded');
@@ -253,11 +328,11 @@ describe('private prepared execution runtime', () => {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
         attempts: createNodeAttemptBridge({
-          resolveExactProvider: (id) =>
-            id === 'adapter-durable'
-              ? durable
-              : id === 'adapter-reserve'
-                ? fallback
+          resolveExactBinding: (binding) =>
+            binding.adapter_id === 'adapter-durable'
+              ? resolvedBinding('durable', durable)
+              : binding.adapter_id === 'adapter-reserve'
+                ? resolvedBinding('reserve', fallback)
                 : undefined,
           now: () => start,
         }),
@@ -401,5 +476,505 @@ describe('private prepared execution runtime', () => {
     expect(
       result.state.slots.every((slot) => slot.status === 'succeeded'),
     ).toBe(true);
+  });
+
+  it('rejects a resolver result whose binding id differs from the frozen launch', async () => {
+    const execute = vi.fn(async () => successfulResult('adapter-primary'));
+    const provider: Provider = {
+      id: 'adapter-primary',
+      displayName: 'Primary',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute,
+    };
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: coordinatorDependencies(),
+      attempts: createNodeAttemptBridge({
+        resolveExactBinding: () => ({
+          binding: {
+            adapter_id: 'adapter-primary',
+            binding_id: 'different-binding',
+          },
+          provider,
+        }),
+        now: () => start,
+      }),
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'frozen_adapter_binding_unavailable',
+        fallback_allowed: false,
+      },
+    });
+  });
+
+  it('keeps polling through transient errors and repeated running states before fallback', async () => {
+    const pollSteps: Array<Error | { status: 'running' | 'failed' }> = [
+      new Error('Bearer secret-token'),
+      { status: 'running' },
+      { status: 'running' },
+      { status: 'failed' },
+    ];
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit: vi.fn(async () => ({
+        provider: 'adapter-durable',
+        taskId: 'task-running',
+        query: 'runtime query',
+        submittedAt: start,
+        status: 'pending' as const,
+      })),
+      poll: vi.fn(async () => {
+        const step = pollSteps.shift();
+        if (step instanceof Error) throw step;
+        if (!step) throw new Error('missing poll step');
+        return step;
+      }),
+      retrieve: vi.fn(),
+    };
+    const reserveExecute = vi.fn(async () =>
+      successfulResult('adapter-reserve'),
+    );
+    const reserve: Provider = {
+      id: 'adapter-reserve',
+      displayName: 'Reserve',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: reserveExecute,
+    };
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [profile('reserve')]),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactBinding: (binding) =>
+            binding.adapter_id === 'adapter-durable'
+              ? resolvedBinding('durable', durable)
+              : binding.adapter_id === 'adapter-reserve'
+                ? resolvedBinding('reserve', reserve)
+                : undefined,
+          now: () => start,
+          wait: async () => {},
+        }),
+      },
+    );
+
+    expect(durable.poll).toHaveBeenCalledTimes(4);
+    expect(reserveExecute).toHaveBeenCalledOnce();
+    expect(result.state.status).toBe('succeeded');
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'failed',
+      durable_handle: { status: 'failed' },
+      error: {
+        code: 'provider_task_failed',
+        fallback_allowed: true,
+      },
+    });
+    expect(JSON.stringify(result.state)).not.toContain('secret-token');
+  });
+
+  it('returns an async accepted handle without polling or retrieving', async () => {
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit: vi.fn(async () => ({
+        provider: 'adapter-durable',
+        taskId: 'async-task',
+        query: 'runtime query',
+        submittedAt: start,
+        status: 'pending' as const,
+      })),
+      poll: vi.fn(),
+      retrieve: vi.fn(),
+    };
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [], 'async'),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactBinding: () => resolvedBinding('durable', durable),
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(result.state.status).toBe('running');
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'submitted',
+      durable_handle: { provider_task_id: 'async-task', status: 'pending' },
+    });
+    expect(result.outputs_by_attempt).toEqual({});
+    expect(durable.poll).not.toHaveBeenCalled();
+    expect(durable.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('times out a hung inline call and executes an eligible fallback', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(start);
+    try {
+      const primary: Provider = {
+        id: 'adapter-primary',
+        displayName: 'Primary',
+        tier: 'raw-search',
+        envVar: '',
+        execution: 'inline',
+        execute: vi.fn(() => new Promise<ProviderResult>(() => {})),
+      };
+      const reserveExecute = vi.fn(async () =>
+        successfulResult('adapter-reserve'),
+      );
+      const reserve: Provider = {
+        id: 'adapter-reserve',
+        displayName: 'Reserve',
+        tier: 'raw-search',
+        envVar: '',
+        execution: 'inline',
+        execute: reserveExecute,
+      };
+      const running = runPreparedExecution(
+        prepared([profile('primary')], [profile('reserve')]),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: systemCoordinatorDependencies(),
+          attempts: createNodeAttemptBridge({
+            resolveExactBinding: (binding) =>
+              binding.adapter_id === 'adapter-primary'
+                ? resolvedBinding('primary', primary)
+                : binding.adapter_id === 'adapter-reserve'
+                  ? resolvedBinding('reserve', reserve)
+                  : undefined,
+            now: Date.now,
+          }),
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await running;
+      expect(result.state.attempts[0]).toMatchObject({
+        status: 'timed_out',
+        error: { code: 'attempt_deadline_exceeded', fallback_allowed: true },
+      });
+      expect(reserveExecute).toHaveBeenCalledOnce();
+      expect(result.state.status).toBe('succeeded');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('turns a hung submit into acceptance uncertainty without fallback', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(start);
+    try {
+      const submit = vi.fn(() => new Promise<never>(() => {}));
+      const durable: Provider = {
+        id: 'adapter-durable',
+        displayName: 'Durable',
+        tier: 'deep-research',
+        envVar: '',
+        execution: 'background',
+        execute: vi.fn(),
+        submit,
+        poll: vi.fn(),
+        retrieve: vi.fn(),
+      };
+      const reserveExecute = vi.fn(async () =>
+        successfulResult('adapter-reserve'),
+      );
+      const reserve: Provider = {
+        id: 'adapter-reserve',
+        displayName: 'Reserve',
+        tier: 'raw-search',
+        envVar: '',
+        execution: 'inline',
+        execute: reserveExecute,
+      };
+      const running = runPreparedExecution(
+        prepared([profile('durable', 'background')], [profile('reserve')]),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: systemCoordinatorDependencies(),
+          attempts: createNodeAttemptBridge({
+            resolveExactBinding: (binding) =>
+              binding.adapter_id === 'adapter-durable'
+                ? resolvedBinding('durable', durable)
+                : binding.adapter_id === 'adapter-reserve'
+                  ? resolvedBinding('reserve', reserve)
+                  : undefined,
+            now: Date.now,
+          }),
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(20_000);
+      const result = await running;
+      expect(submit).toHaveBeenCalledOnce();
+      expect(result.state.attempts[0]?.status).toBe('acceptance_unknown');
+      expect(result.state.unresolved_acceptances[0]).toMatchObject({
+        reason: 'submission_deadline_exceeded',
+      });
+      expect(reserveExecute).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not fall back when an accepted durable poll exceeds its deadline', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(start);
+    try {
+      const durable: Provider = {
+        id: 'adapter-durable',
+        displayName: 'Durable',
+        tier: 'deep-research',
+        envVar: '',
+        execution: 'background',
+        execute: vi.fn(),
+        submit: vi.fn(async () => ({
+          provider: 'adapter-durable',
+          taskId: 'hung-poll',
+          query: 'runtime query',
+          submittedAt: start,
+          status: 'pending' as const,
+        })),
+        poll: vi.fn(() => new Promise<never>(() => {})),
+        retrieve: vi.fn(),
+      };
+      const reserveExecute = vi.fn(async () =>
+        successfulResult('adapter-reserve'),
+      );
+      const reserve: Provider = {
+        id: 'adapter-reserve',
+        displayName: 'Reserve',
+        tier: 'raw-search',
+        envVar: '',
+        execution: 'inline',
+        execute: reserveExecute,
+      };
+      const running = runPreparedExecution(
+        prepared([profile('durable', 'background')], [profile('reserve')]),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: systemCoordinatorDependencies(),
+          attempts: createNodeAttemptBridge({
+            resolveExactBinding: (binding) =>
+              binding.adapter_id === 'adapter-durable'
+                ? resolvedBinding('durable', durable)
+                : binding.adapter_id === 'adapter-reserve'
+                  ? resolvedBinding('reserve', reserve)
+                  : undefined,
+            now: Date.now,
+          }),
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(20_000);
+      const result = await running;
+      expect(result.state.attempts[0]).toMatchObject({
+        status: 'timed_out',
+        durable_handle: { provider_task_id: 'hung-poll', status: 'pending' },
+        error: {
+          code: 'accepted_durable_attempt_deadline_exceeded',
+          fallback_allowed: false,
+        },
+      });
+      expect(reserveExecute).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves a succeeded handle when retrieval fails and permits fallback', async () => {
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit: vi.fn(async () => ({
+        provider: 'adapter-durable',
+        taskId: 'retrieve-failure',
+        query: 'runtime query',
+        submittedAt: start,
+        status: 'pending' as const,
+      })),
+      poll: vi.fn(async () => ({ status: 'completed' as const })),
+      retrieve: vi.fn(async () => {
+        throw new Error('Authorization: secret-token');
+      }),
+    };
+    const reserveExecute = vi.fn(async () =>
+      successfulResult('adapter-reserve'),
+    );
+    const reserve: Provider = {
+      id: 'adapter-reserve',
+      displayName: 'Reserve',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: reserveExecute,
+    };
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [profile('reserve')]),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactBinding: (binding) =>
+            binding.adapter_id === 'adapter-durable'
+              ? resolvedBinding('durable', durable)
+              : binding.adapter_id === 'adapter-reserve'
+                ? resolvedBinding('reserve', reserve)
+                : undefined,
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'failed',
+      durable_handle: { status: 'succeeded' },
+      error: { code: 'adapter_retrieve_failed', fallback_allowed: true },
+    });
+    expect(JSON.stringify(result.state)).not.toContain('secret-token');
+    expect(reserveExecute).toHaveBeenCalledOnce();
+    expect(result.state.status).toBe('succeeded');
+  });
+
+  it('does not spend a fallback after provider-side durable cancellation', async () => {
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit: vi.fn(async () => ({
+        provider: 'adapter-durable',
+        taskId: 'cancelled-task',
+        query: 'runtime query',
+        submittedAt: start,
+        status: 'pending' as const,
+      })),
+      poll: vi.fn(async () => ({ status: 'cancelled' as const })),
+      retrieve: vi.fn(),
+    };
+    const reserveExecute = vi.fn(async () =>
+      successfulResult('adapter-reserve'),
+    );
+    const reserve: Provider = {
+      id: 'adapter-reserve',
+      displayName: 'Reserve',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: reserveExecute,
+    };
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [profile('reserve')]),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactBinding: (binding) =>
+            binding.adapter_id === 'adapter-durable'
+              ? resolvedBinding('durable', durable)
+              : binding.adapter_id === 'adapter-reserve'
+                ? resolvedBinding('reserve', reserve)
+                : undefined,
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'cancelled',
+      durable_handle: { status: 'cancelled' },
+      error: { code: 'provider_task_cancelled', fallback_allowed: false },
+    });
+    expect(reserveExecute).not.toHaveBeenCalled();
+  });
+
+  it('does not execute after losing the dispatch lease CAS race', async () => {
+    const store = new LoseDispatchLeaseStore();
+    const attempts: AttemptExecutionPort = { execute: vi.fn() };
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store,
+      coordinator: coordinatorDependencies(),
+      attempts,
+    });
+
+    expect(store.lostDispatch).toBe(true);
+    expect(attempts.execute).not.toHaveBeenCalled();
+    expect(result.state.attempts[0]?.status).toBe('running');
+  });
+
+  it('derives enough CAS retries for the maximum concurrent completion wave', async () => {
+    const primaries = Array.from({ length: 64 }, (_, index) =>
+      profile(`primary-${index}`),
+    );
+    const result = await runPreparedExecution(prepared(primaries), {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: coordinatorDependencies(),
+      attempts: {
+        execute: async (launch) => ({
+          kind: 'finished',
+          finished: {
+            outcome: 'succeeded',
+            result_id: `result-${launch.attempt_id}`,
+          },
+        }),
+      },
+    });
+
+    expect(result.state.status).toBe('succeeded');
+    expect(result.state.attempts).toHaveLength(64);
+  });
+
+  it('bounds persisted provider diagnostics', async () => {
+    const provider: Provider = {
+      id: 'adapter-primary',
+      displayName: 'Primary',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => ({
+        ...successfulResult('adapter-primary'),
+        error: `Bearer secret-token ${'x'.repeat(3_000)}`,
+      })),
+    };
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: coordinatorDependencies(),
+      attempts: createNodeAttemptBridge({
+        resolveExactBinding: () => resolvedBinding('primary', provider),
+        now: () => start,
+      }),
+    });
+
+    expect(result.state.attempts[0]?.error).toEqual(
+      expect.objectContaining({
+        code: 'provider_reported_error',
+        message: 'The provider returned an error.',
+      }),
+    );
+    expect(JSON.stringify(result.state)).not.toContain('secret-token');
   });
 });

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -157,12 +157,22 @@ function successfulResult(provider: string): ProviderResult {
   };
 }
 
-function resolvedBinding(providerId: string, provider: Provider) {
+function resolvedBinding(
+  providerId: string,
+  provider: Provider,
+  resolvedProfile: ExecutionProfile = profile(
+    providerId,
+    provider.execution === 'background' ? 'background' : 'inline',
+  ),
+  catalogDigest = 'runtime-digest',
+) {
   return {
     binding: {
       adapter_id: `adapter-${providerId}`,
       binding_id: `binding-${providerId}`,
     },
+    profile: resolvedProfile,
+    catalog_digest: catalogDigest,
     provider,
   };
 }
@@ -207,6 +217,46 @@ class LoseDispatchLeaseStore implements CoordinationStateStore {
   }
 }
 
+class AdvanceClockAfterLeaseStore implements CoordinationStateStore {
+  readonly inner = new InMemoryCoordinationStateStore();
+  advanced = false;
+
+  constructor(private readonly advance: () => void) {}
+
+  load(requestId: string): Promise<VersionedCoordinationState | undefined> {
+    return this.inner.load(requestId);
+  }
+
+  create(state: CoordinatorState): Promise<VersionedCoordinationState> {
+    return this.inner.create(state);
+  }
+
+  async compareAndSwap(
+    requestId: string,
+    expectedVersion: number,
+    state: CoordinatorState,
+  ): Promise<CoordinationCompareAndSwapResult> {
+    const result = await this.inner.compareAndSwap(
+      requestId,
+      expectedVersion,
+      state,
+    );
+    if (
+      result.ok &&
+      !this.advanced &&
+      state.attempts.some(
+        (attempt) =>
+          attempt.status === 'dispatch_pending' &&
+          attempt.delivery_lease_id !== undefined,
+      )
+    ) {
+      this.advanced = true;
+      this.advance();
+    }
+    return result;
+  }
+}
+
 describe('private prepared execution runtime', () => {
   it('executes only the frozen adapter binding and never performs provider selection', async () => {
     const exact: Provider = {
@@ -239,7 +289,7 @@ describe('private prepared execution runtime', () => {
     });
     expect(exact.execute).toHaveBeenCalledExactlyOnceWith(
       'runtime query',
-      expect.objectContaining({ timeout: 10_000, signal: expect.anything() }),
+      expect.objectContaining({ timeout: 10, signal: expect.anything() }),
     );
     expect(result.state.status).toBe('succeeded');
     expect(result.outputs_by_attempt).toEqual(
@@ -292,7 +342,7 @@ describe('private prepared execution runtime', () => {
 
     expect(durable.submit).toHaveBeenCalledWith(
       'runtime query',
-      expect.objectContaining({ timeout: 20_000, signal: expect.anything() }),
+      expect.objectContaining({ timeout: 20, signal: expect.anything() }),
     );
     expect(durable.poll).toHaveBeenCalledOnce();
     expect(durable.retrieve).toHaveBeenCalledOnce();
@@ -497,6 +547,8 @@ describe('private prepared execution runtime', () => {
             adapter_id: 'adapter-primary',
             binding_id: 'different-binding',
           },
+          profile: profile('primary'),
+          catalog_digest: 'runtime-digest',
           provider,
         }),
         now: () => start,
@@ -512,6 +564,59 @@ describe('private prepared execution runtime', () => {
       },
     });
   });
+
+  it.each([
+    {
+      name: 'execution profile',
+      resolvedProfile: profile('different-profile'),
+      catalogDigest: 'runtime-digest',
+    },
+    {
+      name: 'catalog digest',
+      resolvedProfile: profile('primary'),
+      catalogDigest: 'different-digest',
+    },
+  ])(
+    'rejects a resolver result with a mismatched frozen $name',
+    async ({ resolvedProfile, catalogDigest }) => {
+      const execute = vi.fn(async () => successfulResult('adapter-primary'));
+      const provider: Provider = {
+        id: 'adapter-primary',
+        displayName: 'Primary',
+        tier: 'raw-search',
+        envVar: '',
+        execution: 'inline',
+        execute,
+      };
+
+      const result = await runPreparedExecution(
+        prepared([profile('primary')]),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: coordinatorDependencies(),
+          attempts: createNodeAttemptBridge({
+            resolveExactBinding: () =>
+              resolvedBinding(
+                'primary',
+                provider,
+                resolvedProfile,
+                catalogDigest,
+              ),
+            now: () => start,
+          }),
+        },
+      );
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(result.state.attempts[0]).toMatchObject({
+        status: 'failed',
+        error: {
+          code: 'frozen_adapter_binding_unavailable',
+          fallback_allowed: false,
+        },
+      });
+    },
+  );
 
   it('keeps polling through transient errors and repeated running states before fallback', async () => {
     const pollSteps: Array<Error | { status: 'running' | 'failed' }> = [
@@ -625,17 +730,171 @@ describe('private prepared execution runtime', () => {
     expect(durable.retrieve).not.toHaveBeenCalled();
   });
 
+  it('retrieves an already-completed durable submission in async mode', async () => {
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit: vi.fn(async () => ({
+        provider: 'adapter-durable',
+        taskId: 'already-completed',
+        query: 'runtime query',
+        submittedAt: start,
+        status: 'completed' as const,
+      })),
+      poll: vi.fn(),
+      retrieve: vi.fn(async () => successfulResult('adapter-durable')),
+    };
+
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [], 'async'),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactBinding: () => resolvedBinding('durable', durable),
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(result.state.status).toBe('succeeded');
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'succeeded',
+      durable_handle: {
+        provider_task_id: 'already-completed',
+        status: 'succeeded',
+      },
+    });
+    expect(durable.poll).not.toHaveBeenCalled();
+    expect(durable.retrieve).toHaveBeenCalledOnce();
+    expect(result.outputs_by_attempt).toEqual(
+      expect.objectContaining({
+        'attempt-2': expect.objectContaining({ content: 'done' }),
+      }),
+    );
+  });
+
+  it.each([
+    {
+      taskStatus: 'failed' as const,
+      attemptStatus: 'failed',
+      errorCode: 'provider_task_failed',
+    },
+    {
+      taskStatus: 'cancelled' as const,
+      attemptStatus: 'cancelled',
+      errorCode: 'provider_task_cancelled',
+    },
+  ])(
+    'terminalizes an already-$taskStatus durable submission without polling',
+    async ({ taskStatus, attemptStatus, errorCode }) => {
+      const durable: Provider = {
+        id: 'adapter-durable',
+        displayName: 'Durable',
+        tier: 'deep-research',
+        envVar: '',
+        execution: 'background',
+        execute: vi.fn(),
+        submit: vi.fn(async () => ({
+          provider: 'adapter-durable',
+          taskId: `already-${taskStatus}`,
+          query: 'runtime query',
+          submittedAt: start,
+          status: taskStatus,
+        })),
+        poll: vi.fn(),
+        retrieve: vi.fn(),
+      };
+
+      const result = await runPreparedExecution(
+        prepared([profile('durable', 'background')], [], 'async'),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: coordinatorDependencies(),
+          attempts: createNodeAttemptBridge({
+            resolveExactBinding: () => resolvedBinding('durable', durable),
+            now: () => start,
+          }),
+        },
+      );
+
+      expect(result.state.attempts[0]).toMatchObject({
+        status: attemptStatus,
+        durable_handle: { status: taskStatus },
+        error: { code: errorCode },
+      });
+      expect(durable.poll).not.toHaveBeenCalled();
+      expect(durable.retrieve).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps accepted durable work resumable after a local execution exception', async () => {
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [], 'async'),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: {
+          execute: async (launch, context) => {
+            await context.submissionAccepted({
+              handle_id: launch.attempt_id,
+              provider_task_id: 'accepted-before-local-error',
+              provider: launch.profile.identity,
+              submitted_at: new Date(start).toISOString(),
+              status: 'pending',
+            });
+            throw new Error('Authorization: secret-after-acceptance');
+          },
+        },
+      },
+    );
+
+    expect(result.state.status).toBe('running');
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'submitted',
+      durable_handle: {
+        provider_task_id: 'accepted-before-local-error',
+        status: 'pending',
+      },
+      transient_poll_error: {
+        code: 'attempt_execution_interrupted',
+        fallback_allowed: false,
+        retryable: true,
+      },
+    });
+    expect(JSON.stringify(result.state)).not.toContain(
+      'secret-after-acceptance',
+    );
+  });
+
   it('times out a hung inline call and executes an eligible fallback', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(start);
     try {
+      let aborted = false;
       const primary: Provider = {
         id: 'adapter-primary',
         displayName: 'Primary',
         tier: 'raw-search',
         envVar: '',
         execution: 'inline',
-        execute: vi.fn(() => new Promise<ProviderResult>(() => {})),
+        execute: vi.fn(
+          (_query, options) =>
+            new Promise<ProviderResult>((_resolve, reject) => {
+              options.signal?.addEventListener(
+                'abort',
+                () => {
+                  aborted = true;
+                  reject(new Error('aborted by deadline'));
+                },
+                { once: true },
+              );
+            }),
+        ),
       };
       const reserveExecute = vi.fn(async () =>
         successfulResult('adapter-reserve'),
@@ -672,6 +931,7 @@ describe('private prepared execution runtime', () => {
         error: { code: 'attempt_deadline_exceeded', fallback_allowed: true },
       });
       expect(reserveExecute).toHaveBeenCalledOnce();
+      expect(aborted).toBe(true);
       expect(result.state.status).toBe('succeeded');
     } finally {
       vi.useRealTimers();
@@ -924,6 +1184,52 @@ describe('private prepared execution runtime', () => {
     expect(store.lostDispatch).toBe(true);
     expect(attempts.execute).not.toHaveBeenCalled();
     expect(result.state.attempts[0]?.status).toBe('running');
+  });
+
+  it('does not dispatch after the request deadline wins the launch race', async () => {
+    const dependencies = mutableCoordinatorDependencies();
+    const store = new AdvanceClockAfterLeaseStore(() => {
+      dependencies.setNow(start + 60_000);
+    });
+    const attempts: AttemptExecutionPort = { execute: vi.fn() };
+
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store,
+      coordinator: dependencies,
+      attempts,
+    });
+
+    expect(store.advanced).toBe(true);
+    expect(attempts.execute).not.toHaveBeenCalled();
+    expect(result.state.status).toBe('unsuccessful');
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'timed_out',
+      error: { code: 'request_deadline_exceeded' },
+    });
+  });
+
+  it('reclaims an expired launch lease before dispatching exactly once', async () => {
+    const dependencies = mutableCoordinatorDependencies();
+    const store = new AdvanceClockAfterLeaseStore(() => {
+      dependencies.setNow(start + 1_001);
+    });
+    const execute = vi.fn(async (launch) => ({
+      kind: 'finished' as const,
+      finished: {
+        outcome: 'succeeded' as const,
+        result_id: `result-${launch.attempt_id}`,
+      },
+    }));
+
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store,
+      coordinator: dependencies,
+      attempts: { execute },
+    });
+
+    expect(store.advanced).toBe(true);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(result.state.status).toBe('succeeded');
   });
 
   it('derives enough CAS retries for the maximum concurrent completion wave', async () => {

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutionProfile } from '../src/contracts/domain/index.js';
+import { InMemoryCoordinationStateStore } from '../src/core/coordinator-store.js';
+import type { PreparedResearchExecution } from '../src/core/execution-plan.js';
+import { profileIdentityKey } from '../src/core/execution-plan.js';
+import {
+  type AttemptExecutionPort,
+  runPreparedExecution,
+} from '../src/core/execution-runtime.js';
+import { createNodeAttemptBridge } from '../src/node-execution-bridge.js';
+import type { Provider, ProviderResult } from '../src/types.js';
+
+const start = Date.parse('2026-08-09T12:00:00.000Z');
+
+function profile(
+  providerId: string,
+  invocation: 'inline' | 'background' = 'inline',
+): ExecutionProfile {
+  return {
+    identity: {
+      provider_id: providerId,
+      profile_id: 'fixture',
+      target: {
+        primary: {
+          model_selection: 'fixed',
+          kind: 'model',
+          target_id: `${providerId}-model`,
+        },
+      },
+    },
+    result_kind: 'grounded_answer',
+    grounding_policy: 'required',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'model_search_tool',
+    access_mode: 'direct',
+    operator_id: providerId,
+    invocation,
+    resumability: invocation === 'inline' ? 'none' : 'durable',
+  };
+}
+
+function prepared(
+  primaries: readonly ExecutionProfile[],
+  reserve: readonly ExecutionProfile[] = [],
+): PreparedResearchExecution {
+  const all = [...primaries, ...reserve];
+  const plans = Object.fromEntries(
+    all.map((item) => [
+      profileIdentityKey(item.identity),
+      {
+        profile_key: profileIdentityKey(item.identity),
+        identity: item.identity,
+        binding: {
+          adapter_id: `adapter-${item.identity.provider_id}`,
+          binding_id: `binding-${item.identity.provider_id}`,
+        },
+      },
+    ]),
+  );
+  return {
+    request: {
+      interchange_version: '1.0',
+      message_type: 'request',
+      request_id: 'runtime-request',
+      requested_at: new Date(start).toISOString(),
+      mode: 'sync',
+      query: 'runtime query',
+      slots: primaries.map((item, position) => ({
+        slot_id: `slot-${position}`,
+        position,
+        requirements: {
+          result_kind: 'grounded_answer',
+          grounding_policy: 'required',
+          corpora: ['web'],
+        },
+        primary: item,
+      })),
+      fallback_reserve: reserve.map((item, position) => ({
+        candidate_id: `reserve-${position}`,
+        position,
+        profile: item,
+        eligible_slot_ids: primaries.map((_, index) => `slot-${index}`),
+      })),
+    },
+    policy: {
+      limits: {
+        max_concurrency: primaries.length,
+        request_deadline_ms: 60_000,
+        inline_attempt_deadline_ms: 10_000,
+        background_attempt_deadline_ms: 20_000,
+        poll_interval_ms: 1_000,
+      },
+      fallback: reserve.length
+        ? { kind: 'explicit', reserve: [] }
+        : { kind: 'disabled' },
+      exclusions: [],
+      refinement: { kind: 'disabled' },
+    },
+    profile_plans_by_identity: plans,
+    catalog: { revision: 'runtime-r1', digest: 'runtime-digest' },
+    notices: [],
+  };
+}
+
+function coordinatorDependencies() {
+  let next = 0;
+  return {
+    clock: { now: () => start },
+    ids: {
+      next: (scope: 'attempt' | 'event' | 'delivery_lease') =>
+        `${scope}-${++next}`,
+    },
+  };
+}
+
+function mutableCoordinatorDependencies() {
+  let now = start;
+  let next = 0;
+  return {
+    clock: { now: () => now },
+    ids: {
+      next: (scope: 'attempt' | 'event' | 'delivery_lease') =>
+        `${scope}-${++next}`,
+    },
+    setNow(value: number) {
+      now = value;
+    },
+  };
+}
+
+function successfulResult(provider: string): ProviderResult {
+  return {
+    provider,
+    tier: 'raw-search',
+    content: 'done',
+    citations: [],
+    durationMs: 1,
+  };
+}
+
+describe('private prepared execution runtime', () => {
+  it('executes only the frozen adapter binding and never performs provider selection', async () => {
+    const exact: Provider = {
+      id: 'adapter-primary',
+      displayName: 'Exact',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => successfulResult('adapter-primary')),
+    };
+    const resolveExactProvider = vi.fn((id: string) =>
+      id === 'adapter-primary' ? exact : undefined,
+    );
+    const plan = prepared([profile('primary')]);
+    const store = new InMemoryCoordinationStateStore();
+    const result = await runPreparedExecution(plan, {
+      store,
+      coordinator: coordinatorDependencies(),
+      attempts: createNodeAttemptBridge({
+        resolveExactProvider,
+        now: () => start,
+      }),
+    });
+
+    expect(resolveExactProvider).toHaveBeenCalledExactlyOnceWith(
+      'adapter-primary',
+    );
+    expect(exact.execute).toHaveBeenCalledExactlyOnceWith('runtime query', {
+      timeout: 10_000,
+    });
+    expect(result.state.status).toBe('succeeded');
+    expect(result.outputs_by_attempt).toEqual(
+      expect.objectContaining({
+        'attempt-2': expect.objectContaining({ content: 'done' }),
+      }),
+    );
+  });
+
+  it('persists durable acceptance before polling and uses the background deadline', async () => {
+    const store = new InMemoryCoordinationStateStore();
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit: vi.fn(async () => ({
+        provider: 'adapter-durable',
+        taskId: 'provider-task',
+        query: 'runtime query',
+        submittedAt: start,
+        status: 'pending' as const,
+      })),
+      poll: vi.fn(async () => {
+        const persisted = await store.load('runtime-request');
+        expect(persisted?.state.attempts[0]?.durable_handle).toMatchObject({
+          provider_task_id: 'provider-task',
+        });
+        return { status: 'completed' as const };
+      }),
+      retrieve: vi.fn(async () => successfulResult('adapter-durable')),
+    };
+
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')]),
+      {
+        store,
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactProvider: (id) =>
+            id === 'adapter-durable' ? durable : undefined,
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(durable.submit).toHaveBeenCalledWith('runtime query', {
+      timeout: 20_000,
+    });
+    expect(durable.poll).toHaveBeenCalledOnce();
+    expect(durable.retrieve).toHaveBeenCalledOnce();
+    expect(result.state.status).toBe('succeeded');
+  });
+
+  it('halts on ambiguous submission acceptance without fallback or retry', async () => {
+    const submit = vi.fn(async () => {
+      throw new Error('connection dropped after submit');
+    });
+    const fallback: Provider = {
+      id: 'adapter-reserve',
+      displayName: 'Reserve',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => successfulResult('adapter-reserve')),
+    };
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit,
+      poll: vi.fn(),
+      retrieve: vi.fn(),
+    };
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [profile('reserve')]),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createNodeAttemptBridge({
+          resolveExactProvider: (id) =>
+            id === 'adapter-durable'
+              ? durable
+              : id === 'adapter-reserve'
+                ? fallback
+                : undefined,
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(submit).toHaveBeenCalledOnce();
+    expect(fallback.execute).not.toHaveBeenCalled();
+    expect(result.state.attempts).toHaveLength(1);
+    expect(result.state.attempts[0]?.status).toBe('acceptance_unknown');
+    expect(result.state.unresolved_acceptances[0]).toMatchObject({
+      reason: 'submission_response_uncertain',
+    });
+  });
+
+  it('drops a late primary output and retains the successful fallback output', async () => {
+    const dependencies = mutableCoordinatorDependencies();
+    const attempts: AttemptExecutionPort = {
+      execute: async (launch) => {
+        if (launch.profile.identity.provider_id === 'primary') {
+          dependencies.setNow(start + 10_000);
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'succeeded',
+              result_id: `result-${launch.attempt_id}`,
+            },
+            output: { source: 'late-primary' },
+          };
+        }
+        return {
+          kind: 'finished',
+          finished: {
+            outcome: 'succeeded',
+            result_id: `result-${launch.attempt_id}`,
+          },
+          output: { source: 'fallback' },
+        };
+      },
+    };
+
+    const result = await runPreparedExecution(
+      prepared([profile('primary')], [profile('reserve')]),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: dependencies,
+        attempts,
+      },
+    );
+
+    expect(result.state.status).toBe('succeeded');
+    expect(
+      result.state.attempts.map((attempt) => [
+        attempt.profile.identity.provider_id,
+        attempt.status,
+      ]),
+    ).toEqual([
+      ['primary', 'timed_out'],
+      ['reserve', 'succeeded'],
+    ]);
+    const fallbackAttempt = result.state.attempts.find(
+      (attempt) => attempt.profile.identity.provider_id === 'reserve',
+    );
+    expect(result.outputs_by_attempt).toEqual({
+      [fallbackAttempt?.attempt_id ?? 'missing']: { source: 'fallback' },
+    });
+  });
+
+  it('fans out deterministic shared reserve replacements through the real runtime loop', async () => {
+    const startedPrimaries: string[] = [];
+    let releasePrimaries: () => void = () => {};
+    const bothPrimariesStarted = new Promise<void>((resolve) => {
+      releasePrimaries = resolve;
+    });
+    const calls: string[] = [];
+    const attempts: AttemptExecutionPort = {
+      execute: async (launch) => {
+        const providerId = launch.profile.identity.provider_id;
+        calls.push(providerId);
+        if (providerId === 'primary-a' || providerId === 'primary-b') {
+          startedPrimaries.push(providerId);
+          if (startedPrimaries.length === 2) releasePrimaries();
+          await bothPrimariesStarted;
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error: {
+                code: 'primary_failed',
+                message: 'Primary failed.',
+                category: 'provider',
+                retryable: true,
+                fallback_allowed: true,
+              },
+            },
+          };
+        }
+        return {
+          kind: 'finished',
+          finished: {
+            outcome: 'succeeded',
+            result_id: `result-${launch.attempt_id}`,
+          },
+          output: { provider: providerId },
+        };
+      },
+    };
+
+    const result = await runPreparedExecution(
+      prepared(
+        [profile('primary-a'), profile('primary-b')],
+        [profile('reserve-shared'), profile('reserve-second')],
+      ),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts,
+      },
+    );
+
+    expect(startedPrimaries).toEqual(['primary-a', 'primary-b']);
+    expect(calls).toEqual([
+      'primary-a',
+      'primary-b',
+      'reserve-shared',
+      'reserve-second',
+    ]);
+    expect(
+      result.state.attempts
+        .filter((attempt) => attempt.round === 1)
+        .map((attempt) => [
+          attempt.slot_id,
+          attempt.profile.identity.provider_id,
+          attempt.status,
+        ]),
+    ).toEqual([
+      ['slot-0', 'reserve-shared', 'succeeded'],
+      ['slot-1', 'reserve-second', 'succeeded'],
+    ]);
+    expect(new Set(calls).size).toBe(calls.length);
+    expect(
+      result.state.slots.every((slot) => slot.status === 'succeeded'),
+    ).toBe(true);
+  });
+});

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -257,6 +257,45 @@ class AdvanceClockAfterLeaseStore implements CoordinationStateStore {
   }
 }
 
+class AdvanceClockAfterDispatchStore implements CoordinationStateStore {
+  readonly inner = new InMemoryCoordinationStateStore();
+  advanced = false;
+
+  constructor(private readonly advance: () => void) {}
+
+  load(requestId: string): Promise<VersionedCoordinationState | undefined> {
+    return this.inner.load(requestId);
+  }
+
+  create(state: CoordinatorState): Promise<VersionedCoordinationState> {
+    return this.inner.create(state);
+  }
+
+  async compareAndSwap(
+    requestId: string,
+    expectedVersion: number,
+    state: CoordinatorState,
+  ): Promise<CoordinationCompareAndSwapResult> {
+    const result = await this.inner.compareAndSwap(
+      requestId,
+      expectedVersion,
+      state,
+    );
+    if (
+      result.ok &&
+      !this.advanced &&
+      state.attempts.some(
+        (attempt) =>
+          attempt.status === 'running' || attempt.status === 'submitting',
+      )
+    ) {
+      this.advanced = true;
+      this.advance();
+    }
+    return result;
+  }
+}
+
 describe('private prepared execution runtime', () => {
   it('executes only the frozen adapter binding and never performs provider selection', async () => {
     const exact: Provider = {
@@ -618,6 +657,38 @@ describe('private prepared execution runtime', () => {
     },
   );
 
+  it('accepts semantically equal frozen profiles with reordered extension keys', async () => {
+    const plannedProfile = profile('primary');
+    plannedProfile.extensions = {
+      'com.librarium:test': { second: 2, first: 1 },
+    };
+    const resolvedProfile = profile('primary');
+    resolvedProfile.extensions = {
+      'com.librarium:test': { first: 1, second: 2 },
+    };
+    const provider: Provider = {
+      id: 'adapter-primary',
+      displayName: 'Primary',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => successfulResult('adapter-primary')),
+    };
+
+    const result = await runPreparedExecution(prepared([plannedProfile]), {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: coordinatorDependencies(),
+      attempts: createNodeAttemptBridge({
+        resolveExactBinding: () =>
+          resolvedBinding('primary', provider, resolvedProfile),
+        now: () => start,
+      }),
+    });
+
+    expect(provider.execute).toHaveBeenCalledOnce();
+    expect(result.state.status).toBe('succeeded');
+  });
+
   it('keeps polling through transient errors and repeated running states before fallback', async () => {
     const pollSteps: Array<Error | { status: 'running' | 'failed' }> = [
       new Error('Bearer secret-token'),
@@ -832,7 +903,7 @@ describe('private prepared execution runtime', () => {
     },
   );
 
-  it('keeps accepted durable work resumable after a local execution exception', async () => {
+  it('retains accepted durable work after a local execution exception', async () => {
     const result = await runPreparedExecution(
       prepared([profile('durable', 'background')], [], 'async'),
       {
@@ -1189,6 +1260,28 @@ describe('private prepared execution runtime', () => {
   it('does not dispatch after the request deadline wins the launch race', async () => {
     const dependencies = mutableCoordinatorDependencies();
     const store = new AdvanceClockAfterLeaseStore(() => {
+      dependencies.setNow(start + 60_000);
+    });
+    const attempts: AttemptExecutionPort = { execute: vi.fn() };
+
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store,
+      coordinator: dependencies,
+      attempts,
+    });
+
+    expect(store.advanced).toBe(true);
+    expect(attempts.execute).not.toHaveBeenCalled();
+    expect(result.state.status).toBe('unsuccessful');
+    expect(result.state.attempts[0]).toMatchObject({
+      status: 'timed_out',
+      error: { code: 'request_deadline_exceeded' },
+    });
+  });
+
+  it('does not invoke the port when the request deadline crosses after the dispatch CAS', async () => {
+    const dependencies = mutableCoordinatorDependencies();
+    const store = new AdvanceClockAfterDispatchStore(() => {
       dependencies.setNow(start + 60_000);
     });
     const attempts: AttemptExecutionPort = { execute: vi.fn() };

--- a/tests/transport-normalization.test.ts
+++ b/tests/transport-normalization.test.ts
@@ -220,25 +220,45 @@ describe('shadow transport golden equality', () => {
 });
 
 describe('selector conflicts', () => {
-  it('rejects competing selectors consistently across all five transports', () => {
+  it('lets explicit providers override a group for CLI and MCP ingress with a notice', () => {
     const input = { query: 'q', providers: ['alpha'], group: 'quick' };
     for (const normalize of [
       normalizeCliRequest,
       normalizeMcpRequest,
       normalizeSilentMcpRequest,
-      normalizeConfigurationRequest,
     ]) {
       const result = normalize(input, FIXTURE_DEFAULTS);
-      expect(result.ok).toBe(false);
-      if (result.ok) continue;
-      expect(result.issues).toEqual([
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      expect(result.request.selector).toEqual({
+        kind: 'targets',
+        targets: [{ provider_id: 'alpha' }],
+      });
+      expect(result.notices).toEqual([
         expect.objectContaining({
-          code: 'transport_selector_conflict',
+          code: 'transport_explicit_providers_override_group',
           phase: 'transport',
           path: '/group',
         }),
       ]);
     }
+  });
+
+  it('rejects providers plus group ambiguity for library and configuration', () => {
+    const configuration = normalizeConfigurationRequest(
+      { query: 'q', providers: ['alpha'], group: 'quick' },
+      FIXTURE_DEFAULTS,
+    );
+    expect(configuration.ok).toBe(false);
+    if (configuration.ok) return;
+    expect(configuration.issues).toEqual([
+      expect.objectContaining({
+        code: 'transport_selector_conflict',
+        phase: 'transport',
+        path: '/group',
+      }),
+    ]);
+
     const library = normalizeLibraryRequest(
       {
         query: 'q',
@@ -356,7 +376,7 @@ describe('transport budgets and legacy mode', () => {
     );
   });
 
-  it('preserves selector conflicts through compilation via the shadow helper', () => {
+  it('preserves approved selector precedence through the shadow helper', () => {
     const catalog = catalogFor([planningProfile(groundedProfile('alpha'))]);
     const compiled = compileNormalizedTransportRequest(
       normalizeCliRequest(
@@ -366,14 +386,14 @@ describe('transport budgets and legacy mode', () => {
       catalog,
       dependencies(),
     );
-    expect(compiled.ok).toBe(false);
-    if (compiled.ok) return;
-    expect(compiled.issues).toEqual([
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    expect(compiled.notices).toContainEqual(
       expect.objectContaining({
-        code: 'transport_selector_conflict',
+        code: 'transport_explicit_providers_override_group',
         path: '/group',
       }),
-    ]);
+    );
 
     const rejected = compileNormalizedTransportRequest(
       normalizeLibraryRequest(

--- a/tests/workers/execution-core.test.ts
+++ b/tests/workers/execution-core.test.ts
@@ -10,6 +10,10 @@ import {
   type FrozenPlanningCatalog,
   prepareResearchExecution,
 } from '../../src/core/execution-plan.js';
+import {
+  type AttemptExecutionPort,
+  runPreparedExecution,
+} from '../../src/core/execution-runtime.js';
 import { CanonicalResearchRequestSchema } from '../../src/core/research-request.js';
 
 const profile: ExecutionProfile = {
@@ -111,6 +115,74 @@ describe('private execution architecture in workerd', () => {
     await expect(store.load(dispatched.request_id)).resolves.toMatchObject({
       version: 1,
       state: { request_id: dispatched.request_id },
+    });
+  });
+
+  it('runs a prepared plan through an injected port without Node APIs', async () => {
+    const catalog: FrozenPlanningCatalog = {
+      revision: 'worker-runtime-r1',
+      digest: 'worker-runtime-digest',
+      profiles: [
+        {
+          profile,
+          binding: {
+            adapter_id: 'worker-adapter',
+            binding_id: 'worker-binding',
+          },
+          estimate: { estimated_cost_microusd: '0' },
+          enabled: true,
+          credentialed: true,
+          configuration_valid: true,
+        },
+      ],
+      resolveGroup: () => undefined,
+      resolveDefault: () => [profile.identity],
+      resolveConfiguredReserve: () => [],
+    };
+    const prepared = prepareResearchExecution(
+      {
+        query: 'worker runtime query',
+        mode: 'sync',
+        selector: { kind: 'default' },
+        fallback: { kind: 'disabled' },
+        limits: {
+          max_concurrency: 1,
+          request_deadline_ms: 60_000,
+          inline_attempt_deadline_ms: 30_000,
+          background_attempt_deadline_ms: 60_000,
+          poll_interval_ms: 1_000,
+        },
+      },
+      catalog,
+      {
+        clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
+        ids: { next: (scope) => `runtime-${scope}` },
+      },
+    );
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+
+    let id = 0;
+    const attempts: AttemptExecutionPort = {
+      execute: async () => ({
+        kind: 'finished',
+        finished: { outcome: 'succeeded', result_id: 'worker-result' },
+        output: { worker_safe: true },
+      }),
+    };
+    const result = await runPreparedExecution(prepared.prepared, {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: {
+        clock: { now: () => Date.parse('2026-08-08T12:00:00Z') },
+        ids: {
+          next: (scope) => `runtime-${scope}-${++id}`,
+        },
+      },
+      attempts,
+    });
+    expect(result.state.status).toBe('succeeded');
+    expect(result.outputs_by_attempt).toEqual({
+      'runtime-attempt-2': { worker_safe: true },
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds the private canonical execution runtime that turns a fully prepared research plan into deterministic coordinator state and executes only its frozen adapter bindings. This establishes the Worker-safe scheduling and Node provider bridge needed for Librarium v2 without changing current public CLI, MCP, or package behavior.

## Changes

- add a Worker-safe prepared-plan runner with CAS-backed launch, lifecycle, deadline, concurrency, and fallback coordination
- add a Node bridge for exact inline and durable-background provider execution
- enforce frozen catalog/profile/binding identity before any provider call
- persist durable submission acceptance before polling or retrieval
- preserve terminal submit statuses and accepted remote work during local interruption
- fence request, attempt, and delivery-lease deadlines before and after dispatch persistence
- support transport-specific provider/group precedence while keeping library/config ambiguity strict
- make custom script provider execution abortable
- add adversarial tests for CAS contention, stale leases, post-CAS deadlines, terminal durable states, fallback contention, secret-safe errors, and Worker compatibility

## Design Decisions

**Private foundation only:** The new runtime is intentionally not exported from the public package entrypoints yet. Current CLI and MCP execution remain unchanged while the remaining v2 package/config and durable-persistence slices are completed.

**No interim result shape:** This change stores private attempt outputs but does not introduce or export a terminal response mapper. That boundary will land with the dedicated result-contract work.

## Testing

- [x] 1,727 unit tests
- [x] 14 Worker compatibility tests
- [x] 14 integration tests
- [x] TypeScript typecheck
- [x] Biome lint
- [x] production build
- [x] independent security, architecture, and testability review with targeted closure replay
