### PR TITLE
fix: bind custom provider trust to source

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -177,6 +177,13 @@ export function mergeConfigs(
   }
 
   if (project?.customProviders) {
+    // A project definition replaces the global code associated with the same
+    // ID, so it must receive its own explicit trust decision. Keep trust for
+    // global providers the project did not replace.
+    const overriddenProviderIds = new Set(Object.keys(project.customProviders));
+    merged.trustedProviderIds = merged.trustedProviderIds.filter(
+      (providerId) => !overriddenProviderIds.has(providerId),
+    );
     merged.customProviders = {
       ...merged.customProviders,
       ...project.customProviders,

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -16,7 +16,7 @@ import {
   loadCustomProviders as loadCustomProvidersInternal,
 } from './adapters/custom.js';
 import { getAllProviders, registerProvider } from './adapters/index.js';
-import { BUILTIN_PROVIDER_DESCRIPTORS } from './adapters/provider-descriptors.js';
+import { BUILTIN_PROVIDER_DEFINITIONS } from './core/provider-descriptor.js';
 import type { Config } from './types.js';
 
 export type { CustomProviderLoadResult } from './adapters/custom.js';
@@ -25,10 +25,8 @@ export * from './node-credentials.js';
 
 export interface LoadCustomProvidersOptions {
   /**
-   * Provider IDs that may not be claimed by a custom provider. Defaults to the
-   * descriptor inventory plus every provider currently registered in the core
-   * registry, so a misconfigured built-in can never be claimed by a custom
-   * provider.
+   * Additional provider IDs that may not be claimed by a custom provider.
+   * Built-in canonical IDs and aliases are always reserved.
    */
   reservedProviderIds?: Iterable<string>;
 }
@@ -44,12 +42,14 @@ export async function loadCustomProviders(
   config: Pick<Config, 'customProviders' | 'trustedProviderIds' | 'providers'>,
   options: LoadCustomProvidersOptions = {},
 ): Promise<CustomProviderLoadResult> {
-  const reservedProviderIds = new Set(
-    options.reservedProviderIds ?? [
-      ...BUILTIN_PROVIDER_DESCRIPTORS.map(({ id }) => id),
-      ...getAllProviders().map((provider) => provider.id),
-    ],
-  );
+  const reservedProviderIds = new Set([
+    ...BUILTIN_PROVIDER_DEFINITIONS.flatMap(({ id, aliases }) => [
+      id,
+      ...aliases,
+    ]),
+    ...getAllProviders().map((provider) => provider.id),
+    ...(options.reservedProviderIds ?? []),
+  ]);
 
   return loadCustomProvidersInternal({
     customProviders: config.customProviders ?? {},

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -548,6 +548,66 @@ describe('mergeConfigs', () => {
     expect(merged.trustedProviderIds).toEqual(['my-custom', 'my-custom-2']);
   });
 
+  it('drops inherited trust when a project overrides a custom provider', () => {
+    const merged = mergeConfigs(
+      {
+        ...baseGlobal,
+        customProviders: {
+          overridden: { type: 'npm', module: 'global-provider' },
+        },
+        trustedProviderIds: ['overridden'],
+      },
+      {
+        customProviders: {
+          overridden: { type: 'npm', module: 'project-provider' },
+        },
+      },
+    );
+
+    expect(merged.trustedProviderIds).toEqual([]);
+  });
+
+  it('keeps a project override trusted when the project explicitly trusts it', () => {
+    const merged = mergeConfigs(
+      {
+        ...baseGlobal,
+        customProviders: {
+          overridden: { type: 'npm', module: 'global-provider' },
+        },
+        trustedProviderIds: ['overridden'],
+      },
+      {
+        customProviders: {
+          overridden: { type: 'npm', module: 'project-provider' },
+        },
+        trustedProviderIds: ['overridden'],
+      },
+    );
+
+    expect(merged.trustedProviderIds).toEqual(['overridden']);
+  });
+
+  it('retains trust for unrelated global custom providers', () => {
+    const merged = mergeConfigs(
+      {
+        ...baseGlobal,
+        customProviders: {
+          overridden: { type: 'npm', module: 'global-provider' },
+          retained: { type: 'npm', module: 'retained-provider' },
+        },
+        trustedProviderIds: ['overridden', 'retained'],
+      },
+      {
+        customProviders: {
+          overridden: { type: 'npm', module: 'project-provider' },
+          'project-only': { type: 'npm', module: 'project-only-provider' },
+        },
+      },
+    );
+
+    expect(merged.trustedProviderIds).toEqual(['retained']);
+  });
+
   it('applies CLI flags', () => {
     const merged = mergeConfigs(baseGlobal, null, {
       timeout: 120,

--- a/tests/node-entry.test.ts
+++ b/tests/node-entry.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,7 +16,6 @@ describe('librarium/node entry', () => {
   let executeResearchRun: typeof import('../src/node-entry.js').executeResearchRun;
   let getProvider: typeof import('../src/adapters/index.js').getProvider;
   let getAllProviders: typeof import('../src/adapters/index.js').getAllProviders;
-  let registerProvider: typeof import('../src/adapters/index.js').registerProvider;
   let initializeProviders: typeof import('../src/adapters/index.js').initializeProviders;
 
   beforeEach(async () => {
@@ -32,7 +31,6 @@ describe('librarium/node entry', () => {
     const registry = await import('../src/adapters/index.js');
     getProvider = registry.getProvider;
     getAllProviders = registry.getAllProviders;
-    registerProvider = registry.registerProvider;
     initializeProviders = registry.initializeProviders;
   });
 
@@ -48,7 +46,7 @@ describe('librarium/node entry', () => {
     expect(typeof executeResearchRun).toBe('function');
   });
 
-  function writeNpmProvider(id: string): void {
+  function writeNpmProvider(id: string, topLevelEffectPath?: string): void {
     const pkgDir = join(tmpDir, 'node_modules', id);
     mkdirSync(pkgDir, { recursive: true });
     writeFileSync(
@@ -68,6 +66,12 @@ describe('librarium/node entry', () => {
     writeFileSync(
       join(pkgDir, 'index.mjs'),
       [
+        ...(topLevelEffectPath
+          ? [
+              "import { writeFileSync } from 'node:fs';",
+              `writeFileSync(${JSON.stringify(topLevelEffectPath)}, 'loaded');`,
+            ]
+          : []),
         'export default {',
         `  id: '${id}',`,
         "  displayName: 'Lib Provider',",
@@ -133,21 +137,57 @@ describe('librarium/node entry', () => {
     expect(executed.content).toBe('lib:hi');
   });
 
-  it('protects reserved provider IDs by default after initializeProviders', async () => {
-    writeNpmProvider('exa');
-    await initializeProviders();
+  it('rejects canonical built-in IDs before importing npm code', async () => {
+    const markerPath = join(tmpDir, 'npm-provider-loaded');
+    writeNpmProvider('exa', markerPath);
 
-    const result = await registerCustomProviders({
-      providers: { exa: { enabled: true } },
-      customProviders: { exa: { type: 'npm', module: 'exa' } },
-      trustedProviderIds: ['exa'],
-    });
+    const result = await loadCustomProviders(
+      {
+        providers: { exa: { enabled: true } },
+        customProviders: { exa: { type: 'npm', module: 'exa' } },
+        trustedProviderIds: ['exa'],
+      },
+      {
+        reservedProviderIds: [],
+      },
+    );
 
     expect(result.loadedIds).not.toContain('exa');
     expect(result.skippedIds).toContain('exa');
     expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
-    // The built-in exa provider is still the registered one.
-    expect(getProvider('exa')?.source).toBe('builtin');
-    expect(registerProvider).toBeDefined();
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it('rejects built-in aliases before spawning script describe code', async () => {
+    const markerPath = join(tmpDir, 'script-provider-described');
+    const scriptPath = join(tmpDir, 'reserved-provider-script.mjs');
+    writeFileSync(
+      scriptPath,
+      [
+        "import { writeFileSync } from 'node:fs';",
+        `writeFileSync(${JSON.stringify(markerPath)}, 'described');`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await loadCustomProviders(
+      {
+        providers: { 'openai-deep': { enabled: true } },
+        customProviders: {
+          'openai-deep': {
+            type: 'script',
+            command: process.execPath,
+            args: [scriptPath],
+          },
+        },
+        trustedProviderIds: ['openai-deep'],
+      },
+      { reservedProviderIds: [] },
+    );
+
+    expect(result.loadedIds).not.toContain('openai-deep');
+    expect(result.skippedIds).toContain('openai-deep');
+    expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
+    expect(existsSync(markerPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary\n\nBind custom-provider trust to the configuration layer that defines the provider, preventing project configuration from inheriting trust when it replaces a globally trusted custom provider. Reserve canonical built-in provider IDs and aliases before any custom npm import or script spawn.\n\n## What's New\n\n- Drop inherited trust for project-defined or overridden custom providers unless the project explicitly trusts them.\n- Preserve trust for unrelated global providers.\n- Treat built-in canonical IDs, aliases, registered IDs, and caller-supplied IDs as an additive reserved set.\n- Add regression tests covering trust rebinding and pre-execution alias collisions.\n\n## Test Plan\n\n- [x] 1,731 unit tests\n- [x] 14 Worker tests\n- [x] TypeScript typecheck\n- [x] Biome lint\n- [x] Three independent adversarial reviews\n\nCloses part of #2555.