### PR TITLE
feat(core): add private shadow compiler

### DIFF
--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -943,21 +943,22 @@ export function prepareResearchExecution(
     ]),
   );
   const primaries = selectPrimaries(request, catalog, byKey, issues);
-
-  const requestedAt = new Date(dependencies.clock.now()).toISOString();
-  const slots: RequestSlot[] = primaries.map((selection, position) => ({
-    slot_id: dependencies.ids.next('slot'),
-    position,
-    requirements:
-      selection.requirements ?? requirementsForProfile(selection.entry.profile),
-    primary: selection.entry.profile,
-  }));
+  const provisionalSlots: RequestSlot[] = primaries.map(
+    (selection, position) => ({
+      slot_id: `provisional-slot-${position}`,
+      position,
+      requirements:
+        selection.requirements ??
+        requirementsForProfile(selection.entry.profile),
+      primary: selection.entry.profile,
+    }),
+  );
   const reserve = resolveReserve(
     request,
     catalog,
     byKey,
     primaries,
-    slots,
+    provisionalSlots,
     issues,
     notices,
   );
@@ -971,6 +972,16 @@ export function prepareResearchExecution(
       notices: sortDiagnostics(notices),
     };
   }
+
+  // Everything above is network-free admission and must remain free of caller
+  // effects. Only a fully accepted plan may observe time or allocate IDs.
+  const requestedAt = new Date(dependencies.clock.now()).toISOString();
+  const slots: RequestSlot[] = provisionalSlots.map(
+    ({ slot_id: _provisionalId, ...slot }) => ({
+      ...slot,
+      slot_id: dependencies.ids.next('slot'),
+    }),
+  );
 
   const fallbackReserve = reserve.map((selection, position) => ({
     candidate_id: dependencies.ids.next('fallback_candidate'),

--- a/src/core/shadow-compilation.ts
+++ b/src/core/shadow-compilation.ts
@@ -1,0 +1,458 @@
+import { PROVIDER_ID_ALIASES } from '../constants.js';
+import type { Config } from '../types.js';
+import {
+  REMOVED_BUILTIN_WORKFLOW_IDS,
+  resolveWorkflowSelection,
+} from './builtin-workflows.js';
+import {
+  type AuthoredGroupProvenance,
+  mapConfiguration,
+  resolveConfigurationProfileToken,
+} from './configuration-mapping.js';
+import type { CredentialContext } from './credentials.js';
+import type {
+  PreparationDependencies,
+  PreparedResearchExecution,
+} from './execution-plan.js';
+import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
+import type {
+  PreparationIssue,
+  PreparationNotice,
+  ProfileTarget,
+} from './research-request.js';
+import { sortPreparationDiagnostics } from './research-request.js';
+import {
+  type CanonicalTransportDefaults,
+  type CliTransportInput,
+  compileNormalizedTransportRequest,
+  type McpTransportInput,
+  normalizeCliRequest,
+  normalizeMcpRequest,
+  normalizeSilentMcpRequest,
+  type TransportNormalizationResult,
+} from './transport-normalization.js';
+
+/**
+ * Private, Worker-safe ingress shapes. This is intentionally not re-exported
+ * from a package entrypoint or wired to a production transport.
+ */
+type RawCliTransportInput = Omit<CliTransportInput, 'exactTargets'>;
+type RawMcpTransportInput = Omit<McpTransportInput, 'exactTargets'>;
+
+export type ShadowCompilationTransport =
+  | { readonly kind: 'cli'; readonly input: RawCliTransportInput }
+  | { readonly kind: 'mcp'; readonly input: RawMcpTransportInput }
+  | { readonly kind: 'silent_mcp'; readonly input: RawMcpTransportInput };
+
+export interface ShadowCompilationInput {
+  /** An already schema-validated merged v1 configuration. */
+  readonly config: Config;
+  /** Preserves which group spellings were explicitly authored. */
+  readonly authoredGroups: AuthoredGroupProvenance;
+  readonly credentials: CredentialContext;
+  /** The v1 total request-deadline formula remains deliberately unresolved. */
+  readonly requestDeadlineMs?: number;
+  readonly transport: ShadowCompilationTransport;
+  readonly preparation: PreparationDependencies;
+}
+
+export type ShadowCompilationResult =
+  | {
+      readonly ok: true;
+      readonly prepared: PreparedResearchExecution;
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+interface ResolvedProviderTokens {
+  readonly targets: readonly ProfileTarget[];
+  readonly notices: readonly PreparationNotice[];
+  readonly issues: readonly PreparationIssue[];
+}
+
+const RESERVED_BUILTIN_PROVIDER_TOKENS = new Set([
+  ...BUILTIN_PROVIDER_DEFINITIONS.map(({ id }) => id),
+  ...Object.keys(PROVIDER_ID_ALIASES),
+]);
+
+function resolveProviderTokens(
+  tokens: readonly string[] | undefined,
+  missingCustomProviderIds: ReadonlySet<string>,
+): ResolvedProviderTokens {
+  if (tokens === undefined) return { targets: [], notices: [], issues: [] };
+
+  const targets: ProfileTarget[] = [];
+  const notices: PreparationNotice[] = [];
+  const issues: PreparationIssue[] = [];
+  const seen = new Set<string>();
+
+  const nonBlankTokens = tokens
+    .map((token, index) => ({ token: token.trim(), index }))
+    .filter(({ token }) => token.length > 0);
+  if (nonBlankTokens.length === 0) {
+    issues.push({
+      code: 'transport_empty_provider_selection',
+      phase: 'transport',
+      path: '/providers',
+      message:
+        'A provider selection was given but contains no usable provider ids. Omit it to use the default selection or pass at least one id.',
+    });
+    return { targets, notices, issues };
+  }
+
+  for (const { index, token } of nonBlankTokens) {
+    const path = `/providers/${index}`;
+    if (missingCustomProviderIds.has(token)) {
+      issues.push({
+        code: 'custom_provider_profile_missing',
+        phase: 'migration',
+        path,
+        message:
+          'This trusted enabled custom provider has no execution-profile metadata, so shadow compilation cannot plan it safely.',
+      });
+      continue;
+    }
+    const resolution = resolveConfigurationProfileToken(token);
+    if (resolution.kind === 'unknown') {
+      issues.push({
+        code: 'shadow_provider_token_unknown',
+        phase: 'migration',
+        path,
+        message:
+          'The provider token does not resolve to an implemented exact provider profile.',
+      });
+      continue;
+    }
+    if (resolution.kind === 'ambiguous') {
+      issues.push({
+        code: 'shadow_provider_token_ambiguous',
+        phase: 'migration',
+        path,
+        message:
+          'The provider token resolves to multiple profiles. Use an exact adapter id or qualified "provider/profile" reference.',
+      });
+      continue;
+    }
+    if (resolution.alias) {
+      notices.push({
+        code: 'configuration_provider_alias_migrated',
+        phase: 'migration',
+        path,
+        message: 'A retired provider alias was migrated to its exact profile.',
+        profile_key: `${resolution.target.provider_id}/${resolution.target.profile_id}`,
+      });
+    }
+    const key = `${resolution.target.provider_id}/${resolution.target.profile_id}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      targets.push(resolution.target);
+    }
+  }
+  return { targets, notices, issues };
+}
+
+function canonicalGroup(
+  group: string | undefined,
+  aliases: Readonly<Record<string, string>>,
+): {
+  readonly group: string | undefined;
+  readonly notices: readonly PreparationNotice[];
+} {
+  if (group === undefined) return { group, notices: [] };
+  const token = group.trim();
+  if (!Object.hasOwn(aliases, token)) return { group: token, notices: [] };
+  const migrated = aliases[token]!;
+  return {
+    group: migrated,
+    notices: [
+      {
+        code: 'configuration_group_alias_migrated',
+        phase: 'migration',
+        path: '/group',
+        message:
+          'The authored group name was migrated to its exact catalog group id.',
+      },
+    ],
+  };
+}
+
+function groupSelectionDiagnostics(
+  group: string | undefined,
+  customGroupIds: readonly string[],
+): readonly PreparationIssue[] {
+  if (group === undefined) return [];
+  if (group.length === 0) {
+    return [
+      {
+        code: 'shadow_group_blank',
+        phase: 'migration',
+        path: '/group',
+        message: 'A group selection must not be blank.',
+      },
+    ];
+  }
+  const selection = resolveWorkflowSelection(group, customGroupIds);
+  if (selection.kind !== 'unknown') return [];
+  return [
+    {
+      code: REMOVED_BUILTIN_WORKFLOW_IDS.includes(group)
+        ? 'shadow_group_removed'
+        : 'shadow_group_unknown',
+      phase: 'migration',
+      path: '/group',
+      message: selection.message,
+    },
+  ];
+}
+
+function escapePointerSegment(segment: string): string {
+  return segment.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function customProviderIssues(
+  config: Config,
+  transport: ShadowCompilationTransport,
+  canonicalGroupId: string | undefined,
+): readonly PreparationIssue[] {
+  const configured = missingCustomProviderIds(config);
+  if (configured.length === 0) return [];
+
+  const rawProviders = transport.input.providers;
+  const relevant =
+    rawProviders !== undefined
+      ? []
+      : canonicalGroupId === undefined
+        ? configured
+        : configured.filter((id) => {
+            const rawGroupId = canonicalGroupId.replace(/^custom:/, '');
+            const members = Object.hasOwn(config.groups, canonicalGroupId)
+              ? config.groups[canonicalGroupId]
+              : Object.hasOwn(config.groups, rawGroupId)
+                ? config.groups[rawGroupId]
+                : undefined;
+            return members?.includes(id) === true;
+          });
+  return relevant.map((id) => ({
+    code: 'custom_provider_profile_missing',
+    phase: 'migration',
+    path:
+      rawProviders !== undefined
+        ? `/providers/${rawProviders.findIndex((token) => token.trim() === id)}`
+        : canonicalGroupId === undefined
+          ? `/customProviders/${escapePointerSegment(id)}`
+          : '/group',
+    message:
+      'This trusted enabled custom provider has no execution-profile metadata, so shadow compilation cannot plan it safely.',
+  }));
+}
+
+function missingCustomProviderIds(config: Config): readonly string[] {
+  const trusted = new Set(config.trustedProviderIds);
+  return Object.keys(config.customProviders).filter(
+    (id) =>
+      !RESERVED_BUILTIN_PROVIDER_TOKENS.has(id) &&
+      trusted.has(id) &&
+      Object.hasOwn(config.providers, id) &&
+      config.providers[id]?.enabled === true,
+  );
+}
+
+function exactTargetSmugglingIssues(
+  transport: ShadowCompilationTransport,
+): readonly PreparationIssue[] {
+  if (!Object.hasOwn(transport.input, 'exactTargets')) return [];
+  return [
+    {
+      code: 'shadow_exact_targets_not_allowed',
+      phase: 'transport',
+      path: '/providers',
+      message:
+        'Raw shadow ingress cannot supply pre-resolved exact targets. Use provider tokens so configuration canonicalization remains authoritative.',
+    },
+  ];
+}
+
+function collisionGroupDiagnostics(
+  group: string | undefined,
+  issues: readonly PreparationIssue[],
+): readonly PreparationIssue[] {
+  if (
+    group === undefined ||
+    !issues.some(
+      (issue) =>
+        (issue.code === 'reserved_workflow_name_collision' ||
+          issue.code === 'custom_group_name_collision') &&
+        issue.path === `/groups/${group}`,
+    )
+  ) {
+    return [];
+  }
+  return [
+    {
+      code: 'shadow_group_collision',
+      phase: 'migration',
+      path: '/group',
+      message:
+        'The requested group has a configuration naming collision and cannot be selected safely.',
+    },
+  ];
+}
+
+function normalizeTransport(
+  transport: ShadowCompilationTransport,
+  defaults: CanonicalTransportDefaults,
+  targets: readonly ProfileTarget[] | undefined,
+  group: string | undefined,
+): TransportNormalizationResult {
+  switch (transport.kind) {
+    case 'cli': {
+      const projected: CliTransportInput = {
+        query: transport.input.query,
+        mode: transport.input.mode,
+        parallel: transport.input.parallel,
+        timeoutSeconds: transport.input.timeoutSeconds,
+        maxCostUsd: transport.input.maxCostUsd,
+        maxEstimatedCostUsd: transport.input.maxEstimatedCostUsd,
+        fallback: transport.input.fallback,
+        refine: transport.input.refine,
+        ...(targets !== undefined && { exactTargets: targets }),
+        ...(group !== undefined && { group }),
+      };
+      return normalizeCliRequest(projected, defaults);
+    }
+    case 'mcp': {
+      const projected: McpTransportInput = {
+        query: transport.input.query,
+        mode: transport.input.mode,
+        refine: transport.input.refine,
+        ...(targets !== undefined && { exactTargets: targets }),
+        ...(group !== undefined && { group }),
+      };
+      return normalizeMcpRequest(projected, defaults);
+    }
+    case 'silent_mcp': {
+      const projected: McpTransportInput = {
+        query: transport.input.query,
+        mode: transport.input.mode,
+        refine: transport.input.refine,
+        ...(targets !== undefined && { exactTargets: targets }),
+        ...(group !== undefined && { group }),
+      };
+      return normalizeSilentMcpRequest(projected, defaults);
+    }
+  }
+}
+
+/**
+ * Compile a v1 configuration plus one transport-shaped input without touching
+ * runtime execution, stores, bridges, files, imports, registries, or network.
+ */
+export function compileShadowRequest(
+  input: ShadowCompilationInput,
+): ShadowCompilationResult {
+  const rawGroup = input.transport.input.group?.trim();
+  const mapped = mapConfiguration(input.config, {
+    authoredGroups: input.authoredGroups,
+    credentials: input.credentials,
+    ...(input.requestDeadlineMs !== undefined && {
+      requestDeadlineMs: input.requestDeadlineMs,
+    }),
+  });
+  const mapperNotices = mapped.preflight.notices;
+  const mapperIssues = mapped.preflight.issues;
+
+  // Mapping is the gate: neither token conversion nor transport normalization
+  // may run until collisions, catalog facts, and deadline policy are sound.
+  if (mapperIssues.length > 0 || mapped.transport_defaults === undefined) {
+    return {
+      ok: false,
+      issues: sortPreparationDiagnostics([
+        ...mapperIssues,
+        ...collisionGroupDiagnostics(rawGroup, mapperIssues),
+      ]),
+      notices: sortPreparationDiagnostics(mapperNotices),
+    };
+  }
+
+  const smugglingIssues = exactTargetSmugglingIssues(input.transport);
+  if (smugglingIssues.length > 0) {
+    return {
+      ok: false,
+      issues: sortPreparationDiagnostics(smugglingIssues),
+      notices: sortPreparationDiagnostics(mapperNotices),
+    };
+  }
+
+  const group = canonicalGroup(
+    input.transport.input.group,
+    mapped.group_aliases,
+  );
+  const rawProviders = input.transport.input.providers;
+  // Providers own CLI/MCP selector precedence, so a competing group is
+  // intentionally ignored rather than independently migrated.
+  const effectiveGroupNotices =
+    rawProviders === undefined ? group.notices : ([] as const);
+  const resolved = resolveProviderTokens(
+    rawProviders,
+    new Set(missingCustomProviderIds(input.config)),
+  );
+  // A supplied provider selection owns selector precedence, even when its
+  // tokens are invalid. Its error should not be obscured by an ignored group.
+  const groupIssues =
+    rawProviders === undefined
+      ? groupSelectionDiagnostics(group.group, mapped.catalog.custom_group_ids)
+      : [];
+  const relevantCustomIssues = customProviderIssues(
+    input.config,
+    input.transport,
+    group.group,
+  );
+  if (
+    resolved.issues.length > 0 ||
+    groupIssues.length > 0 ||
+    relevantCustomIssues.length > 0
+  ) {
+    return {
+      ok: false,
+      issues: sortPreparationDiagnostics([
+        ...resolved.issues,
+        ...groupIssues,
+        ...relevantCustomIssues,
+      ]),
+      notices: sortPreparationDiagnostics([
+        ...mapperNotices,
+        ...effectiveGroupNotices,
+        ...resolved.notices,
+      ]),
+    };
+  }
+
+  const normalized = normalizeTransport(
+    input.transport,
+    mapped.transport_defaults,
+    rawProviders === undefined ? undefined : resolved.targets,
+    group.group,
+  );
+  const compiled = compileNormalizedTransportRequest(
+    normalized,
+    mapped.catalog,
+    input.preparation,
+  );
+  const notices = sortPreparationDiagnostics([
+    ...mapperNotices,
+    ...effectiveGroupNotices,
+    ...resolved.notices,
+    ...compiled.notices,
+  ]);
+  return compiled.ok
+    ? { ok: true, prepared: compiled.prepared, notices }
+    : {
+        ok: false,
+        issues: sortPreparationDiagnostics(compiled.issues),
+        notices,
+      };
+}

--- a/src/core/transport-normalization.ts
+++ b/src/core/transport-normalization.ts
@@ -337,6 +337,36 @@ function targetsFromProviderIds(
   return { value: targets, raw_path: path };
 }
 
+/**
+ * Keep raw provider-token handling intact for existing ingress callers while
+ * allowing the private configuration compiler to hand over exact catalog
+ * identities. The two lanes are deliberately mutually exclusive: accepting
+ * both would make the selected strategy dependent on undocumented precedence.
+ */
+function targetsFromRawOrExactTargets(
+  providerIds: readonly string[] | undefined,
+  exactTargets: readonly ProfileTarget[] | undefined,
+  issues: PreparationIssue[],
+): SelectorCandidateInput<readonly ProfileTarget[]> | undefined {
+  if (providerIds !== undefined && exactTargets !== undefined) {
+    issues.push({
+      code: 'transport_raw_and_exact_targets_conflict',
+      phase: 'transport',
+      path: '/providers',
+      message:
+        'Raw provider tokens and exact resolved targets cannot be supplied together. Supply exactly one selection form.',
+    });
+    return undefined;
+  }
+  if (exactTargets !== undefined) {
+    // The exact lane is an internal replacement for this transport's raw
+    // provider tokens, so keep all later selector diagnostics at the public
+    // ingress path rather than exposing the private implementation detail.
+    return { value: exactTargets, raw_path: '/providers' };
+  }
+  return targetsFromProviderIds(providerIds, '/providers', issues);
+}
+
 export function exactUsdBudgets(
   maxCostUsd: number | undefined,
   maxEstimatedCostUsd: number | undefined,
@@ -456,6 +486,12 @@ export function normalizeLibraryRequest(
 export interface CliTransportInput {
   readonly query?: string;
   readonly providers?: readonly string[];
+  /**
+   * Private compiler lane for already-resolved catalog targets. Public CLI
+   * callers continue to use `providers`; passing both is rejected so a raw
+   * token can never silently win over an exact target.
+   */
+  readonly exactTargets?: readonly ProfileTarget[];
   readonly group?: string;
   readonly mode?: string;
   readonly parallel?: number;
@@ -483,9 +519,9 @@ export function normalizeCliRequest(
         query: input.query,
         mode: input.mode,
         selector: {
-          targets: targetsFromProviderIds(
+          targets: targetsFromRawOrExactTargets(
             input.providers,
-            '/providers',
+            input.exactTargets,
             issues,
           ),
           group:
@@ -521,6 +557,8 @@ export function normalizeCliRequest(
 export interface McpTransportInput {
   readonly query?: string;
   readonly providers?: readonly string[];
+  /** See CliTransportInput.exactTargets. */
+  readonly exactTargets?: readonly ProfileTarget[];
   readonly group?: string;
   readonly mode?: string;
   readonly refine?: boolean;
@@ -533,7 +571,11 @@ function mcpProjection(input: McpTransportInput): TransportProjection {
       query: input.query,
       mode: input.mode,
       selector: {
-        targets: targetsFromProviderIds(input.providers, '/providers', issues),
+        targets: targetsFromRawOrExactTargets(
+          input.providers,
+          input.exactTargets,
+          issues,
+        ),
         group:
           input.group === undefined
             ? undefined

--- a/tests/execution-plan.test.ts
+++ b/tests/execution-plan.test.ts
@@ -517,6 +517,34 @@ describe('research execution preparation', () => {
     );
   });
 
+  it('rejects zero-budget admission before observing the clock or allocating ids', () => {
+    const clock = vi.fn(() => Date.parse('2026-08-08T12:00:00Z'));
+    const next = vi.fn(
+      (scope: 'request' | 'slot' | 'fallback_candidate') =>
+        `unexpected-${scope}`,
+    );
+    const result = prepareResearchExecution(
+      {
+        ...targetRequest(),
+        budgets: { max_estimated_cost_microusd: '0' },
+      },
+      new FixtureCatalog([planningProfile(groundedProfile('alpha'))]),
+      { clock: { now: clock }, ids: { next } },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: 'primary_plan_budget_exceeded',
+          path: '/budgets/max_estimated_cost_microusd',
+        }),
+      ]);
+    }
+    expect(clock).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('bounds billable unit arrays and addresses duplicate catalog profiles by index', () => {
     const alpha = planningProfile(groundedProfile('alpha'));
     const duplicated = prepareResearchExecution(

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -1,0 +1,806 @@
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_PROVIDER_CATALOG } from '../src/core/provider-profiles.js';
+import { comparePreparationDiagnostics } from '../src/core/research-request.js';
+import {
+  compileShadowRequest,
+  type ShadowCompilationTransport,
+} from '../src/core/shadow-compilation.js';
+import type { Config } from '../src/types.js';
+
+function config(
+  overrides: Partial<Config> & { defaults?: Partial<Config['defaults']> } = {},
+): Config {
+  const { defaults, ...rest } = overrides;
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel: 3,
+      timeout: 30,
+      asyncTimeout: 300,
+      asyncPollInterval: 5,
+      mode: 'sync',
+      llmWebSearch: true,
+      ...defaults,
+    },
+    providers: {},
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {},
+    ...rest,
+  };
+}
+
+function credentials() {
+  return {
+    env: Object.fromEntries(
+      BUILTIN_PROVIDER_CATALOG.map((entry) => [
+        entry.credential.env_var,
+        'test-credential',
+      ]),
+    ),
+  };
+}
+
+function preparation() {
+  const counts = new Map<string, number>();
+  return {
+    clock: { now: () => Date.parse('2026-08-09T12:00:00Z') },
+    ids: {
+      next: (scope: 'request' | 'slot' | 'fallback_candidate') => {
+        const count = (counts.get(scope) ?? 0) + 1;
+        counts.set(scope, count);
+        return `${scope}-${count}`;
+      },
+    },
+  };
+}
+
+function countedPreparation() {
+  let calls = 0;
+  return {
+    dependencies: {
+      clock: {
+        now: () => {
+          calls += 1;
+          return Date.parse('2026-08-09T12:00:00Z');
+        },
+      },
+      ids: {
+        next: (scope: 'request' | 'slot' | 'fallback_candidate') => {
+          calls += 1;
+          return `unexpected-${scope}-${calls}`;
+        },
+      },
+    },
+    calls: () => calls,
+  };
+}
+
+function compile(
+  source: Config,
+  transport: ShadowCompilationTransport,
+  requestDeadlineMs = 1_000_000,
+) {
+  return compileShadowRequest({
+    config: source,
+    authoredGroups: { global: source.groups, project: {} },
+    credentials: credentials(),
+    requestDeadlineMs,
+    transport,
+    preparation: preparation(),
+  });
+}
+
+function profileKeys(result: ReturnType<typeof compile>) {
+  if (!result.ok) throw new Error(JSON.stringify(result.issues));
+  return result.prepared.request.slots.map(
+    (slot) =>
+      `${slot.primary.identity.provider_id}/${slot.primary.identity.profile_id}`,
+  );
+}
+
+describe('private shadow compilation', () => {
+  it('resolves exact adapter ids, display names, qualified profiles, and split OpenRouter targets', () => {
+    const result = compile(
+      config({
+        providers: {
+          exa: { enabled: true },
+          'openrouter-online': { enabled: true },
+          'openrouter-chat': { enabled: true },
+        },
+      }),
+      {
+        kind: 'cli',
+        input: {
+          query: 'token forms',
+          providers: [
+            'exa',
+            'Exa Search',
+            'openrouter-online',
+            'openrouter/chat',
+            'openrouter-chat',
+          ],
+        },
+      },
+    );
+
+    expect(profileKeys(result)).toEqual([
+      'exa/search',
+      'openrouter/grounded',
+      'openrouter/chat',
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const openRouterPlans = Object.values(
+      result.prepared.profile_plans_by_identity,
+    ).filter((plan) => plan.identity.provider_id === 'openrouter');
+    expect(
+      openRouterPlans.find((plan) => plan.identity.profile_id === 'grounded')
+        ?.binding.adapter_id,
+    ).toBe('openrouter-online');
+    expect(
+      openRouterPlans.find((plan) => plan.identity.profile_id === 'chat')
+        ?.binding.adapter_id,
+    ).toBe('openrouter-chat');
+  });
+
+  it('retains alias notices while deduplicating their canonical target', () => {
+    const result = compile(
+      config({
+        providers: { 'openai-research': { enabled: true } },
+        defaults: { mode: 'async' },
+      }),
+      {
+        kind: 'mcp',
+        input: {
+          query: 'OpenAI aliases',
+          providers: ['openai-deep', 'openai-research', 'openai-deep-o3'],
+          mode: 'async',
+        },
+      },
+    );
+
+    expect(profileKeys(result)).toEqual(['openai-research/research']);
+    expect(
+      result.notices.filter(
+        (notice) => notice.code === 'configuration_provider_alias_migrated',
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('filters blank provider entries like v1 and retains stable token diagnostics', () => {
+    const result = compile(config({ providers: { exa: { enabled: true } } }), {
+      kind: 'silent_mcp',
+      input: {
+        query: 'bad tokens',
+        providers: ['missing', 'openrouter', ' '],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues.map(({ code, path }) => [code, path])).toEqual([
+      ['shadow_provider_token_unknown', '/providers/0'],
+      ['shadow_provider_token_ambiguous', '/providers/1'],
+    ]);
+
+    const filtered = compile(
+      config({ providers: { exa: { enabled: true } } }),
+      {
+        kind: 'mcp',
+        input: { query: 'filter blanks', providers: [' ', 'exa', ''] },
+      },
+    );
+    expect(profileKeys(filtered)).toEqual(['exa/search']);
+
+    const empty = compile(config({ providers: { exa: { enabled: true } } }), {
+      kind: 'mcp',
+      input: { query: 'all blank', providers: [' ', ''] },
+    });
+    expect(empty.ok).toBe(false);
+    if (!empty.ok) {
+      expect(empty.issues).toEqual([
+        expect.objectContaining({
+          code: 'transport_empty_provider_selection',
+          path: '/providers',
+        }),
+      ]);
+    }
+  });
+
+  it('rejects runtime exact-target smuggling after the mapping gate', () => {
+    const source = config({ providers: { exa: { enabled: true } } });
+    for (const input of [
+      {
+        query: 'exact alone',
+        exactTargets: [{ provider_id: 'exa', profile_id: 'search' }],
+      },
+      {
+        query: 'raw and exact',
+        providers: ['exa'],
+        exactTargets: [{ provider_id: 'exa', profile_id: 'search' }],
+      },
+    ]) {
+      const counted = countedPreparation();
+      const result = compileShadowRequest({
+        config: source,
+        authoredGroups: { global: {}, project: {} },
+        credentials: credentials(),
+        requestDeadlineMs: 1_000_000,
+        transport: {
+          kind: 'mcp',
+          input,
+        } as unknown as ShadowCompilationTransport,
+        preparation: counted.dependencies,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toEqual([
+          expect.objectContaining({
+            code: 'shadow_exact_targets_not_allowed',
+            path: '/providers',
+          }),
+        ]);
+      }
+      expect(counted.calls()).toBe(0);
+    }
+  });
+
+  it('keeps bare OpenRouter ambiguous even when only one adapter is enabled', () => {
+    const result = compile(
+      config({
+        providers: {
+          'openrouter-online': { enabled: true },
+          'openrouter-chat': { enabled: false },
+        },
+      }),
+      {
+        kind: 'mcp',
+        input: { query: 'bare OpenRouter', providers: ['openrouter'] },
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'shadow_provider_token_ambiguous',
+          path: '/providers/0',
+        }),
+      );
+    }
+  });
+
+  it('keeps injected quick built in but routes authored quick and team through group aliases', () => {
+    const injectedQuick = compile(
+      config({ providers: { exa: { enabled: true } } }),
+      { kind: 'mcp', input: { query: 'built in quick', group: 'quick' } },
+    );
+    expect(profileKeys(injectedQuick)).toEqual(['exa/search']);
+
+    const authored = config({
+      providers: { exa: { enabled: true }, tavily: { enabled: true } },
+      groups: { quick: ['exa'], team: ['tavily'] },
+    });
+    const authoredQuick = compile(authored, {
+      kind: 'mcp',
+      input: { query: 'authored quick', group: 'quick' },
+    });
+    const team = compile(authored, {
+      kind: 'mcp',
+      input: { query: 'authored team', group: ' team ' },
+    });
+    expect(profileKeys(authoredQuick)).toEqual(['exa/search']);
+    expect(profileKeys(team)).toEqual(['tavily/search']);
+    expect(authoredQuick.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_group_alias_migrated',
+        path: '/group',
+      }),
+    );
+    expect(team.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_group_alias_migrated',
+        path: '/group',
+      }),
+    );
+  });
+
+  it('keeps the CLI/MCP provider-over-group notice after canonicalization', () => {
+    const source = config({
+      providers: { exa: { enabled: true }, tavily: { enabled: true } },
+      groups: { team: ['tavily'] },
+    });
+    const result = compile(source, {
+      kind: 'cli',
+      input: { query: 'providers win', providers: ['exa'], group: 'team' },
+    });
+    expect(profileKeys(result)).toEqual(['exa/search']);
+    expect(result.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'transport_explicit_providers_override_group',
+        path: '/group',
+      }),
+    );
+
+    const ignoredUnknown = compile(source, {
+      kind: 'mcp',
+      input: { query: 'ignore group', providers: ['exa'], group: ' missing ' },
+    });
+    expect(profileKeys(ignoredUnknown)).toEqual(['exa/search']);
+    expect(ignoredUnknown.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'transport_explicit_providers_override_group',
+      }),
+    );
+  });
+
+  it('reports blank, removed, and unknown effective group selectors at /group', () => {
+    const source = config({ providers: { exa: { enabled: true } } });
+    for (const [group, code] of [
+      [' ', 'shadow_group_blank'],
+      ['raw', 'shadow_group_removed'],
+      ['missing', 'shadow_group_unknown'],
+    ] as const) {
+      const result = compile(source, {
+        kind: 'mcp',
+        input: { query: group, group },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toContainEqual(
+          expect.objectContaining({ code, path: '/group' }),
+        );
+      }
+    }
+  });
+
+  it('handles prototype-like group and provider tokens without prototype lookup', () => {
+    const source = config({
+      providers: { exa: { enabled: true }, tavily: { enabled: true } },
+    });
+    source.groups = JSON.parse(
+      '{"__proto__":["exa"],"constructor":["tavily"],"prototype":["exa"]}',
+    ) as Config['groups'];
+    for (const [group, expected] of [
+      ['__proto__', 'exa/search'],
+      ['constructor', 'tavily/search'],
+      ['prototype', 'exa/search'],
+    ] as const) {
+      for (const spelling of [group, `custom:${group}`]) {
+        expect(
+          profileKeys(
+            compile(source, {
+              kind: 'mcp',
+              input: { query: spelling, group: spelling },
+            }),
+          ),
+        ).toEqual([expected]);
+      }
+    }
+    for (const token of ['__proto__', 'constructor', 'prototype']) {
+      const unknown = compile(source, {
+        kind: 'mcp',
+        input: { query: `provider ${token}`, providers: [token] },
+      });
+      expect(unknown.ok).toBe(false);
+      if (!unknown.ok) {
+        expect(unknown.issues).toContainEqual(
+          expect.objectContaining({
+            code: 'shadow_provider_token_unknown',
+            path: '/providers/0',
+          }),
+        );
+      }
+    }
+  });
+
+  it('fails closed for trusted enabled custom providers without profile metadata', () => {
+    const source = config({
+      providers: {
+        exa: { enabled: true },
+        'custom-search': { enabled: true },
+      },
+      customProviders: {
+        'custom-search': { type: 'npm', module: 'custom-search' },
+      },
+      trustedProviderIds: ['custom-search'],
+    });
+    const defaultResult = compile(source, {
+      kind: 'mcp',
+      input: { query: 'custom default' },
+    });
+    const explicitResult = compile(source, {
+      kind: 'mcp',
+      input: { query: 'custom explicit', providers: ['custom-search'] },
+    });
+    const groupSource = config({
+      ...source,
+      groups: { team: ['custom-search'] },
+    });
+    const groupResult = compile(groupSource, {
+      kind: 'mcp',
+      input: { query: 'custom group', group: 'team' },
+    });
+    for (const result of [defaultResult, explicitResult]) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toContainEqual(
+          expect.objectContaining({ code: 'custom_provider_profile_missing' }),
+        );
+      }
+    }
+    expect(explicitResult.ok).toBe(false);
+    if (!explicitResult.ok) {
+      expect(explicitResult.issues).not.toContainEqual(
+        expect.objectContaining({ code: 'shadow_provider_token_unknown' }),
+      );
+    }
+    expect(groupResult.ok).toBe(false);
+    if (!groupResult.ok) {
+      expect(groupResult.issues).toContainEqual(
+        expect.objectContaining({ code: 'configuration_group_member_unknown' }),
+      );
+    }
+  });
+
+  it('never treats built-in ids or aliases as missing custom profiles', () => {
+    const canonical = compile(
+      config({
+        providers: { exa: { enabled: true } },
+        customProviders: { exa: { type: 'npm', module: 'malicious-exa' } },
+        trustedProviderIds: ['exa'],
+      }),
+      {
+        kind: 'mcp',
+        input: { query: 'canonical collision', providers: ['exa'] },
+      },
+    );
+    expect(profileKeys(canonical)).toEqual(['exa/search']);
+    expect(canonical.notices).not.toContainEqual(
+      expect.objectContaining({ code: 'custom_provider_profile_missing' }),
+    );
+
+    const alias = compile(
+      config({
+        providers: { 'openai-deep': { enabled: true } },
+        customProviders: {
+          'openai-deep': { type: 'npm', module: 'malicious-openai' },
+        },
+        trustedProviderIds: ['openai-deep'],
+        defaults: { mode: 'async' },
+      }),
+      {
+        kind: 'mcp',
+        input: {
+          query: 'alias collision',
+          providers: ['openai-deep'],
+          mode: 'async',
+        },
+      },
+    );
+    expect(profileKeys(alias)).toEqual(['openai-research/research']);
+    expect(alias.notices).not.toContainEqual(
+      expect.objectContaining({ code: 'custom_provider_profile_missing' }),
+    );
+  });
+
+  it('does not traverse prototype keys during custom-provider group analysis', () => {
+    const source = config({
+      providers: {
+        exa: { enabled: true },
+        'custom-search': { enabled: true },
+      },
+      customProviders: {
+        'custom-search': { type: 'npm', module: 'custom-search' },
+      },
+      trustedProviderIds: ['custom-search'],
+    });
+    for (const group of ['__proto__', 'constructor', 'prototype']) {
+      const result = compile(source, {
+        kind: 'mcp',
+        input: { query: group, group },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toContainEqual(
+          expect.objectContaining({
+            code: 'shadow_group_unknown',
+            path: '/group',
+          }),
+        );
+      }
+    }
+  });
+
+  it('returns mapping gates before any clock or id calls', () => {
+    const source = config({
+      providers: { exa: { enabled: true } },
+      groups: { quick: ['exa'], 'custom:quick': ['exa'] },
+    });
+    const collisionDependencies = countedPreparation();
+    const collision = compileShadowRequest({
+      config: source,
+      authoredGroups: { global: source.groups, project: {} },
+      credentials: credentials(),
+      requestDeadlineMs: 1_000_000,
+      transport: { kind: 'mcp', input: { query: 'collision', group: 'quick' } },
+      preparation: collisionDependencies.dependencies,
+    });
+    expect(collision.ok).toBe(false);
+    if (!collision.ok) {
+      expect(collision.issues).toEqual([
+        expect.objectContaining({ code: 'shadow_group_collision' }),
+        expect.objectContaining({ code: 'reserved_workflow_name_collision' }),
+      ]);
+    }
+    expect(collisionDependencies.calls()).toBe(0);
+
+    const deadlineSource = config({ providers: { exa: { enabled: true } } });
+    const deadlineDependencies = countedPreparation();
+    const deadline = compileShadowRequest({
+      config: deadlineSource,
+      authoredGroups: { global: deadlineSource.groups, project: {} },
+      credentials: credentials(),
+      transport: {
+        kind: 'mcp',
+        input: { query: 'deadline', providers: ['exa'] },
+      },
+      preparation: deadlineDependencies.dependencies,
+    });
+    expect(deadline.ok).toBe(false);
+    if (!deadline.ok) {
+      expect(deadline.issues).toEqual([
+        expect.objectContaining({
+          code: 'configuration_request_deadline_required',
+          path: '/defaults/requestDeadlineMs',
+        }),
+      ]);
+    }
+    expect(deadlineDependencies.calls()).toBe(0);
+
+    const inexactSource = config({
+      providers: { exa: { enabled: true } },
+      defaults: { maxEstimatedCostUsd: 0.0000001 },
+    });
+    const inexactDependencies = countedPreparation();
+    const inexact = compileShadowRequest({
+      config: inexactSource,
+      authoredGroups: { global: inexactSource.groups, project: {} },
+      credentials: credentials(),
+      requestDeadlineMs: 1_000_000,
+      transport: { kind: 'mcp', input: { query: 'inexact' } },
+      preparation: inexactDependencies.dependencies,
+    });
+    expect(inexact.ok).toBe(false);
+    if (!inexact.ok) {
+      expect(inexact.issues).toContainEqual(
+        expect.objectContaining({ code: 'transport_budget_not_exact' }),
+      );
+    }
+    expect(inexactDependencies.calls()).toBe(0);
+  });
+
+  it('sorts merged diagnostics globally and prepares CLI, MCP, and silent MCP identically', () => {
+    const source = config({ providers: { exa: { enabled: true } } });
+    const invalid = compile(source, {
+      kind: 'cli',
+      input: { query: 'sorted', providers: ['missing', ' '] },
+    });
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect([...invalid.issues].sort(comparePreparationDiagnostics)).toEqual(
+        invalid.issues,
+      );
+    }
+
+    const openRouterSource = config({
+      providers: {
+        'openrouter-online': { enabled: true },
+        'openrouter-chat': { enabled: true },
+      },
+    });
+    const transports: ShadowCompilationTransport[] = [
+      {
+        kind: 'cli',
+        input: {
+          query: '  parity  ',
+          providers: ['OpenRouter Online Search', 'openrouter-chat'],
+        },
+      },
+      {
+        kind: 'mcp',
+        input: {
+          query: '  parity  ',
+          providers: ['openrouter-online', 'openrouter/chat'],
+        },
+      },
+      {
+        kind: 'silent_mcp',
+        input: {
+          query: '  parity  ',
+          providers: ['openrouter/grounded', 'openrouter-chat'],
+        },
+      },
+    ];
+    const prepared = transports.map((transport) => {
+      const result = compile(openRouterSource, transport);
+      if (!result.ok) throw new Error(JSON.stringify(result.issues));
+      return JSON.stringify(result.prepared);
+    });
+    expect(new Set(prepared).size).toBe(1);
+
+    const budgetSource = config({
+      providers: { 'brave-search': { enabled: true } },
+      defaults: { maxCostUsd: 0.25, maxEstimatedCostUsd: 0.1 },
+    });
+    const budgetPrepared = (['cli', 'mcp', 'silent_mcp'] as const).map(
+      (kind) => {
+        const result = compile(budgetSource, {
+          kind,
+          input: { query: 'budget parity', providers: ['brave-search'] },
+        });
+        if (!result.ok) throw new Error(JSON.stringify(result.issues));
+        expect(result.prepared.policy.budgets).toEqual({
+          max_estimated_cost_microusd: '100000',
+          max_actual_cost_microusd: '250000',
+        });
+        return JSON.stringify(result.prepared);
+      },
+    );
+    expect(new Set(budgetPrepared).size).toBe(1);
+  });
+
+  it('keeps authored group aliases and mixed-mode migration byte-identical across transports', () => {
+    const groupSource = config({
+      providers: { exa: { enabled: true } },
+      groups: { team: ['exa'] },
+    });
+    const groupPrepared = (['cli', 'mcp', 'silent_mcp'] as const).map(
+      (kind) => {
+        const result = compile(groupSource, {
+          kind,
+          input: { query: 'group parity', group: 'team' },
+        });
+        if (!result.ok) throw new Error(JSON.stringify(result.issues));
+        expect(result.notices).toContainEqual(
+          expect.objectContaining({
+            code: 'configuration_group_alias_migrated',
+          }),
+        );
+        return JSON.stringify(result.prepared);
+      },
+    );
+    expect(new Set(groupPrepared).size).toBe(1);
+
+    const mixedSource = config({
+      providers: { 'openai-research': { enabled: true } },
+      defaults: { mode: 'mixed' },
+    });
+    const mixedPrepared = [
+      {
+        kind: 'cli' as const,
+        input: { query: 'mixed parity', providers: ['openai-deep'] },
+      },
+      {
+        kind: 'mcp' as const,
+        input: { query: 'mixed parity', providers: ['openai-research'] },
+      },
+      {
+        kind: 'silent_mcp' as const,
+        input: { query: 'mixed parity', providers: ['openai-deep-o3'] },
+      },
+    ].map((transport) => {
+      const result = compile(mixedSource, transport);
+      if (!result.ok) throw new Error(JSON.stringify(result.issues));
+      expect(result.notices).toContainEqual(
+        expect.objectContaining({ code: 'legacy_mixed_mode_migrated' }),
+      );
+      return JSON.stringify(result.prepared);
+    });
+    expect(new Set(mixedPrepared).size).toBe(1);
+  });
+
+  it('merges compatible mapper, group, and planner notices in global order', () => {
+    const source = config({
+      providers: { 'openai-deep': { enabled: true } },
+      groups: { team: ['openai-deep'] },
+      defaults: { mode: 'mixed' },
+    });
+    const result = compile(source, {
+      kind: 'mcp',
+      input: { query: 'merged notices', group: 'team' },
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result.issues));
+    expect([...result.notices].sort(comparePreparationDiagnostics)).toEqual(
+      result.notices,
+    );
+    for (const code of [
+      'configuration_provider_id_migrated',
+      'configuration_provider_alias_migrated',
+      'configuration_group_alias_migrated',
+      'legacy_mixed_mode_migrated',
+    ]) {
+      expect(result.notices).toContainEqual(expect.objectContaining({ code }));
+    }
+  });
+
+  it('sorts provider-alias, override, and mixed-mode notices together', () => {
+    const source = config({
+      providers: { 'openai-research': { enabled: true } },
+      defaults: { mode: 'mixed' },
+    });
+    const result = compile(source, {
+      kind: 'cli',
+      input: {
+        query: 'provider precedence notices',
+        providers: ['openai-deep'],
+        group: 'ignored-group',
+      },
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result.issues));
+    expect([...result.notices].sort(comparePreparationDiagnostics)).toEqual(
+      result.notices,
+    );
+    for (const code of [
+      'configuration_provider_alias_migrated',
+      'transport_explicit_providers_override_group',
+      'legacy_mixed_mode_migrated',
+    ]) {
+      expect(result.notices).toContainEqual(expect.objectContaining({ code }));
+    }
+  });
+
+  it('stays private and has an edge-safe esbuild dependency graph', async () => {
+    const result = await build({
+      entryPoints: [
+        fileURLToPath(
+          new URL('../src/core/shadow-compilation.ts', import.meta.url),
+        ),
+      ],
+      bundle: true,
+      format: 'esm',
+      metafile: true,
+      packages: 'external',
+      platform: 'neutral',
+      write: false,
+      logLevel: 'silent',
+    });
+    const graph = [
+      ...Object.keys(result.metafile.inputs),
+      ...Object.values(result.metafile.inputs).flatMap((input) =>
+        input.imports.map(({ path }) => path),
+      ),
+    ].join('\n');
+    expect(graph).not.toMatch(
+      /(?:node:|execution-runtime|coordinator(?:-store)?|bridge|dispatcher|research-run|node-registry|(?:^|\/)commands(?:\/|$)|(?:^|\/)mcp(?:\/|$))/,
+    );
+    const productionEntryPoints = [
+      fileURLToPath(new URL('../src/cli.ts', import.meta.url)),
+      fileURLToPath(new URL('../src/core-entry.ts', import.meta.url)),
+      fileURLToPath(new URL('../src/node-entry.ts', import.meta.url)),
+      ...readdirSync(fileURLToPath(new URL('../src/mcp/', import.meta.url)))
+        .filter((name) => name.endsWith('.ts'))
+        .map((name) =>
+          fileURLToPath(new URL(`../src/mcp/${name}`, import.meta.url)),
+        ),
+    ];
+    const production = await build({
+      entryPoints: productionEntryPoints,
+      bundle: true,
+      format: 'esm',
+      metafile: true,
+      outdir: 'metafile-only',
+      packages: 'external',
+      platform: 'node',
+      write: false,
+      logLevel: 'silent',
+    });
+    expect(Object.keys(production.metafile.inputs).join('\n')).not.toContain(
+      'shadow-compilation',
+    );
+  });
+});

--- a/tests/transport-normalization.test.ts
+++ b/tests/transport-normalization.test.ts
@@ -220,6 +220,25 @@ describe('shadow transport golden equality', () => {
 });
 
 describe('selector conflicts', () => {
+  it('rejects raw provider tokens plus private exact targets deterministically', () => {
+    const result = normalizeMcpRequest(
+      {
+        query: 'q',
+        providers: ['alpha'],
+        exactTargets: [{ provider_id: 'alpha', profile_id: 'grounded-web' }],
+      },
+      FIXTURE_DEFAULTS,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'transport_raw_and_exact_targets_conflict',
+        path: '/providers',
+      }),
+    ]);
+  });
+
   it('lets explicit providers override a group for CLI and MCP ingress with a notice', () => {
     const input = { query: 'q', providers: ['alpha'], group: 'quick' };
     for (const normalize of [

--- a/tests/workers/shadow-compilation.test.ts
+++ b/tests/workers/shadow-compilation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { compileShadowRequest } from '../../src/core/shadow-compilation.js';
+import type { Config } from '../../src/types.js';
+
+const config: Config = {
+  version: 1,
+  defaults: {
+    outputDir: './agents/librarium',
+    maxParallel: 2,
+    timeout: 30,
+    asyncTimeout: 120,
+    asyncPollInterval: 5,
+    mode: 'sync',
+    llmWebSearch: true,
+  },
+  providers: { exa: { enabled: true } },
+  customProviders: {},
+  trustedProviderIds: [],
+  groups: {},
+};
+
+describe('private shadow compiler in workerd', () => {
+  it('imports and prepares a plan without Node runtime dependencies', () => {
+    const counts = new Map<string, number>();
+    const result = compileShadowRequest({
+      config,
+      authoredGroups: { global: {}, project: {} },
+      credentials: { env: { EXA_API_KEY: 'worker-test-key' } },
+      requestDeadlineMs: 300_000,
+      transport: {
+        kind: 'silent_mcp',
+        input: { query: 'worker-safe shadow plan', providers: ['Exa Search'] },
+      },
+      preparation: {
+        clock: { now: () => Date.parse('2026-08-09T12:00:00Z') },
+        ids: {
+          next: (scope) => {
+            const count = (counts.get(scope) ?? 0) + 1;
+            counts.set(scope, count);
+            return `worker-${scope}-${count}`;
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.prepared.request.slots).toHaveLength(1);
+    expect(result.prepared.request.slots[0]?.primary.identity).toMatchObject({
+      provider_id: 'exa',
+      profile_id: 'search',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a private, Worker-safe shadow compiler that proves v1 configuration and CLI/MCP-shaped inputs can compile into the canonical v2 execution plan without changing production behavior.

## Changes

- map validated v1 configuration into the frozen provider catalog before request compilation
- canonicalize provider and group aliases to exact provider/profile targets
- preserve legacy provider-over-group and mixed-mode migration notices
- fail closed for ambiguous OpenRouter targets and custom providers without canonical profile metadata
- carry exact budgets, fallback reserve eligibility, and request limits into the prepared plan
- reject private exact-target injection at the raw transport boundary
- move budget admission before clock and ID effects
- verify the shadow graph is Worker-safe and absent from production CLI, core, Node, and MCP entry graphs

## Compatibility

- the compiler is private, unexported, and not wired to production execution
- existing CLI, MCP, library, refinement, and runtime behavior are unchanged
- production cutover remains a separate reviewed change

## Testing

- 1,772 unit tests
- 180 focused planning, mapping, and adversarial tests
- 16 Worker compatibility tests
- 14 integration tests
- TypeScript typecheck
- Biome lint
- production build
- independent adversarial re-review