### PR TITLE
feat: add canonical config mapping

### DIFF
--- a/src/core/builtin-workflows.ts
+++ b/src/core/builtin-workflows.ts
@@ -127,7 +127,7 @@ function sortedRecord(
 export function migrateUserWorkflowNames(
   groups: Readonly<Record<string, readonly string[]>>,
 ): WorkflowMigrationResult {
-  const migrated: Record<string, readonly string[]> = {};
+  const migrated = Object.create(null) as Record<string, readonly string[]>;
   const notices: PreparationNotice[] = [];
   const issues: PreparationIssue[] = [];
 
@@ -138,7 +138,7 @@ export function migrateUserWorkflowNames(
     }
 
     const renamed = customWorkflowId(name);
-    if (renamed in groups) {
+    if (Object.hasOwn(groups, renamed)) {
       // Preserve both definitions verbatim; the reserved key keeps resolving to
       // the built-in workflow and `custom:<name>` keeps the user's group.
       migrated[name] = members;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -17,6 +17,48 @@ import { safeWriteFile } from './fs-utils.js';
 export const CONFIG_DIR = resolve(homedir(), '.config', 'librarium');
 export const CONFIG_FILE = resolve(CONFIG_DIR, 'config.json');
 
+/**
+ * Only authored groups are meaningful to the v2 catalog. `loadConfig` still
+ * injects DEFAULT_GROUPS for the unchanged v1 dispatcher, so retain the two
+ * authored layers out-of-band instead of making injected defaults look like
+ * custom user workflows.
+ */
+export interface ConfigGroupProvenance {
+  readonly global: Readonly<Record<string, readonly string[]>>;
+  readonly project: Readonly<Record<string, readonly string[]>>;
+}
+
+const groupProvenanceByConfig = new WeakMap<Config, ConfigGroupProvenance>();
+
+function cloneGroups(
+  groups: Readonly<Record<string, readonly string[]>>,
+): Record<string, string[]> {
+  return Object.fromEntries(
+    Object.entries(groups).map(([name, members]) => [name, [...members]]),
+  );
+}
+
+function setConfigGroupProvenance(
+  config: Config,
+  provenance: ConfigGroupProvenance,
+): Config {
+  groupProvenanceByConfig.set(config, {
+    global: cloneGroups(provenance.global),
+    project: cloneGroups(provenance.project),
+  });
+  return config;
+}
+
+/**
+ * Returns authored global/project group layers for a config loaded or merged
+ * by this module. Hand-built Config values are treated as authored global
+ * config, which keeps this helper useful in library callers and tests.
+ */
+export function configGroupProvenance(config: Config): ConfigGroupProvenance {
+  const known = groupProvenanceByConfig.get(config);
+  return known ?? { global: config.groups, project: {} };
+}
+
 const DEFAULT_CONFIG: Config = {
   version: 1,
   defaults: {
@@ -87,13 +129,16 @@ export function validateFallbacks(config: Config): string[] {
 export function loadConfig(globalPath?: string): Config {
   const path = globalPath ?? CONFIG_FILE;
   if (!existsSync(path))
-    return {
-      ...DEFAULT_CONFIG,
-      providers: {},
-      customProviders: {},
-      trustedProviderIds: [],
-      groups: { ...DEFAULT_GROUPS },
-    };
+    return setConfigGroupProvenance(
+      {
+        ...DEFAULT_CONFIG,
+        providers: {},
+        customProviders: {},
+        trustedProviderIds: [],
+        groups: { ...DEFAULT_GROUPS },
+      },
+      { global: {}, project: {} },
+    );
 
   let raw: unknown;
   try {
@@ -104,11 +149,24 @@ export function loadConfig(globalPath?: string): Config {
     );
   }
   const config = ConfigSchema.parse(raw);
+  // Keep the authored spelling for the pure v2 mapper. v1 still mutates
+  // config.groups below, but doing that here would erase alias provenance
+  // before the mapper can issue its structured migration diagnostic.
+  const explicitGlobalGroups = cloneGroups(config.groups);
   const storedDefaultGroupRosters = captureStoredDefaultGroupRosters(
     config.groups,
   );
   const migrationWarnings = migrateLegacyProviderIds(config);
-  migratePriorCanonicalDefaultGroups(config, storedDefaultGroupRosters);
+  const migratedDefaultGroups = migratePriorCanonicalDefaultGroups(
+    config,
+    storedDefaultGroupRosters,
+  );
+  // The two exact historical shipped rosters are a narrow exception: preserve
+  // their approved replacement rather than making the retired roster a custom
+  // group in v2. No other authored member is rewritten in provenance.
+  for (const name of migratedDefaultGroups) {
+    explicitGlobalGroups[name] = [...(config.groups[name] ?? [])];
+  }
   // Merge defaults only after inspecting explicitly stored global groups.
   // User groups, including customized comprehensive/all rosters, win.
   config.groups = { ...DEFAULT_GROUPS, ...config.groups };
@@ -122,7 +180,10 @@ export function loadConfig(globalPath?: string): Config {
     console.error(`[librarium] warning: ${warning}`);
   }
 
-  return config;
+  return setConfigGroupProvenance(config, {
+    global: explicitGlobalGroups,
+    project: {},
+  });
 }
 
 /**
@@ -213,6 +274,13 @@ export function mergeConfigs(
   }
 
   migrateLegacyProviderIds(merged);
+
+  const globalGroups = configGroupProvenance(global).global;
+  const projectGroups = project?.groups ?? {};
+  setConfigGroupProvenance(merged, {
+    global: globalGroups,
+    project: projectGroups,
+  });
 
   return merged;
 }
@@ -450,7 +518,8 @@ function captureStoredDefaultGroupRosters(
 function migratePriorCanonicalDefaultGroups(
   config: Config,
   storedRosters: StoredDefaultGroupRosters,
-): void {
+): Array<'comprehensive' | 'all'> {
+  const migrated: Array<'comprehensive' | 'all'> = [];
   for (const groupName of ['comprehensive', 'all'] as const) {
     const storedMembers = storedRosters[groupName];
     if (!storedMembers) continue;
@@ -459,8 +528,10 @@ function migratePriorCanonicalDefaultGroups(
     ].some((snapshot) => orderedExactMatch(storedMembers, snapshot));
     if (matchesPriorSnapshot) {
       config.groups[groupName] = [...DEFAULT_GROUPS[groupName]];
+      migrated.push(groupName);
     }
   }
+  return migrated;
 }
 
 function orderedExactMatch(

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -1,7 +1,7 @@
 import {
   normalizeProviderName,
+  PROVIDER_ID_ALIASES,
   type ProviderNameEntry,
-  resolveProviderId,
   resolveProviderToken,
 } from '../constants.js';
 import type { Config, ProviderConfig } from '../types.js';
@@ -97,6 +97,29 @@ const PROVIDER_NAME_ENTRIES: readonly ProviderNameEntry[] =
     id: definition.id,
     displayName: definition.display.name,
   }));
+
+/** Internal config-derived maps must never inherit JSON-authored keys. */
+function safeRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+/** Return an ordinary public record while retaining an own `__proto__` key. */
+function publicRecord<T>(
+  record: Readonly<Record<string, T>>,
+): Record<string, T> {
+  return Object.fromEntries(Object.entries(record));
+}
+
+function ownValue<T>(
+  record: Readonly<Record<string, T>>,
+  key: string,
+): T | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
+function canonicalProviderId(id: string): string {
+  return Object.hasOwn(PROVIDER_ID_ALIASES, id) ? PROVIDER_ID_ALIASES[id]! : id;
+}
 
 /**
  * Purely resolve a legacy provider/display/qualified token to one exact
@@ -255,13 +278,13 @@ function canonicalizeProviderConfigs(
   providerConfigs: Record<string, ProviderConfig>;
   notices: PreparationNotice[];
 } {
-  const providerConfigs: Record<string, ProviderConfig> = {};
+  const providerConfigs = safeRecord<ProviderConfig>();
   const notices: PreparationNotice[] = [];
   const openAiCandidates = [
     'openai-deep',
     'openai-deep-o3',
     'openai-research',
-  ].filter((id) => providers[id] !== undefined);
+  ].filter((id) => ownValue(providers, id) !== undefined);
   const selectedOpenAi = openAiCandidates.includes('openai-research')
     ? 'openai-research'
     : openAiCandidates.includes('openai-deep-o3')
@@ -271,9 +294,9 @@ function canonicalizeProviderConfigs(
         : undefined;
 
   for (const [id, config] of Object.entries(providers)) {
-    const adapterId = resolveProviderId(id);
+    const adapterId = canonicalProviderId(id);
     const fallback = config.fallback
-      ? resolveProviderId(config.fallback)
+      ? canonicalProviderId(config.fallback)
       : undefined;
     if (adapterId !== id) {
       notices.push({
@@ -307,7 +330,7 @@ function canonicalizeProviderConfigs(
       });
       continue;
     }
-    if (!providerConfigs[adapterId] || id === adapterId) {
+    if (!ownValue(providerConfigs, adapterId) || id === adapterId) {
       providerConfigs[adapterId] = normalized;
       continue;
     }
@@ -319,14 +342,14 @@ function canonicalizeProviderConfigs(
         'A colliding provider alias was ignored because its canonical adapter is configured.',
     });
   }
-  return { providerConfigs, notices };
+  return { providerConfigs: publicRecord(providerConfigs), notices };
 }
 
 function materializeProviderConfigs(config: Config): {
   providerConfigs: Record<string, ProviderConfig>;
   notices: PreparationNotice[];
 } {
-  const byAdapter: Record<string, ProviderConfig> = {};
+  const byAdapter = safeRecord<ProviderConfig>();
   const bindings = adapterProfileBindings();
   const normalized = canonicalizeProviderConfigs(config.providers);
 
@@ -346,14 +369,20 @@ function materializeProviderConfigs(config: Config): {
     };
   }
 
-  return { providerConfigs: byAdapter, notices: normalized.notices };
+  return {
+    providerConfigs: publicRecord(byAdapter),
+    notices: normalized.notices,
+  };
 }
 
 function authoredGroups(
   provenance: AuthoredGroupProvenance,
 ): Record<string, readonly string[]> {
   // Project authoring intentionally wins without reordering either layer.
-  return { ...provenance.global, ...provenance.project };
+  return Object.fromEntries([
+    ...Object.entries(provenance.global),
+    ...Object.entries(provenance.project),
+  ]);
 }
 
 function canonicalizeGroups(
@@ -363,7 +392,7 @@ function canonicalizeGroups(
   notices: PreparationNotice[];
   issues: PreparationIssue[];
 } {
-  const mapped: Record<string, string[]> = {};
+  const mapped = safeRecord<string[]>();
   const notices: PreparationNotice[] = [];
   const issues: PreparationIssue[] = [];
   for (const [name, members] of Object.entries(groups)) {
@@ -410,7 +439,7 @@ function canonicalizeGroups(
     }
     mapped[name] = exact;
   }
-  return { groups: mapped, notices, issues };
+  return { groups: publicRecord(mapped), notices, issues };
 }
 
 function groupAliases(
@@ -418,15 +447,15 @@ function groupAliases(
   catalog: ProviderCatalog,
 ): Record<string, string> {
   const customGroups = new Set(catalog.custom_group_ids);
-  const aliases: Record<string, string> = {};
+  const aliases = safeRecord<string>();
   for (const name of Object.keys(groups)) {
     if (name.startsWith('custom:')) continue;
     const target = customWorkflowId(name);
-    if (customGroups.has(target) && !groups[target]) {
+    if (customGroups.has(target) && ownValue(groups, target) === undefined) {
       aliases[name] = target;
     }
   }
-  return aliases;
+  return publicRecord(aliases);
 }
 
 function fallbackReserve(
@@ -488,18 +517,18 @@ function fallbackReserve(
     const target = adapterProfileBinding(fallback);
     if (!target) {
       issues.push({
-        code: providerConfigs[fallback]
+        code: ownValue(providerConfigs, fallback)
           ? 'configuration_fallback_unbound_target'
           : 'configuration_fallback_unknown_adapter',
         phase: 'migration',
         path,
-        message: providerConfigs[fallback]
+        message: ownValue(providerConfigs, fallback)
           ? 'The fallback adapter has no exact executable profile binding.'
           : 'The fallback adapter is not a known implemented adapter.',
       });
       continue;
     }
-    if (!providerConfigs[fallback]) {
+    if (!ownValue(providerConfigs, fallback)) {
       issues.push({
         code: 'configuration_fallback_target_unconfigured',
         phase: 'migration',
@@ -545,7 +574,7 @@ function fallbackReserve(
       });
     }
     if (
-      providerConfigs[edge.fallback]?.enabled === false &&
+      ownValue(providerConfigs, edge.fallback)?.enabled === false &&
       !reserveOnly.has(edge.fallback)
     ) {
       reserveOnly.add(edge.fallback);

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -1,0 +1,672 @@
+import {
+  normalizeProviderName,
+  type ProviderNameEntry,
+  resolveProviderId,
+  resolveProviderToken,
+} from '../constants.js';
+import type { Config, ProviderConfig } from '../types.js';
+import { customWorkflowId } from './builtin-workflows.js';
+import type { CredentialContext } from './credentials.js';
+import {
+  type AdapterProfileBinding,
+  adapterProfileBinding,
+  adapterProfileBindings,
+} from './profile-bindings.js';
+import {
+  buildProviderCatalog,
+  type CatalogProfileTarget,
+  type ProviderCatalog,
+} from './profile-catalog.js';
+import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
+import type { ProviderCatalogEntry } from './provider-profiles.js';
+import type {
+  PreparationIssue,
+  PreparationNotice,
+} from './research-request.js';
+import { comparePreparationDiagnostics } from './research-request.js';
+import type {
+  CanonicalTransportDefaults,
+  ConfigurationTransportInput,
+} from './transport-normalization.js';
+import { exactUsdBudgets } from './transport-normalization.js';
+
+/** Dependencies are injected so mapping stays pure and network-free. */
+export interface ConfigurationMappingOptions {
+  /**
+   * The v1 total request deadline has no approved conversion formula yet.
+   * Callers must supply the already-approved canonical deadline explicitly.
+   */
+  readonly requestDeadlineMs?: number;
+  /** Required to prevent injected v1 DEFAULT_GROUPS entering the catalog. */
+  readonly authoredGroups: AuthoredGroupProvenance;
+  readonly credentials?: CredentialContext;
+  readonly catalog?: readonly ProviderCatalogEntry[];
+}
+
+export interface AuthoredGroupProvenance {
+  readonly global: Readonly<Record<string, readonly string[]>>;
+  readonly project: Readonly<Record<string, readonly string[]>>;
+}
+
+export interface ConfigurationPreflight {
+  readonly notices: readonly PreparationNotice[];
+  readonly issues: readonly PreparationIssue[];
+}
+
+/**
+ * Pure v1-config to v2-catalog mapping. No registry construction, provider
+ * imports, subprocesses, network, or filesystem access occurs here.
+ */
+export interface ConfigurationMappingResult {
+  readonly catalog: ProviderCatalog;
+  /** Omitted until the caller supplies the explicitly approved request limit. */
+  readonly transport_defaults?: CanonicalTransportDefaults;
+  readonly transport_input: ConfigurationTransportInput;
+  readonly groups: Readonly<Record<string, readonly string[]>>;
+  /** v1 group spelling to the exact catalog group id. */
+  readonly group_aliases: Readonly<Record<string, string>>;
+  readonly reserve: readonly CatalogProfileTarget[];
+  readonly reserve_only_adapter_ids: readonly string[];
+  readonly preflight: ConfigurationPreflight;
+}
+
+export type ConfigurationProfileTokenResolution =
+  | {
+      readonly kind: 'exact';
+      readonly token: string;
+      readonly target: CatalogProfileTarget;
+      /** Present only for a retired provider-id alias. */
+      readonly alias?: {
+        readonly from: string;
+        readonly adapter_id: string;
+      };
+    }
+  | {
+      readonly kind: 'ambiguous';
+      readonly token: string;
+      readonly candidates: readonly CatalogProfileTarget[];
+    }
+  | {
+      readonly kind: 'unknown';
+      readonly token: string;
+      readonly suggestions: readonly string[];
+    };
+
+const PROVIDER_NAME_ENTRIES: readonly ProviderNameEntry[] =
+  BUILTIN_PROVIDER_DEFINITIONS.map((definition) => ({
+    id: definition.id,
+    displayName: definition.display.name,
+  }));
+
+/**
+ * Purely resolve a legacy provider/display/qualified token to one exact
+ * catalog identity. An unqualified provider with more than one profile is
+ * deliberately ambiguous; callers must preserve the exact strategy.
+ */
+export function resolveConfigurationProfileToken(
+  token: string,
+): ConfigurationProfileTokenResolution {
+  const trimmed = token.trim();
+  const qualified = trimmed.split('/');
+  if (qualified.length === 2 && qualified[0] && qualified[1]) {
+    const target = {
+      provider_id: qualified[0],
+      profile_id: qualified[1],
+    };
+    const known = [...adapterProfileBindings().values()].some((binding) =>
+      sameProfile(binding, target),
+    );
+    return known
+      ? { kind: 'exact', token: trimmed, target }
+      : { kind: 'unknown', token: trimmed, suggestions: [] };
+  }
+  if (qualified.length !== 1) {
+    return { kind: 'unknown', token: trimmed, suggestions: [] };
+  }
+
+  const direct = adapterProfileBinding(trimmed);
+  if (direct) return exactToken(trimmed, direct);
+
+  const catalogMatches = [...adapterProfileBindings().values()]
+    .filter((binding) => binding.provider_id === trimmed)
+    .sort((left, right) => profileKey(left).localeCompare(profileKey(right)));
+  if (catalogMatches.length === 1)
+    return exactToken(trimmed, catalogMatches[0]);
+  if (catalogMatches.length > 1) {
+    return {
+      kind: 'ambiguous',
+      token: trimmed,
+      candidates: catalogMatches.map((binding) => ({
+        provider_id: binding.provider_id,
+        profile_id: binding.profile_id,
+      })),
+    };
+  }
+
+  // Retain every display-name match so a duplicate stays ambiguous instead of
+  // selecting whichever descriptor happened to be declared first.
+  const displayMatches = PROVIDER_NAME_ENTRIES.filter(
+    (entry) =>
+      normalizeProviderName(entry.displayName) ===
+      normalizeProviderName(trimmed),
+  );
+  if (displayMatches.length === 1) {
+    const [display] = exactTargetsForProviderEntries(displayMatches);
+    if (display) return { kind: 'exact', token: trimmed, target: display };
+  }
+  if (displayMatches.length > 1) {
+    return {
+      kind: 'ambiguous',
+      token: trimmed,
+      candidates: exactTargetsForProviderEntries(displayMatches),
+    };
+  }
+
+  const provider = resolveProviderToken(trimmed, [...PROVIDER_NAME_ENTRIES]);
+  if (provider.kind === 'unknown') {
+    return {
+      kind: 'unknown',
+      token: trimmed,
+      suggestions: provider.suggestions.map((candidate) => candidate.id),
+    };
+  }
+  if (provider.kind === 'ambiguous') {
+    return {
+      kind: 'ambiguous',
+      token: trimmed,
+      candidates: exactTargetsForProviderEntries(provider.candidates),
+    };
+  }
+  const matches = [...adapterProfileBindings().values()]
+    .filter((binding) => binding.provider_id === provider.id)
+    .sort((left, right) => profileKey(left).localeCompare(profileKey(right)));
+  if (matches.length === 1) {
+    return exactToken(
+      trimmed,
+      matches[0],
+      provider.kind === 'alias'
+        ? { from: trimmed, adapter_id: provider.id }
+        : undefined,
+    );
+  }
+  if (matches.length > 1) {
+    return {
+      kind: 'ambiguous',
+      token: trimmed,
+      candidates: matches.map((binding) => ({
+        provider_id: binding.provider_id,
+        profile_id: binding.profile_id,
+      })),
+    };
+  }
+  return { kind: 'unknown', token: trimmed, suggestions: [] };
+}
+
+function exactTargetsForProviderEntries(
+  entries: readonly ProviderNameEntry[],
+): CatalogProfileTarget[] {
+  const targets = entries.flatMap((entry) => {
+    const adapter = adapterProfileBinding(entry.id);
+    if (adapter) {
+      return [
+        { provider_id: adapter.provider_id, profile_id: adapter.profile_id },
+      ];
+    }
+    return [...adapterProfileBindings().values()]
+      .filter((binding) => binding.provider_id === entry.id)
+      .map((binding) => ({
+        provider_id: binding.provider_id,
+        profile_id: binding.profile_id,
+      }));
+  });
+  return [
+    ...new Map(
+      targets.map((target) => [
+        `${target.provider_id}/${target.profile_id}`,
+        target,
+      ]),
+    ).values(),
+  ].sort((left, right) =>
+    `${left.provider_id}/${left.profile_id}`.localeCompare(
+      `${right.provider_id}/${right.profile_id}`,
+    ),
+  );
+}
+
+function exactToken(
+  token: string,
+  binding: AdapterProfileBinding,
+  alias?: { readonly from: string; readonly adapter_id: string },
+): ConfigurationProfileTokenResolution {
+  return {
+    kind: 'exact',
+    token,
+    target: {
+      provider_id: binding.provider_id,
+      profile_id: binding.profile_id,
+    },
+    ...(alias && { alias }),
+  };
+}
+
+function canonicalizeProviderConfigs(
+  providers: Readonly<Record<string, ProviderConfig>>,
+): {
+  providerConfigs: Record<string, ProviderConfig>;
+  notices: PreparationNotice[];
+} {
+  const providerConfigs: Record<string, ProviderConfig> = {};
+  const notices: PreparationNotice[] = [];
+  const openAiCandidates = [
+    'openai-deep',
+    'openai-deep-o3',
+    'openai-research',
+  ].filter((id) => providers[id] !== undefined);
+  const selectedOpenAi = openAiCandidates.includes('openai-research')
+    ? 'openai-research'
+    : openAiCandidates.includes('openai-deep-o3')
+      ? 'openai-deep-o3'
+      : openAiCandidates.includes('openai-deep')
+        ? 'openai-deep'
+        : undefined;
+
+  for (const [id, config] of Object.entries(providers)) {
+    const adapterId = resolveProviderId(id);
+    const fallback = config.fallback
+      ? resolveProviderId(config.fallback)
+      : undefined;
+    if (adapterId !== id) {
+      notices.push({
+        code: 'configuration_provider_id_migrated',
+        phase: 'migration',
+        path: `/providers/${id}`,
+        message:
+          'A retired provider id was migrated to its canonical adapter id.',
+      });
+    }
+    if (fallback !== config.fallback && config.fallback !== undefined) {
+      notices.push({
+        code: 'configuration_fallback_id_migrated',
+        phase: 'migration',
+        path: `/providers/${id}/fallback`,
+        message:
+          'A retired fallback id was migrated to its canonical adapter id.',
+      });
+    }
+    const normalized = {
+      ...config,
+      ...(fallback !== undefined && { fallback }),
+    };
+    if (adapterId === 'openai-research' && id !== selectedOpenAi) {
+      notices.push({
+        code: 'configuration_provider_alias_collision',
+        phase: 'migration',
+        path: `/providers/${id}`,
+        message:
+          'A colliding OpenAI research alias was ignored by canonical precedence.',
+      });
+      continue;
+    }
+    if (!providerConfigs[adapterId] || id === adapterId) {
+      providerConfigs[adapterId] = normalized;
+      continue;
+    }
+    notices.push({
+      code: 'configuration_provider_alias_collision',
+      phase: 'migration',
+      path: `/providers/${id}`,
+      message:
+        'A colliding provider alias was ignored because its canonical adapter is configured.',
+    });
+  }
+  return { providerConfigs, notices };
+}
+
+function materializeProviderConfigs(config: Config): {
+  providerConfigs: Record<string, ProviderConfig>;
+  notices: PreparationNotice[];
+} {
+  const byAdapter: Record<string, ProviderConfig> = {};
+  const bindings = adapterProfileBindings();
+  const normalized = canonicalizeProviderConfigs(config.providers);
+
+  for (const [adapterId, providerConfig] of Object.entries(
+    normalized.providerConfigs,
+  )) {
+    const binding = bindings.get(adapterId);
+    const options = { ...(providerConfig.options ?? {}) };
+    // v1 applies this global only to LLM/chat providers, and only when the
+    // provider did not make an explicit per-provider choice.
+    if (binding?.profile_id === 'chat' && options.webSearch === undefined) {
+      options.webSearch = config.defaults.llmWebSearch;
+    }
+    byAdapter[adapterId] = {
+      ...providerConfig,
+      ...(Object.keys(options).length > 0 && { options }),
+    };
+  }
+
+  return { providerConfigs: byAdapter, notices: normalized.notices };
+}
+
+function authoredGroups(
+  provenance: AuthoredGroupProvenance,
+): Record<string, readonly string[]> {
+  // Project authoring intentionally wins without reordering either layer.
+  return { ...provenance.global, ...provenance.project };
+}
+
+function canonicalizeGroups(
+  groups: Readonly<Record<string, readonly string[]>>,
+): {
+  groups: Record<string, string[]>;
+  notices: PreparationNotice[];
+  issues: PreparationIssue[];
+} {
+  const mapped: Record<string, string[]> = {};
+  const notices: PreparationNotice[] = [];
+  const issues: PreparationIssue[] = [];
+  for (const [name, members] of Object.entries(groups)) {
+    const exact: string[] = [];
+    const seen = new Set<string>();
+    for (const [index, member] of members.entries()) {
+      const path = `/groups/${name}/${index}`;
+      const resolution = resolveConfigurationProfileToken(member);
+      if (resolution.kind === 'unknown') {
+        issues.push({
+          code: 'configuration_group_member_unknown',
+          phase: 'migration',
+          path,
+          message:
+            'The group member does not resolve to an implemented exact provider profile.',
+        });
+        continue;
+      }
+      if (resolution.kind === 'ambiguous') {
+        issues.push({
+          code: 'configuration_group_member_ambiguous',
+          phase: 'migration',
+          path,
+          message:
+            'The group member resolves to multiple profiles. Use a qualified "provider/profile" reference.',
+        });
+        continue;
+      }
+      if (resolution.alias) {
+        notices.push({
+          code: 'configuration_provider_alias_migrated',
+          phase: 'migration',
+          path,
+          message:
+            'A retired provider alias was migrated to its exact profile.',
+          profile_key: `${resolution.target.provider_id}/${resolution.target.profile_id}`,
+        });
+      }
+      const key = `${resolution.target.provider_id}/${resolution.target.profile_id}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        exact.push(key);
+      }
+    }
+    mapped[name] = exact;
+  }
+  return { groups: mapped, notices, issues };
+}
+
+function groupAliases(
+  groups: Readonly<Record<string, readonly string[]>>,
+  catalog: ProviderCatalog,
+): Record<string, string> {
+  const customGroups = new Set(catalog.custom_group_ids);
+  const aliases: Record<string, string> = {};
+  for (const name of Object.keys(groups)) {
+    if (name.startsWith('custom:')) continue;
+    const target = customWorkflowId(name);
+    if (customGroups.has(target) && !groups[target]) {
+      aliases[name] = target;
+    }
+  }
+  return aliases;
+}
+
+function fallbackReserve(
+  providerConfigs: Readonly<Record<string, ProviderConfig>>,
+): {
+  reserve: CatalogProfileTarget[];
+  reserveOnlyAdapterIds: string[];
+  notices: PreparationNotice[];
+  issues: PreparationIssue[];
+} {
+  const reserve: CatalogProfileTarget[] = [];
+  const reserveOnlyAdapterIds: string[] = [];
+  const issues: PreparationIssue[] = [];
+  const notices: PreparationNotice[] = [];
+  const seen = new Set<string>();
+  const reserveOnly = new Set<string>();
+  const accepted: Array<{
+    readonly adapterId: string;
+    readonly fallback: string;
+    readonly target: AdapterProfileBinding;
+    readonly path: string;
+  }> = [];
+
+  for (const [adapterId, providerConfig] of Object.entries(providerConfigs)) {
+    const fallback = (providerConfig as { fallback?: unknown }).fallback;
+    if (fallback === undefined) continue;
+    const path = `/providers/${adapterId}/fallback`;
+    if (providerConfig.enabled !== true) {
+      notices.push({
+        code: 'configuration_fallback_disabled_source_omitted',
+        phase: 'migration',
+        path,
+        message: 'A fallback from a disabled source adapter was omitted.',
+      });
+      continue;
+    }
+    if (typeof fallback !== 'string' || fallback.trim().length === 0) {
+      issues.push({
+        code: 'configuration_fallback_malformed',
+        phase: 'migration',
+        path,
+        message:
+          'A configured fallback must be a non-empty adapter id. Remove it or name an implemented adapter.',
+      });
+      continue;
+    }
+
+    const source = adapterProfileBinding(adapterId);
+    if (!source) {
+      issues.push({
+        code: 'configuration_fallback_unbound_source',
+        phase: 'migration',
+        path,
+        message:
+          'The configured source adapter has no exact executable profile binding, so its fallback cannot be migrated.',
+      });
+      continue;
+    }
+    const target = adapterProfileBinding(fallback);
+    if (!target) {
+      issues.push({
+        code: providerConfigs[fallback]
+          ? 'configuration_fallback_unbound_target'
+          : 'configuration_fallback_unknown_adapter',
+        phase: 'migration',
+        path,
+        message: providerConfigs[fallback]
+          ? 'The fallback adapter has no exact executable profile binding.'
+          : 'The fallback adapter is not a known implemented adapter.',
+      });
+      continue;
+    }
+    if (!providerConfigs[fallback]) {
+      issues.push({
+        code: 'configuration_fallback_target_unconfigured',
+        phase: 'migration',
+        path,
+        message:
+          'The fallback adapter is implemented but is not explicitly configured.',
+      });
+      continue;
+    }
+    if (sameProfile(source, target)) {
+      issues.push({
+        code: 'configuration_fallback_self_reference',
+        phase: 'migration',
+        path,
+        message:
+          'The fallback resolves to the same exact profile as its configured source.',
+        profile_key: profileKey(target),
+      });
+      continue;
+    }
+
+    accepted.push({ adapterId, fallback, target, path });
+  }
+
+  const acceptedSources = new Set(accepted.map((edge) => edge.adapterId));
+  for (const edge of accepted) {
+    if (acceptedSources.has(edge.fallback)) {
+      notices.push({
+        code: 'configuration_fallback_chain_flattened',
+        phase: 'migration',
+        path: edge.path,
+        message:
+          'A fallback chain was flattened into the ordered global fallback reserve.',
+      });
+    }
+
+    const key = profileKey(edge.target);
+    if (!seen.has(key)) {
+      seen.add(key);
+      reserve.push({
+        provider_id: edge.target.provider_id,
+        profile_id: edge.target.profile_id,
+      });
+    }
+    if (
+      providerConfigs[edge.fallback]?.enabled === false &&
+      !reserveOnly.has(edge.fallback)
+    ) {
+      reserveOnly.add(edge.fallback);
+      reserveOnlyAdapterIds.push(edge.fallback);
+    }
+  }
+
+  return { reserve, reserveOnlyAdapterIds, notices, issues };
+}
+
+function sameProfile(
+  left: Pick<AdapterProfileBinding, 'provider_id' | 'profile_id'>,
+  right: Pick<AdapterProfileBinding, 'provider_id' | 'profile_id'>,
+): boolean {
+  return (
+    left.provider_id === right.provider_id &&
+    left.profile_id === right.profile_id
+  );
+}
+
+function profileKey(binding: AdapterProfileBinding): string {
+  return `${binding.provider_id}/${binding.profile_id}`;
+}
+
+function canonicalDefaults(
+  config: Config,
+  requestDeadlineMs: number | undefined,
+  issues: PreparationIssue[],
+): CanonicalTransportDefaults | undefined {
+  if (requestDeadlineMs === undefined) {
+    issues.push({
+      code: 'configuration_request_deadline_required',
+      phase: 'migration',
+      path: '/defaults/requestDeadlineMs',
+      message:
+        'The v1 total request-deadline conversion is not approved. Supply requestDeadlineMs explicitly when mapping this configuration.',
+    });
+    return undefined;
+  }
+  const budgets = exactUsdBudgets(
+    config.defaults.maxCostUsd,
+    config.defaults.maxEstimatedCostUsd,
+    '/defaults',
+  );
+  issues.push(...budgets.issues);
+  if (budgets.issues.length > 0) return undefined;
+  return {
+    mode: config.defaults.mode,
+    limits: {
+      max_concurrency: config.defaults.maxParallel,
+      request_deadline_ms: requestDeadlineMs,
+      inline_attempt_deadline_ms: config.defaults.timeout * 1_000,
+      background_attempt_deadline_ms: config.defaults.asyncTimeout * 1_000,
+      poll_interval_ms: config.defaults.asyncPollInterval * 1_000,
+    },
+    fallback: { kind: 'configured' },
+    refinement: { kind: 'disabled' },
+    ...(budgets.budgets && { budgets: budgets.budgets }),
+  };
+}
+
+/**
+ * Map an already validated v1 Config into catalog policy and injected canonical
+ * transport defaults. Diagnostics contain no credentials and are stable by
+ * path/code ordering.
+ */
+export function mapConfiguration(
+  config: Config,
+  options: ConfigurationMappingOptions,
+): ConfigurationMappingResult {
+  const providerConfigMapping = materializeProviderConfigs(config);
+  const providerConfigs = providerConfigMapping.providerConfigs;
+  const authored = authoredGroups(options.authoredGroups);
+  const canonicalGroups = canonicalizeGroups(authored);
+  const groups = canonicalGroups.groups;
+  const fallback = fallbackReserve(providerConfigs);
+  const issues = [...canonicalGroups.issues, ...fallback.issues];
+  const transportDefaults = canonicalDefaults(
+    config,
+    options.requestDeadlineMs,
+    issues,
+  );
+  const catalog = buildProviderCatalog({
+    ...(options.catalog && { catalog: options.catalog }),
+    providerConfigs,
+    ...(options.credentials && { credentials: options.credentials }),
+    groups,
+    // Defaults intentionally stay catalog-owned. config.providers never
+    // derives a v2 default roster.
+    reserve: fallback.reserve,
+    reserveOnlyAdapterIds: fallback.reserveOnlyAdapterIds,
+  });
+  const notices = [
+    ...canonicalGroups.notices,
+    ...providerConfigMapping.notices,
+    ...fallback.notices,
+    ...catalog.notices,
+  ].sort(comparePreparationDiagnostics);
+  const allIssues = [...issues, ...catalog.issues].sort(
+    comparePreparationDiagnostics,
+  );
+  const aliases = groupAliases(groups, catalog);
+
+  return {
+    catalog,
+    ...(transportDefaults && { transport_defaults: transportDefaults }),
+    transport_input: {
+      defaults: {
+        mode: config.defaults.mode,
+        maxParallel: config.defaults.maxParallel,
+        timeout: config.defaults.timeout,
+        asyncTimeout: config.defaults.asyncTimeout,
+        asyncPollInterval: config.defaults.asyncPollInterval,
+        maxCostUsd: config.defaults.maxCostUsd,
+        maxEstimatedCostUsd: config.defaults.maxEstimatedCostUsd,
+      },
+    },
+    groups,
+    group_aliases: aliases,
+    reserve: fallback.reserve,
+    reserve_only_adapter_ids: fallback.reserveOnlyAdapterIds,
+    preflight: { notices, issues: allIssues },
+  };
+}

--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -30,6 +30,7 @@ import {
 import {
   type CanonicalResearchRequest,
   CanonicalResearchRequestSchema,
+  comparePreparationDiagnostics,
   migrateLegacyResearchRequest,
   type PreparationIssue,
   type PreparationNotice,
@@ -57,6 +58,8 @@ export interface PlanningProfile {
   readonly enabled: boolean;
   readonly credentialed: boolean;
   readonly configuration_valid: boolean;
+  /** Disabled in v1 but deliberately retained for fallback reserve only. */
+  readonly reserve_only?: boolean;
 }
 
 /**
@@ -137,15 +140,6 @@ interface SelectedProfile {
   readonly requirements?: EvidenceRequirements;
 }
 
-const PHASE_ORDER = {
-  transport: 0,
-  migration: 1,
-  canonicalization: 2,
-  selection: 3,
-  validation: 4,
-  compilation: 5,
-} as const;
-
 function escapeJsonPointerToken(token: string): string {
   return token.replaceAll('~', '~0').replaceAll('/', '~1');
 }
@@ -208,15 +202,7 @@ function canonicalIssueCode(path: string, message: string): string {
 function sortDiagnostics<T extends PreparationIssue | PreparationNotice>(
   diagnostics: readonly T[],
 ): T[] {
-  const compareText = (left: string, right: string): number =>
-    left < right ? -1 : left > right ? 1 : 0;
-  return [...diagnostics].sort(
-    (left, right) =>
-      PHASE_ORDER[left.phase] - PHASE_ORDER[right.phase] ||
-      compareText(left.path, right.path) ||
-      compareText(left.code, right.code) ||
-      compareText(left.profile_key ?? '', right.profile_key ?? ''),
-  );
+  return [...diagnostics].sort(comparePreparationDiagnostics);
 }
 
 function profileIdentityKey(identity: ProviderIdentity): string {
@@ -391,11 +377,20 @@ function resolveIdentities(
 function profileAvailabilityIssues(
   selection: SelectedProfile,
   mode: CanonicalResearchRequest['mode'],
+  allowReserveOnly = false,
 ): PreparationIssue[] {
   const { entry, path } = selection;
   const key = profileIdentityKey(entry.profile.identity);
   const issues: PreparationIssue[] = [];
-  if (!entry.enabled) {
+  if (entry.reserve_only && !allowReserveOnly) {
+    issues.push({
+      code: 'profile_reserve_only',
+      phase: 'validation',
+      path,
+      message: 'The selected profile is available only as a fallback reserve.',
+      profile_key: key,
+    });
+  } else if (!entry.enabled && !(allowReserveOnly && entry.reserve_only)) {
     issues.push({
       code: 'profile_disabled',
       phase: 'validation',
@@ -441,6 +436,7 @@ function isUsableCapabilityMatch(
 ): boolean {
   return (
     entry.enabled &&
+    !entry.reserve_only &&
     entry.credentialed &&
     entry.configuration_valid &&
     (request.mode !== 'async' || entry.profile.resumability === 'durable') &&
@@ -790,7 +786,11 @@ function resolveReserve(
       continue;
     }
 
-    const availability = profileAvailabilityIssues(selection, request.mode);
+    const availability = profileAvailabilityIssues(
+      selection,
+      request.mode,
+      true,
+    );
     if (availability.length > 0) {
       if (explicit) {
         issues.push(...availability);

--- a/src/core/profile-bindings.ts
+++ b/src/core/profile-bindings.ts
@@ -239,10 +239,13 @@ function firecrawlSourcesProjection(
   return corpora.length > 0 ? { ...profile, corpora } : profile;
 }
 
-interface BindingSpec {
+export interface AdapterProfileBinding {
+  readonly adapter_id: string;
   readonly provider_id: string;
   readonly profile_id: string;
-  readonly adapter_id: string;
+}
+
+interface BindingSpec extends AdapterProfileBinding {
   readonly project?: BindingInput['project'];
 }
 
@@ -392,6 +395,57 @@ export const BUILTIN_PROFILE_BINDING_SPECS: readonly BindingSpec[] = [
     project: chatWebSearchProjection,
   },
 ];
+
+/**
+ * Resolve one v1 adapter id to its exact catalog identity.
+ *
+ * Provider configuration is keyed by adapter id, while the v2 catalog is
+ * keyed by provider/profile. Keeping this small validated bridge here avoids
+ * callers accidentally treating an alias as a provider id (notably the two
+ * distinct OpenRouter strategies).
+ */
+export function adapterProfileBinding(
+  adapterId: string,
+  specs: readonly AdapterProfileBinding[] = BUILTIN_PROFILE_BINDING_SPECS,
+): AdapterProfileBinding | undefined {
+  const matches = specs.filter((spec) => spec.adapter_id === adapterId);
+  if (matches.length > 1) {
+    throw new ProfileBindingError(
+      `Adapter id has more than one exact profile binding: ${adapterId}`,
+    );
+  }
+  const match = matches[0];
+  return match
+    ? Object.freeze({
+        adapter_id: match.adapter_id,
+        provider_id: match.provider_id,
+        profile_id: match.profile_id,
+      })
+    : undefined;
+}
+
+/** Validate and materialize the complete adapter-id binding matrix. */
+export function adapterProfileBindings(
+  specs: readonly AdapterProfileBinding[] = BUILTIN_PROFILE_BINDING_SPECS,
+): ReadonlyMap<string, AdapterProfileBinding> {
+  const bindings = new Map<string, AdapterProfileBinding>();
+  for (const spec of specs) {
+    if (bindings.has(spec.adapter_id)) {
+      throw new ProfileBindingError(
+        `Adapter id has more than one exact profile binding: ${spec.adapter_id}`,
+      );
+    }
+    bindings.set(
+      spec.adapter_id,
+      Object.freeze({
+        adapter_id: spec.adapter_id,
+        provider_id: spec.provider_id,
+        profile_id: spec.profile_id,
+      }),
+    );
+  }
+  return bindings;
+}
 
 export function buildProfileBindings(
   declarationsByKey: ReadonlyMap<string, ExecutableProfileDeclaration>,

--- a/src/core/profile-catalog.ts
+++ b/src/core/profile-catalog.ts
@@ -52,6 +52,7 @@ export interface ResolvedCatalogProfile {
   readonly estimate?: NetworkFreeEstimate;
   readonly availability: {
     readonly enabled: boolean;
+    readonly reserve_only: boolean;
     readonly credential_valid: boolean;
     readonly configuration_valid: boolean;
     readonly selectable: boolean;
@@ -76,6 +77,8 @@ export interface ProviderCatalogOptions {
   readonly defaults?: readonly CatalogProfileTarget[];
   /** The ordered global reserve for `fallback: configured`. */
   readonly reserve?: readonly CatalogProfileTarget[];
+  /** Adapter ids which are disabled for primary selection but valid reserve. */
+  readonly reserveOnlyAdapterIds?: readonly string[];
 }
 
 export interface WorkflowOmission {
@@ -158,6 +161,7 @@ function resolveDeclaration(
       profile: ownFrozen(declared),
       availability: ownFrozen({
         enabled: false,
+        reserve_only: false,
         credential_valid: false,
         configuration_valid: true,
         selectable: false,
@@ -168,6 +172,9 @@ function resolveDeclaration(
 
   const providerConfig = bindingConfig(options, binding.adapter_id);
   const enabled = providerConfig?.enabled === true;
+  const reserveOnly =
+    !enabled &&
+    options.reserveOnlyAdapterIds?.includes(binding.adapter_id) === true;
   const credentialReference =
     providerConfig?.apiKey ??
     (entry.credential.env_var ? `$${entry.credential.env_var}` : undefined);
@@ -206,6 +213,7 @@ function resolveDeclaration(
     ...(estimate && { estimate: ownFrozen(estimate) }),
     availability: ownFrozen({
       enabled,
+      reserve_only: reserveOnly,
       credential_valid: credentialValid,
       configuration_valid: configurationValid,
       selectable: enabled && credentialValid && configurationValid,
@@ -528,6 +536,7 @@ export function buildProviderCatalog(
       },
       ...(item.estimate && { estimate: item.estimate }),
       enabled: item.availability.enabled,
+      reserve_only: item.availability.reserve_only,
       credentialed: item.availability.credential_valid,
       configuration_valid: item.availability.configuration_valid,
     }));

--- a/src/core/research-request.ts
+++ b/src/core/research-request.ts
@@ -187,6 +187,39 @@ export interface PreparationDiagnostic {
 export type PreparationIssue = PreparationDiagnostic;
 export type PreparationNotice = PreparationDiagnostic;
 
+const PREPARATION_PHASE_ORDER: Readonly<Record<PreparationPhase, number>> = {
+  transport: 0,
+  migration: 1,
+  canonicalization: 2,
+  selection: 3,
+  validation: 4,
+  compilation: 5,
+};
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Stable ordering for every preflight, normalization, and planner diagnostic. */
+export function comparePreparationDiagnostics(
+  left: PreparationIssue | PreparationNotice,
+  right: PreparationIssue | PreparationNotice,
+): number {
+  return (
+    PREPARATION_PHASE_ORDER[left.phase] -
+      PREPARATION_PHASE_ORDER[right.phase] ||
+    compareText(left.path, right.path) ||
+    compareText(left.code, right.code) ||
+    compareText(left.profile_key ?? '', right.profile_key ?? '')
+  );
+}
+
+export function sortPreparationDiagnostics<
+  T extends PreparationIssue | PreparationNotice,
+>(diagnostics: readonly T[]): T[] {
+  return [...diagnostics].sort(comparePreparationDiagnostics);
+}
+
 export interface LegacyMigrationResult {
   readonly input: unknown;
   readonly notices: readonly PreparationNotice[];

--- a/src/core/transport-normalization.ts
+++ b/src/core/transport-normalization.ts
@@ -14,6 +14,7 @@ import type {
   RefinementIntent,
   ResearchExecutionLimits,
 } from './research-request.js';
+import { sortPreparationDiagnostics } from './research-request.js';
 
 /**
  * Shadow-only transport normalization for the v2 request pipeline
@@ -48,10 +49,12 @@ export type TransportSource =
 
 /** Injected per-caller context; this module ships no default policy values. */
 export interface CanonicalTransportDefaults {
-  readonly mode: 'sync' | 'async';
+  /** `mixed` reaches the existing legacy migration boundary unchanged. */
+  readonly mode: 'sync' | 'async' | 'mixed';
   readonly limits: ResearchExecutionLimits;
   readonly fallback: FallbackIntent;
   readonly refinement: RefinementIntent;
+  readonly budgets?: ExactBudgetLimits;
 }
 
 export type TransportNormalizationResult =
@@ -210,7 +213,11 @@ function normalizeTransportRequest(
   }
 
   if (issues.length > 0) {
-    return { ok: false, issues, notices };
+    return {
+      ok: false,
+      issues: sortPreparationDiagnostics(issues),
+      notices: sortPreparationDiagnostics(notices),
+    };
   }
 
   const request: Record<string, unknown> = {
@@ -222,8 +229,9 @@ function normalizeTransportRequest(
     exclusions: fields.exclusions ?? [],
     refinement: fields.refinement ?? defaults.refinement,
   };
-  if (fields.budgets !== undefined) request.budgets = fields.budgets;
-  return { ok: true, request, notices };
+  const budgets = fields.budgets ?? defaults.budgets;
+  if (budgets !== undefined) request.budgets = budgets;
+  return { ok: true, request, notices: sortPreparationDiagnostics(notices) };
 }
 
 /**
@@ -262,7 +270,10 @@ export function compileNormalizedTransportRequest(
     catalog,
     dependencies,
   );
-  const notices = [...normalized.notices, ...result.notices];
+  const notices = sortPreparationDiagnostics([
+    ...normalized.notices,
+    ...result.notices,
+  ]);
   return result.ok
     ? { ok: true, prepared: result.prepared, notices }
     : { ok: false, issues: result.issues, notices };
@@ -326,12 +337,15 @@ function targetsFromProviderIds(
   return { value: targets, raw_path: path };
 }
 
-function usdBudgets(
+export function exactUsdBudgets(
   maxCostUsd: number | undefined,
   maxEstimatedCostUsd: number | undefined,
   pathPrefix: string,
-  issues: PreparationIssue[],
-): ExactBudgetLimits | undefined {
+): {
+  readonly budgets?: ExactBudgetLimits;
+  readonly issues: readonly PreparationIssue[];
+} {
+  const issues: PreparationIssue[] = [];
   const budgets: {
     max_estimated_cost_microusd?: string;
     max_actual_cost_microusd?: string;
@@ -352,10 +366,24 @@ function usdBudgets(
     if ('issue' in converted) issues.push(converted.issue);
     else budgets.max_actual_cost_microusd = converted.value;
   }
-  return budgets.max_estimated_cost_microusd !== undefined ||
+  return {
+    ...(budgets.max_estimated_cost_microusd !== undefined ||
     budgets.max_actual_cost_microusd !== undefined
-    ? budgets
-    : undefined;
+      ? { budgets }
+      : {}),
+    issues,
+  };
+}
+
+function usdBudgets(
+  maxCostUsd: number | undefined,
+  maxEstimatedCostUsd: number | undefined,
+  pathPrefix: string,
+  issues: PreparationIssue[],
+): ExactBudgetLimits | undefined {
+  const result = exactUsdBudgets(maxCostUsd, maxEstimatedCostUsd, pathPrefix);
+  issues.push(...result.issues);
+  return result.budgets;
 }
 
 function toggleIntent<TIntent>(
@@ -547,9 +575,21 @@ export interface ConfigurationTransportInput {
   readonly defaults?: {
     readonly mode?: string;
     readonly maxParallel?: number;
+    /** v1 inline per-attempt deadline, in seconds. */
+    readonly timeout?: number;
+    /** v1 background per-attempt deadline, in seconds. */
+    readonly asyncTimeout?: number;
+    /** v1 background poll interval, in seconds. */
+    readonly asyncPollInterval?: number;
+    /** Explicit caller-provided canonical request deadline, in milliseconds. */
+    readonly requestDeadlineMs?: number;
+    /** @deprecated shadow compatibility spelling; prefer timeout. */
     readonly timeoutSeconds?: number;
+    /** @deprecated shadow compatibility spelling; prefer asyncTimeout. */
     readonly backgroundTimeoutSeconds?: number;
+    /** @deprecated shadow compatibility spelling; prefer requestDeadlineMs. */
     readonly requestTimeoutSeconds?: number;
+    /** @deprecated shadow compatibility spelling; prefer asyncPollInterval. */
     readonly pollIntervalSeconds?: number;
     readonly maxCostUsd?: number;
     readonly maxEstimatedCostUsd?: number;
@@ -566,18 +606,24 @@ export function normalizeConfigurationRequest(
   if (configured.maxParallel !== undefined) {
     limits.max_concurrency = configured.maxParallel;
   }
-  if (configured.timeoutSeconds !== undefined) {
-    limits.inline_attempt_deadline_ms = configured.timeoutSeconds * 1_000;
+  const timeout = configured.timeout ?? configured.timeoutSeconds;
+  if (timeout !== undefined) {
+    limits.inline_attempt_deadline_ms = timeout * 1_000;
   }
-  if (configured.backgroundTimeoutSeconds !== undefined) {
-    limits.background_attempt_deadline_ms =
-      configured.backgroundTimeoutSeconds * 1_000;
+  const backgroundTimeout =
+    configured.asyncTimeout ?? configured.backgroundTimeoutSeconds;
+  if (backgroundTimeout !== undefined) {
+    limits.background_attempt_deadline_ms = backgroundTimeout * 1_000;
   }
-  if (configured.requestTimeoutSeconds !== undefined) {
+  if (configured.requestDeadlineMs !== undefined) {
+    limits.request_deadline_ms = configured.requestDeadlineMs;
+  } else if (configured.requestTimeoutSeconds !== undefined) {
     limits.request_deadline_ms = configured.requestTimeoutSeconds * 1_000;
   }
-  if (configured.pollIntervalSeconds !== undefined) {
-    limits.poll_interval_ms = configured.pollIntervalSeconds * 1_000;
+  const pollInterval =
+    configured.asyncPollInterval ?? configured.pollIntervalSeconds;
+  if (pollInterval !== undefined) {
+    limits.poll_interval_ms = pollInterval * 1_000;
   }
   return normalizeTransportRequest(
     'configuration',

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -323,6 +323,56 @@ describe('configuration mapping', () => {
     }
   });
 
+  it('preserves JSON-authored prototype-like group names as own custom groups', () => {
+    const source = config({
+      providers: {
+        exa: { enabled: true },
+        tavily: { enabled: true },
+        'brave-search': { enabled: true },
+      },
+    });
+    source.groups = JSON.parse(
+      '{"__proto__":["exa"],"constructor":["tavily"],"prototype":["brave-search"]}',
+    ) as Config['groups'];
+    const mapped = map(source, {
+      requestDeadlineMs: 2_000_000,
+      credentials: credentials(),
+    });
+
+    expect(Object.getPrototypeOf(mapped.groups)).toBe(Object.prototype);
+    for (const [name, member] of [
+      ['__proto__', 'exa/search'],
+      ['constructor', 'tavily/search'],
+      ['prototype', 'brave-search/search'],
+    ]) {
+      expect(Object.hasOwn(mapped.groups, name)).toBe(true);
+      expect(mapped.groups[name]).toEqual([member]);
+      expect(mapped.group_aliases[name]).toBe(`custom:${name}`);
+      expect(mapped.catalog.custom_group_ids).toContain(`custom:${name}`);
+    }
+    expect(keys(mapped.catalog.resolveGroup('custom:__proto__') ?? [])).toEqual(
+      ['exa/search'],
+    );
+  });
+
+  it('handles a JSON-authored provider prototype key without prototype lookup', () => {
+    const source = config();
+    source.providers = JSON.parse(
+      '{"__proto__":{"enabled":true,"fallback":"exa"},"exa":{"enabled":true}}',
+    ) as Config['providers'];
+    const mapped = map(source, {
+      requestDeadlineMs: 2_000_000,
+      credentials: credentials(),
+    });
+    expect(mapped.preflight.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_unbound_source',
+        path: '/providers/__proto__/fallback',
+      }),
+    );
+    expect(keys(mapped.catalog.resolveDefault())).toEqual(['exa/search']);
+  });
+
   it('retains raw global and project authored layers with project precedence', () => {
     const global = config({
       groups: {

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -1,0 +1,771 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  configGroupProvenance,
+  loadConfig,
+  mergeConfigs,
+} from '../src/core/config.js';
+import {
+  type ConfigurationMappingOptions,
+  mapConfiguration as mapRawConfiguration,
+  resolveConfigurationProfileToken,
+} from '../src/core/configuration-mapping.js';
+import { prepareResearchExecution } from '../src/core/execution-plan.js';
+import {
+  adapterProfileBinding,
+  adapterProfileBindings,
+  BUILTIN_PROFILE_BINDING_SPECS,
+} from '../src/core/profile-bindings.js';
+import { BUILTIN_PROVIDER_CATALOG } from '../src/core/provider-profiles.js';
+import { sortPreparationDiagnostics } from '../src/core/research-request.js';
+import {
+  compileNormalizedTransportRequest,
+  normalizeCliRequest,
+  normalizeConfigurationRequest,
+  normalizeMcpRequest,
+} from '../src/core/transport-normalization.js';
+import type { Config } from '../src/types.js';
+
+function config(
+  overrides: Partial<Config> & {
+    defaults?: Partial<Config['defaults']>;
+  } = {},
+): Config {
+  const { defaults, ...rest } = overrides;
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel: 6,
+      timeout: 30,
+      asyncTimeout: 1800,
+      asyncPollInterval: 10,
+      mode: 'sync',
+      llmWebSearch: true,
+      ...defaults,
+    },
+    providers: {},
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {},
+    ...rest,
+  };
+}
+
+function credentials() {
+  return {
+    env: Object.fromEntries(
+      BUILTIN_PROVIDER_CATALOG.map((entry) => [
+        entry.credential.env_var,
+        'test-credential',
+      ]),
+    ),
+  };
+}
+
+function dependencies() {
+  const counts = new Map<string, number>();
+  return {
+    clock: { now: () => Date.parse('2026-08-09T12:00:00Z') },
+    ids: {
+      next: (scope: 'request' | 'slot' | 'fallback_candidate') => {
+        const next = (counts.get(scope) ?? 0) + 1;
+        counts.set(scope, next);
+        return `${scope}-${next}`;
+      },
+    },
+  };
+}
+
+function keys(values: readonly { provider_id: string; profile_id: string }[]) {
+  return values.map((value) => `${value.provider_id}/${value.profile_id}`);
+}
+
+function map(
+  config: Config,
+  options: Omit<ConfigurationMappingOptions, 'authoredGroups'> & {
+    authoredGroups?: ConfigurationMappingOptions['authoredGroups'];
+  } = {},
+) {
+  return mapRawConfiguration(config, {
+    authoredGroups: { global: config.groups, project: {} },
+    ...options,
+  });
+}
+
+describe('configuration mapping', () => {
+  it('orders preflight diagnostics by phase, path, code, and profile key', () => {
+    const sorted = sortPreparationDiagnostics([
+      {
+        code: 'z',
+        phase: 'validation',
+        path: '/a',
+        message: 'validation',
+      },
+      {
+        code: 'z',
+        phase: 'migration',
+        path: '/z',
+        message: 'migration later path',
+      },
+      {
+        code: 'a',
+        phase: 'migration',
+        path: '/a',
+        message: 'migration earlier path',
+      },
+      {
+        code: 'same',
+        phase: 'migration',
+        path: '/same',
+        message: 'later key',
+        profile_key: 'z/profile',
+      },
+      {
+        code: 'same',
+        phase: 'migration',
+        path: '/same',
+        message: 'earlier key',
+        profile_key: 'a/profile',
+      },
+      {
+        code: 'a-code',
+        phase: 'migration',
+        path: '/tie',
+        message: 'code first',
+      },
+      {
+        code: 'z-code',
+        phase: 'migration',
+        path: '/tie',
+        message: 'code last',
+      },
+    ]);
+    expect(
+      sorted.map(({ phase, path, code, profile_key }) => [
+        phase,
+        path,
+        code,
+        profile_key,
+      ]),
+    ).toEqual([
+      ['migration', '/a', 'a', undefined],
+      ['migration', '/same', 'same', 'a/profile'],
+      ['migration', '/same', 'same', 'z/profile'],
+      ['migration', '/tie', 'a-code', undefined],
+      ['migration', '/tie', 'z-code', undefined],
+      ['migration', '/z', 'z', undefined],
+      ['validation', '/a', 'z', undefined],
+    ]);
+  });
+
+  it('uses the validated full adapter matrix, including distinct OpenRouter identities', () => {
+    const matrix = adapterProfileBindings();
+    expect(matrix.size).toBe(BUILTIN_PROFILE_BINDING_SPECS.length);
+    expect(
+      [...matrix.values()].map((binding) => binding.adapter_id).sort(),
+    ).toEqual(
+      BUILTIN_PROFILE_BINDING_SPECS.map((binding) => binding.adapter_id).sort(),
+    );
+    expect(adapterProfileBinding('openrouter-online')).toMatchObject({
+      provider_id: 'openrouter',
+      profile_id: 'grounded',
+    });
+    expect(adapterProfileBinding('openrouter-chat')).toMatchObject({
+      provider_id: 'openrouter',
+      profile_id: 'chat',
+    });
+  });
+
+  it('resolves aliases, display names, and qualified profiles without collapsing OpenRouter', () => {
+    expect(resolveConfigurationProfileToken('perplexity-sonar')).toEqual({
+      kind: 'exact',
+      token: 'perplexity-sonar',
+      target: { provider_id: 'perplexity-sonar-pro', profile_id: 'grounded' },
+      alias: {
+        from: 'perplexity-sonar',
+        adapter_id: 'perplexity-sonar-pro',
+      },
+    });
+    expect(
+      resolveConfigurationProfileToken('OpenRouter Online Search'),
+    ).toEqual({
+      kind: 'exact',
+      token: 'OpenRouter Online Search',
+      target: { provider_id: 'openrouter', profile_id: 'grounded' },
+    });
+    expect(resolveConfigurationProfileToken('openrouter/chat')).toEqual({
+      kind: 'exact',
+      token: 'openrouter/chat',
+      target: { provider_id: 'openrouter', profile_id: 'chat' },
+    });
+    expect(resolveConfigurationProfileToken('openrouter')).toEqual({
+      kind: 'ambiguous',
+      token: 'openrouter',
+      candidates: [
+        { provider_id: 'openrouter', profile_id: 'chat' },
+        { provider_id: 'openrouter', profile_id: 'grounded' },
+      ],
+    });
+  });
+
+  it('preserves raw aliases from the real load/merge path for mapper notices', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'librarium-mapping-'));
+    try {
+      const path = join(directory, 'config.json');
+      writeFileSync(
+        path,
+        JSON.stringify(config({ groups: { global: ['perplexity-sonar'] } })),
+      );
+      const merged = mergeConfigs(loadConfig(path), {
+        groups: { project: ['perplexity-sonar'] },
+      });
+      const provenance = configGroupProvenance(merged);
+      expect(provenance).toEqual({
+        global: { global: ['perplexity-sonar'] },
+        project: { project: ['perplexity-sonar'] },
+      });
+      // v1 merged execution remains canonicalized independently.
+      expect(merged.groups.global).toEqual(['perplexity-sonar-pro']);
+      expect(merged.groups.project).toEqual(['perplexity-sonar-pro']);
+
+      const mapped = map(merged, {
+        requestDeadlineMs: 2_000_000,
+        credentials: credentials(),
+        authoredGroups: provenance,
+      });
+      expect(mapped.groups).toEqual({
+        global: ['perplexity-sonar-pro/grounded'],
+        project: ['perplexity-sonar-pro/grounded'],
+      });
+      expect(
+        mapped.preflight.notices.filter(
+          (notice) => notice.code === 'configuration_provider_alias_migrated',
+        ),
+      ).toHaveLength(2);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves the default roster catalog-owned and ordered by selection order', () => {
+    const mapped = map(
+      config({
+        // Deliberately opposite catalog order.
+        providers: {
+          'brave-search': { enabled: true },
+          exa: { enabled: true },
+        },
+      }),
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
+    );
+
+    expect(keys(mapped.catalog.resolveDefault())).toEqual([
+      'exa/search',
+      'brave-search/search',
+    ]);
+  });
+
+  it('does not map injected v1 default groups as custom groups, but migrates explicit reserved groups', () => {
+    const global = loadConfig('/definitely/missing/librarium-config.json');
+    const direct = map(global, {
+      requestDeadlineMs: 300_000,
+      credentials: credentials(),
+      authoredGroups: configGroupProvenance(global),
+    });
+    expect(direct.catalog.custom_group_ids).toEqual([]);
+    const merged = mergeConfigs(global, {
+      groups: { quick: ['exa/search'] },
+    });
+    const mapped = map(merged, {
+      requestDeadlineMs: 300_000,
+      credentials: credentials(),
+      authoredGroups: configGroupProvenance(merged),
+    });
+
+    expect(configGroupProvenance(merged)).toEqual({
+      global: {},
+      project: { quick: ['exa/search'] },
+    });
+    expect(mapped.groups).toEqual({ quick: ['exa/search'] });
+    expect(mapped.group_aliases).toEqual({ quick: 'custom:quick' });
+    expect(mapped.catalog.custom_group_ids).toEqual(['custom:quick']);
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'reserved_workflow_name_migrated',
+        path: '/groups/quick',
+      }),
+    );
+  });
+
+  it('does not alias a colliding raw group over an explicit custom group', () => {
+    for (const [groups, code] of [
+      [
+        { quick: ['exa'], 'custom:quick': ['tavily'] },
+        'reserved_workflow_name_collision',
+      ],
+      [
+        { team: ['exa'], 'custom:team': ['tavily'] },
+        'custom_group_name_collision',
+      ],
+    ] as const) {
+      const source = config({ groups });
+      const mapped = map(source, {
+        requestDeadlineMs: 2_000_000,
+        credentials: credentials(),
+      });
+      expect(mapped.group_aliases).toEqual({});
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({ code }),
+      );
+    }
+  });
+
+  it('retains raw global and project authored layers with project precedence', () => {
+    const global = config({
+      groups: {
+        shared: ['perplexity-sonar'],
+        global: ['exa'],
+      },
+    });
+    const merged = mergeConfigs(global, {
+      groups: {
+        shared: ['OpenRouter Online Search'],
+        project: ['brave-search'],
+      },
+    });
+    const provenance = configGroupProvenance(merged);
+    expect(provenance).toEqual({
+      global: {
+        shared: ['perplexity-sonar'],
+        global: ['exa'],
+      },
+      project: {
+        shared: ['OpenRouter Online Search'],
+        project: ['brave-search'],
+      },
+    });
+    const mapped = map(merged, {
+      requestDeadlineMs: 2_000_000,
+      credentials: credentials(),
+      authoredGroups: provenance,
+    });
+    expect(mapped.groups).toEqual({
+      shared: ['openrouter/grounded'],
+      global: ['exa/search'],
+      project: ['brave-search/search'],
+    });
+  });
+
+  it('materializes defaults.llmWebSearch only for chat adapters lacking an explicit option', () => {
+    const defaultsOff = map(
+      config({
+        defaults: { llmWebSearch: false },
+        providers: { 'openrouter-chat': { enabled: true } },
+      }),
+      { requestDeadlineMs: 300_000, credentials: credentials() },
+    );
+    expect(
+      defaultsOff.catalog.get('openrouter', 'chat')?.profile.result_kind,
+    ).toBe('model_answer');
+
+    const providerOverride = map(
+      config({
+        defaults: { llmWebSearch: false },
+        providers: {
+          'openrouter-chat': { enabled: true, options: { webSearch: true } },
+        },
+      }),
+      { requestDeadlineMs: 300_000, credentials: credentials() },
+    );
+    expect(
+      providerOverride.catalog.get('openrouter', 'chat')?.profile.result_kind,
+    ).toBe('grounded_answer');
+  });
+
+  it('flattens and deduplicates valid fallback edges in declaration order', () => {
+    const mapped = map(
+      config({
+        providers: {
+          exa: { enabled: true, fallback: 'brave-search' },
+          tavily: { enabled: true, fallback: 'brave-search' },
+          'brave-search': { enabled: false },
+          serpapi: { enabled: true, fallback: 'tavily' },
+        },
+      }),
+      { requestDeadlineMs: 300_000, credentials: credentials() },
+    );
+
+    expect(keys(mapped.reserve)).toEqual([
+      'brave-search/search',
+      'tavily/search',
+    ]);
+    expect(mapped.reserve_only_adapter_ids).toEqual(['brave-search']);
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_chain_flattened',
+        path: '/providers/serpapi/fallback',
+      }),
+    );
+  });
+
+  it('does not call a rejected nested edge a flattened fallback chain', () => {
+    const mapped = map(
+      config({
+        providers: {
+          exa: { enabled: true, fallback: 'brave-search' },
+          'brave-search': { enabled: false, fallback: 'tavily' },
+          tavily: { enabled: false },
+        },
+      }),
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
+    );
+    expect(keys(mapped.reserve)).toEqual(['brave-search/search']);
+    expect(mapped.reserve_only_adapter_ids).toEqual(['brave-search']);
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_disabled_source_omitted',
+        path: '/providers/brave-search/fallback',
+      }),
+    );
+    expect(mapped.preflight.notices).not.toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_chain_flattened',
+        path: '/providers/exa/fallback',
+      }),
+    );
+  });
+
+  it('diagnoses malformed, self, unknown, and unbound fallback entries at stable paths', () => {
+    const mapped = map(
+      config({
+        providers: {
+          exa: { enabled: true, fallback: 'exa' },
+          tavily: { enabled: true, fallback: 'missing-adapter' },
+          'custom-adapter': { enabled: true, fallback: 'exa' },
+          serpapi: { enabled: true, fallback: '' },
+          'unbound-target': { enabled: true },
+          'brave-search': { enabled: true, fallback: 'unbound-target' },
+        } as Config['providers'],
+      }),
+      { requestDeadlineMs: 2_000_000 },
+    );
+    expect(
+      mapped.preflight.issues.map(({ code, path }) => [code, path]),
+    ).toEqual([
+      [
+        'configuration_fallback_unbound_target',
+        '/providers/brave-search/fallback',
+      ],
+      [
+        'configuration_fallback_unbound_source',
+        '/providers/custom-adapter/fallback',
+      ],
+      ['configuration_fallback_self_reference', '/providers/exa/fallback'],
+      ['configuration_fallback_malformed', '/providers/serpapi/fallback'],
+      ['configuration_fallback_unknown_adapter', '/providers/tavily/fallback'],
+    ]);
+  });
+
+  it('canonicalizes raw provider aliases and requires active configured fallback edges', () => {
+    const raw = config({
+      providers: {
+        'openai-deep': { enabled: true, fallback: 'perplexity-sonar' },
+        'openai-deep-o3': { enabled: false },
+        'openai-research': { enabled: true },
+        'perplexity-sonar': { enabled: false },
+        exa: { enabled: false, fallback: 'brave-search' },
+        tavily: { enabled: true, fallback: 'brave-search' },
+        serpapi: { enabled: true, fallback: 'perplexity-sonar' },
+        'brave-search': { enabled: false },
+      },
+    });
+    const mapped = map(raw, {
+      requestDeadlineMs: 2_000_000,
+      credentials: credentials(),
+    });
+    expect(
+      mapped.catalog.get('openai-research', 'research')?.availability.enabled,
+    ).toBe(true);
+    expect(keys(mapped.reserve)).toEqual([
+      'brave-search/search',
+      'perplexity-sonar-pro/grounded',
+    ]);
+    expect(mapped.reserve_only_adapter_ids).toEqual([
+      'brave-search',
+      'perplexity-sonar-pro',
+    ]);
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({ code: 'configuration_provider_id_migrated' }),
+    );
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_id_migrated',
+        path: '/providers/serpapi/fallback',
+      }),
+    );
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_provider_alias_collision',
+      }),
+    );
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_disabled_source_omitted',
+        path: '/providers/exa/fallback',
+      }),
+    );
+
+    const missingTarget = map(
+      config({
+        providers: { exa: { enabled: true, fallback: 'brave-search' } },
+      }),
+      { requestDeadlineMs: 2_000_000 },
+    );
+    expect(missingTarget.preflight.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_fallback_target_unconfigured',
+        path: '/providers/exa/fallback',
+      }),
+    );
+  });
+
+  it('keeps disabled fallback-only profiles out of primary selection but permits the reserve', () => {
+    const mapped = map(
+      config({
+        providers: {
+          exa: { enabled: true, fallback: 'brave-search' },
+          'brave-search': { enabled: false },
+        },
+      }),
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
+    );
+    expect(keys(mapped.catalog.resolveDefault())).toEqual(['exa/search']);
+    expect(keys(mapped.catalog.workflow('all').members)).toEqual([
+      'exa/search',
+    ]);
+    expect(keys(mapped.catalog.resolveConfiguredReserve([]))).toEqual([
+      'brave-search/search',
+    ]);
+
+    const primary = prepareResearchExecution(
+      {
+        query: 'not primary',
+        mode: 'sync',
+        selector: {
+          kind: 'targets',
+          targets: [{ provider_id: 'brave-search', profile_id: 'search' }],
+        },
+        fallback: { kind: 'disabled' },
+        limits: mapped.transport_defaults?.limits,
+        exclusions: [],
+        refinement: { kind: 'disabled' },
+      },
+      mapped.catalog,
+      dependencies(),
+    );
+    expect(primary.ok).toBe(false);
+    if (primary.ok) throw new Error('reserve-only profile selected as primary');
+    expect(primary.issues.map((issue) => issue.code)).toContain(
+      'profile_reserve_only',
+    );
+    expect(primary.issues.map((issue) => issue.code)).not.toContain(
+      'profile_disabled',
+    );
+
+    const capability = prepareResearchExecution(
+      {
+        query: 'not capability',
+        mode: 'sync',
+        selector: {
+          kind: 'capabilities',
+          requirements: { result_kind: 'search_results', corpora: ['web'] },
+        },
+        fallback: { kind: 'disabled' },
+        limits: mapped.transport_defaults?.limits,
+        exclusions: [],
+        refinement: { kind: 'disabled' },
+      },
+      mapped.catalog,
+      dependencies(),
+    );
+    expect(capability.ok).toBe(true);
+    if (!capability.ok) return;
+    expect(
+      keys(
+        capability.prepared.request.slots.map((slot) => slot.primary.identity),
+      ),
+    ).toEqual(['exa/search']);
+
+    const prepared = prepareResearchExecution(
+      {
+        query: 'reserve only',
+        mode: 'sync',
+        selector: {
+          kind: 'targets',
+          targets: [{ provider_id: 'exa', profile_id: 'search' }],
+        },
+        fallback: { kind: 'configured' },
+        limits: mapped.transport_defaults?.limits,
+        exclusions: [],
+        refinement: { kind: 'disabled' },
+      },
+      mapped.catalog,
+      dependencies(),
+    );
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(
+      keys(
+        prepared.prepared.request.fallback_reserve.map(
+          (entry) => entry.profile.identity,
+        ),
+      ),
+    ).toEqual(['brave-search/search']);
+  });
+
+  it('uses the real v1 defaults fields and exact budgets, without inventing a request deadline', () => {
+    const source = config({
+      defaults: {
+        mode: 'sync',
+        maxParallel: 3,
+        timeout: 12,
+        asyncTimeout: 90,
+        asyncPollInterval: 7,
+        maxCostUsd: 0.25,
+        maxEstimatedCostUsd: 0.1,
+      },
+    });
+    const missingDeadline = map(source);
+    expect(missingDeadline.transport_defaults).toBeUndefined();
+    expect(missingDeadline.preflight.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_request_deadline_required',
+        path: '/defaults/requestDeadlineMs',
+      }),
+    );
+
+    const mapped = map(source, { requestDeadlineMs: 300_000 });
+    const normalized = normalizeConfigurationRequest(
+      { query: 'v1 defaults', providers: ['exa'], ...mapped.transport_input },
+      mapped.transport_defaults!,
+    );
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.request.limits).toEqual({
+      max_concurrency: 3,
+      request_deadline_ms: 300_000,
+      inline_attempt_deadline_ms: 12_000,
+      background_attempt_deadline_ms: 90_000,
+      poll_interval_ms: 7_000,
+    });
+    expect(normalized.request.budgets).toEqual({
+      max_estimated_cost_microusd: '100000',
+      max_actual_cost_microusd: '250000',
+    });
+
+    for (const normalize of [normalizeCliRequest, normalizeMcpRequest]) {
+      const inherited = normalize(
+        { query: 'inherited budget', providers: ['exa'] },
+        mapped.transport_defaults!,
+      );
+      expect(inherited.ok).toBe(true);
+      if (!inherited.ok) continue;
+      expect(inherited.request.budgets).toEqual(normalized.request.budgets);
+    }
+  });
+
+  it('withholds transport defaults when any configured budget is inexact', () => {
+    const source = config({
+      defaults: { maxCostUsd: 0.25, maxEstimatedCostUsd: 0.0000001 },
+    });
+    const mapped = map(source, { requestDeadlineMs: 300_000 });
+    expect(mapped.transport_defaults).toBeUndefined();
+    expect(mapped.preflight.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'transport_budget_not_exact',
+        path: '/defaults/maxEstimatedCostUsd',
+      }),
+    );
+  });
+
+  it('preserves legacy mixed defaults through normalization for the migration notice', () => {
+    const mapped = map(
+      config({
+        defaults: { mode: 'mixed' },
+        providers: { 'openai-research': { enabled: true } },
+      }),
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
+    );
+    const normalized = normalizeConfigurationRequest(
+      {
+        query: 'mixed default',
+        providers: ['openai-research'],
+        ...mapped.transport_input,
+      },
+      mapped.transport_defaults!,
+    );
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.request.mode).toBe('mixed');
+    const compiled = compileNormalizedTransportRequest(
+      normalized,
+      mapped.catalog,
+      dependencies(),
+    );
+    if (!compiled.ok) throw new Error(JSON.stringify(compiled.issues));
+    expect(compiled.notices).toContainEqual(
+      expect.objectContaining({ code: 'legacy_mixed_mode_migrated' }),
+    );
+  });
+
+  it('canonicalizes authored group members while preserving order and diagnostics', () => {
+    const mapped = map(
+      config({
+        groups: {
+          team: [
+            'perplexity-sonar',
+            'OpenRouter Online Search',
+            'openrouter-online',
+            'missing',
+            'openrouter',
+          ],
+        },
+      }),
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
+    );
+    expect(mapped.groups).toEqual({
+      team: ['perplexity-sonar-pro/grounded', 'openrouter/grounded'],
+    });
+    expect(mapped.preflight.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_provider_alias_migrated',
+        path: '/groups/team/0',
+      }),
+    );
+    expect(
+      mapped.preflight.issues.map(({ code, path }) => [code, path]),
+    ).toEqual([
+      ['configuration_group_member_unknown', '/groups/team/3'],
+      ['configuration_group_member_ambiguous', '/groups/team/4'],
+    ]);
+  });
+
+  it('merges sorted catalog and mapping diagnostics into preflight', () => {
+    const mapped = map(
+      config({
+        groups: { broken: ['nope/search'] },
+        providers: { exa: { enabled: true, fallback: 'missing-adapter' } },
+      }),
+      { requestDeadlineMs: 300_000 },
+    );
+    expect(
+      mapped.preflight.issues.map(({ code, path }) => [code, path]),
+    ).toEqual([
+      ['configuration_group_member_unknown', '/groups/broken/0'],
+      ['configuration_fallback_unknown_adapter', '/providers/exa/fallback'],
+    ]);
+  });
+});

--- a/tests/transport-normalization.test.ts
+++ b/tests/transport-normalization.test.ts
@@ -277,8 +277,8 @@ describe('selector conflicts', () => {
     expect(library.ok).toBe(false);
     if (library.ok) return;
     expect(library.issues.map(({ code, path }) => [code, path])).toEqual([
-      ['transport_selector_conflict', '/group'],
       ['transport_selector_conflict', '/capabilities'],
+      ['transport_selector_conflict', '/group'],
     ]);
   });
 

--- a/tests/workers/provider-catalog.test.ts
+++ b/tests/workers/provider-catalog.test.ts
@@ -3,11 +3,13 @@ import {
   catalogFingerprint,
   isCatalogFingerprint,
 } from '../../src/core/catalog-fingerprint.js';
+import { mapConfiguration } from '../../src/core/configuration-mapping.js';
 import { prepareResearchExecution } from '../../src/core/execution-plan.js';
 import { BUILTIN_PROFILE_BINDING_SPECS } from '../../src/core/profile-bindings.js';
 import { buildProviderCatalog } from '../../src/core/profile-catalog.js';
 import { BUILTIN_PROVIDER_CATALOG } from '../../src/core/provider-profiles.js';
 import { collectionProvenanceFor } from '../../src/core/result-provenance.js';
+import type { Config } from '../../src/types.js';
 
 function workerCatalog() {
   return buildProviderCatalog({
@@ -38,6 +40,34 @@ describe('provider catalog in workerd', () => {
     expect(catalog.workflow('quick').members).toHaveLength(5);
     expect(catalog.workflow('visibility').members).toHaveLength(9);
     expect(catalog.workflow('deep').members).toHaveLength(5);
+  });
+
+  it('maps configuration without importing Node config loading', () => {
+    const config: Config = {
+      version: 1,
+      defaults: {
+        outputDir: './agents/librarium',
+        maxParallel: 2,
+        timeout: 30,
+        asyncTimeout: 60,
+        asyncPollInterval: 5,
+        mode: 'sync',
+        llmWebSearch: true,
+      },
+      providers: { exa: { enabled: true } },
+      customProviders: {},
+      trustedProviderIds: [],
+      groups: { team: ['exa'] },
+    };
+    const mapped = mapConfiguration(config, {
+      authoredGroups: { global: config.groups, project: {} },
+      requestDeadlineMs: 60_000,
+      credentials: {
+        env: { EXA_API_KEY: 'worker-synthetic-credential' },
+      },
+    });
+    expect(mapped.groups).toEqual({ team: ['exa/search'] });
+    expect(mapped.catalog.resolveDefault()).toHaveLength(1);
   });
 
   it('fingerprints deterministically without crypto', () => {


### PR DESCRIPTION
## Summary\n\nAdd a private, Worker-safe canonical configuration mapper for Librarium v2. It translates validated v1 configuration into exact provider/profile catalog policy without changing production CLI, MCP, dispatcher, or result behavior.\n\n## What's New\n\n- Preserve authored global/project group provenance while excluding injected legacy default groups.\n- Resolve provider aliases, display names, qualified profiles, and split OpenRouter strategies to exact catalog identities.\n- Carry exact budgets, per-attempt limits, legacy mixed-mode migration, and stable preflight diagnostics.\n- Flatten valid fallback edges into one ordered global reserve.\n- Keep disabled fallback-only providers reserve-eligible without widening primary, default, capability, or workflow selection.\n- Materialize global chat web-search defaults only when provider options do not override them.\n- Harden all config-derived dictionaries against prototype-like JSON keys.\n\n## Design Decisions\n\n**On production behavior:** This mapper remains private and unwired. Existing CLI/MCP execution, artifacts, async status/retrieve, and terminal response contracts are unchanged.\n\n**On request deadlines:** The mapper requires an explicitly injected total request deadline until the v1 migration formula is finalized; absence returns an actionable preflight issue.\n\n## Test Plan\n\n- [x] 1,752 unit tests\n- [x] 15 Worker compatibility tests\n- [x] 14 integration tests\n- [x] TypeScript typecheck\n- [x] Biome lint\n- [x] Production build\n- [x] Independent architecture, security, and test-integrity reviews