### PR TITLE
feat(core): add trusted custom planning profiles

### DIFF
--- a/src/core/catalog-fingerprint.ts
+++ b/src/core/catalog-fingerprint.ts
@@ -22,6 +22,11 @@ const FNV_64_OFFSET_BASIS = 0xcbf2_9ce4_8422_2325n;
 const FNV_64_PRIME = 0x0000_0100_0000_01b3n;
 const UINT64_MASK = 0xffff_ffff_ffff_ffffn;
 
+/** Locale-independent UTF-16 ordering shared by catalog arrays and JSON keys. */
+export function compareCanonicalStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 /**
  * Canonical JSON: object keys sorted, array order preserved, `undefined`
  * omitted. Key sorting is what makes the fingerprint independent of the order
@@ -38,7 +43,7 @@ export function canonicalJson(value: unknown): string {
   if (typeof value === 'object') {
     const entries = Object.entries(value as Record<string, unknown>)
       .filter(([, item]) => item !== undefined)
-      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+      .sort(([left], [right]) => compareCanonicalStrings(left, right));
     return `{${entries
       .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
       .join(',')}}`;

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -4,6 +4,7 @@ import {
   type ProviderNameEntry,
   resolveProviderToken,
 } from '../constants.js';
+import { OpaqueIdSchema } from '../contracts/common.js';
 import type { Config, ProviderConfig } from '../types.js';
 import { customWorkflowId } from './builtin-workflows.js';
 import type { CredentialContext } from './credentials.js';
@@ -15,15 +16,20 @@ import {
 import {
   buildProviderCatalog,
   type CatalogProfileTarget,
+  type CustomCatalogProfile,
   type ProviderCatalog,
 } from './profile-catalog.js';
 import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
-import type { ProviderCatalogEntry } from './provider-profiles.js';
+import {
+  BUILTIN_PROVIDER_CATALOG,
+  type ProviderCatalogEntry,
+} from './provider-profiles.js';
 import type {
   PreparationIssue,
   PreparationNotice,
 } from './research-request.js';
 import { comparePreparationDiagnostics } from './research-request.js';
+import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 import type {
   CanonicalTransportDefaults,
   ConfigurationTransportInput,
@@ -67,6 +73,8 @@ export interface ConfigurationMappingResult {
   readonly group_aliases: Readonly<Record<string, string>>;
   readonly reserve: readonly CatalogProfileTarget[];
   readonly reserve_only_adapter_ids: readonly string[];
+  /** Trust-filtered, closure-free custom bindings used by private ingress. */
+  readonly custom_profile_bindings: readonly CustomCatalogProfile[];
   readonly preflight: ConfigurationPreflight;
 }
 
@@ -110,11 +118,29 @@ function publicRecord<T>(
   return Object.fromEntries(Object.entries(record));
 }
 
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value))
+    return value;
+  Object.freeze(value);
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return value;
+}
+
+function ownCustomProfiles(
+  profiles: readonly CustomCatalogProfile[],
+): readonly CustomCatalogProfile[] {
+  return deepFreeze(structuredClone(profiles));
+}
+
 function ownValue<T>(
   record: Readonly<Record<string, T>>,
   key: string,
 ): T | undefined {
   return Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
+function escapePointerSegment(segment: string): string {
+  return segment.replaceAll('~', '~0').replaceAll('/', '~1');
 }
 
 function canonicalProviderId(id: string): string {
@@ -128,6 +154,7 @@ function canonicalProviderId(id: string): string {
  */
 export function resolveConfigurationProfileToken(
   token: string,
+  customProfiles: readonly CustomCatalogProfile[] = [],
 ): ConfigurationProfileTokenResolution {
   const trimmed = token.trim();
   const qualified = trimmed.split('/');
@@ -136,9 +163,10 @@ export function resolveConfigurationProfileToken(
       provider_id: qualified[0],
       profile_id: qualified[1],
     };
-    const known = [...adapterProfileBindings().values()].some((binding) =>
-      sameProfile(binding, target),
-    );
+    const known = [
+      ...adapterProfileBindings().values(),
+      ...customProfiles.map(customProfileBinding),
+    ].some((binding) => sameProfile(binding, target));
     return known
       ? { kind: 'exact', token: trimmed, target }
       : { kind: 'unknown', token: trimmed, suggestions: [] };
@@ -150,7 +178,16 @@ export function resolveConfigurationProfileToken(
   const direct = adapterProfileBinding(trimmed);
   if (direct) return exactToken(trimmed, direct);
 
-  const catalogMatches = [...adapterProfileBindings().values()]
+  const directCustom = customProfiles.find(
+    (profile) => profile.adapter_id === trimmed,
+  );
+  if (directCustom)
+    return exactToken(trimmed, customProfileBinding(directCustom));
+
+  const catalogMatches = [
+    ...adapterProfileBindings().values(),
+    ...customProfiles.map(customProfileBinding),
+  ]
     .filter((binding) => binding.provider_id === trimmed)
     .sort((left, right) => profileKey(left).localeCompare(profileKey(right)));
   if (catalogMatches.length === 1)
@@ -200,7 +237,10 @@ export function resolveConfigurationProfileToken(
       candidates: exactTargetsForProviderEntries(provider.candidates),
     };
   }
-  const matches = [...adapterProfileBindings().values()]
+  const matches = [
+    ...adapterProfileBindings().values(),
+    ...customProfiles.map(customProfileBinding),
+  ]
     .filter((binding) => binding.provider_id === provider.id)
     .sort((left, right) => profileKey(left).localeCompare(profileKey(right)));
   if (matches.length === 1) {
@@ -258,7 +298,10 @@ function exactTargetsForProviderEntries(
 
 function exactToken(
   token: string,
-  binding: AdapterProfileBinding,
+  binding: Pick<
+    AdapterProfileBinding,
+    'adapter_id' | 'provider_id' | 'profile_id'
+  >,
   alias?: { readonly from: string; readonly adapter_id: string },
 ): ConfigurationProfileTokenResolution {
   return {
@@ -270,6 +313,165 @@ function exactToken(
     },
     ...(alias && { alias }),
   };
+}
+
+function customProfileBinding(
+  profile: CustomCatalogProfile,
+): AdapterProfileBinding {
+  return {
+    adapter_id: profile.adapter_id,
+    provider_id: profile.profile.identity.provider_id,
+    profile_id: profile.profile.identity.profile_id,
+  };
+}
+
+function customCatalogProfileCandidates(
+  config: Config,
+): CustomCatalogProfile[] {
+  const trusted = new Set(config.trustedProviderIds);
+  const candidates: CustomCatalogProfile[] = [];
+  for (const [adapterId, source] of Object.entries(config.customProviders)) {
+    if (
+      RESERVED_BUILTIN_PROVIDER_IDS.has(adapterId) ||
+      !trusted.has(adapterId) ||
+      source.executionProfile === undefined
+    ) {
+      continue;
+    }
+    candidates.push({
+      adapter_id: adapterId,
+      binding_id: source.executionProfile.bindingId,
+      profile: source.executionProfile.profile,
+      ...(source.executionProfile.credential && {
+        credential_env_var: source.executionProfile.credential.envVar,
+      }),
+    });
+  }
+  return candidates;
+}
+
+function validateCustomCatalogProfiles(
+  candidates: readonly CustomCatalogProfile[],
+  catalog: readonly ProviderCatalogEntry[] = BUILTIN_PROVIDER_CATALOG,
+): {
+  profiles: CustomCatalogProfile[];
+  issues: PreparationIssue[];
+} {
+  const profiles: CustomCatalogProfile[] = [];
+  const issues: PreparationIssue[] = [];
+  const profileKeys = new Set(
+    catalog.flatMap((entry) =>
+      entry.profiles.map((profile) =>
+        JSON.stringify([entry.provider_id, profile.profile_id]),
+      ),
+    ),
+  );
+  const bindingKeys = new Set<string>();
+
+  for (const candidate of candidates) {
+    const adapterId = candidate.adapter_id;
+    const basePath = `/customProviders/${escapePointerSegment(adapterId)}/executionProfile`;
+    let addressable = true;
+    if (!OpaqueIdSchema.safeParse(adapterId).success) {
+      addressable = false;
+      issues.push({
+        code: 'custom_provider_adapter_id_invalid',
+        phase: 'migration',
+        path: `/customProviders/${escapePointerSegment(adapterId)}`,
+        message:
+          'Custom-provider adapter ids must be non-empty, trimmed, control-free opaque identifiers.',
+      });
+    }
+    if (adapterId.includes('/')) {
+      addressable = false;
+      issues.push({
+        code: 'custom_provider_adapter_id_unaddressable',
+        phase: 'migration',
+        path: `/customProviders/${escapePointerSegment(adapterId)}`,
+        message:
+          'Custom-provider adapter ids cannot contain the "/" selector delimiter.',
+      });
+    }
+    const providerId = candidate.profile.identity.provider_id;
+    const profileId = candidate.profile.identity.profile_id;
+    if (RESERVED_BUILTIN_PROVIDER_IDS.has(providerId)) {
+      addressable = false;
+      issues.push({
+        code: 'custom_provider_profile_provider_id_reserved',
+        phase: 'migration',
+        path: `${basePath}/profile/identity/provider_id`,
+        message:
+          'A custom profile cannot claim a current, planned, or retired built-in provider id.',
+      });
+    }
+    for (const [field, value] of [
+      ['provider_id', providerId],
+      ['profile_id', profileId],
+    ] as const) {
+      if (!value.includes('/')) continue;
+      addressable = false;
+      issues.push({
+        code: 'custom_provider_profile_id_unaddressable',
+        phase: 'migration',
+        path: `${basePath}/profile/identity/${field}`,
+        message: `Custom-provider profile ${field} cannot contain the "/" selector delimiter.`,
+      });
+    }
+    if (!addressable) continue;
+    if (!OpaqueIdSchema.safeParse(candidate.binding_id).success) {
+      issues.push({
+        code: 'custom_provider_binding_id_invalid',
+        phase: 'migration',
+        path: `${basePath}/bindingId`,
+        message:
+          'Custom-provider binding ids must be non-empty, trimmed, control-free opaque identifiers.',
+      });
+      continue;
+    }
+    if (candidate.profile.resumability === 'process_local') {
+      issues.push({
+        code: 'custom_provider_process_local_unsupported',
+        phase: 'migration',
+        path: `${basePath}/profile/resumability`,
+        message:
+          'Custom-provider shadow planning supports inline or durable background profiles; process-local resumability remains on the v1 runtime path.',
+      });
+      continue;
+    }
+    const profile = customProfileBinding(candidate);
+    const identityTuple = JSON.stringify([
+      profile.provider_id,
+      profile.profile_id,
+    ]);
+    const identityDisplay = profileKey(profile);
+    if (profileKeys.has(identityTuple)) {
+      issues.push({
+        code: 'custom_provider_profile_duplicate',
+        phase: 'migration',
+        path: `${basePath}/profile/identity`,
+        message:
+          'Each custom provider must declare a unique provider/profile identity.',
+        profile_key: identityDisplay,
+      });
+      continue;
+    }
+    const bindingKey = JSON.stringify([adapterId, candidate.binding_id]);
+    if (bindingKeys.has(bindingKey)) {
+      issues.push({
+        code: 'custom_provider_binding_duplicate',
+        phase: 'migration',
+        path: `${basePath}/bindingId`,
+        message:
+          'Each custom provider must declare a unique adapter/binding identity.',
+        profile_key: identityDisplay,
+      });
+      continue;
+    }
+    profileKeys.add(identityTuple);
+    bindingKeys.add(bindingKey);
+    profiles.push(candidate);
+  }
+  return { profiles, issues };
 }
 
 function canonicalizeProviderConfigs(
@@ -387,6 +589,7 @@ function authoredGroups(
 
 function canonicalizeGroups(
   groups: Readonly<Record<string, readonly string[]>>,
+  customProfiles: readonly CustomCatalogProfile[] = [],
 ): {
   groups: Record<string, string[]>;
   notices: PreparationNotice[];
@@ -400,7 +603,10 @@ function canonicalizeGroups(
     const seen = new Set<string>();
     for (const [index, member] of members.entries()) {
       const path = `/groups/${name}/${index}`;
-      const resolution = resolveConfigurationProfileToken(member);
+      const resolution = resolveConfigurationProfileToken(
+        member,
+        customProfiles,
+      );
       if (resolution.kind === 'unknown') {
         issues.push({
           code: 'configuration_group_member_unknown',
@@ -460,6 +666,7 @@ function groupAliases(
 
 function fallbackReserve(
   providerConfigs: Readonly<Record<string, ProviderConfig>>,
+  customProfiles: readonly CustomCatalogProfile[] = [],
 ): {
   reserve: CatalogProfileTarget[];
   reserveOnlyAdapterIds: string[];
@@ -503,7 +710,11 @@ function fallbackReserve(
       continue;
     }
 
-    const source = adapterProfileBinding(adapterId);
+    const source =
+      adapterProfileBinding(adapterId) ??
+      customProfiles
+        .filter((profile) => profile.adapter_id === adapterId)
+        .map(customProfileBinding)[0];
     if (!source) {
       issues.push({
         code: 'configuration_fallback_unbound_source',
@@ -514,7 +725,11 @@ function fallbackReserve(
       });
       continue;
     }
-    const target = adapterProfileBinding(fallback);
+    const target =
+      adapterProfileBinding(fallback) ??
+      customProfiles
+        .filter((profile) => profile.adapter_id === fallback)
+        .map(customProfileBinding)[0];
     if (!target) {
       issues.push({
         code: ownValue(providerConfigs, fallback)
@@ -647,11 +862,35 @@ export function mapConfiguration(
 ): ConfigurationMappingResult {
   const providerConfigMapping = materializeProviderConfigs(config);
   const providerConfigs = providerConfigMapping.providerConfigs;
+  const customCandidates = customCatalogProfileCandidates(config);
+  // Disabled custom providers are admitted only when a validated configured
+  // fallback edge needs them as reserve-only targets. This preliminary pass
+  // determines that eligibility; final diagnostics and reserve facts are
+  // recomputed after semantic validation below.
+  const preliminaryFallback = fallbackReserve(
+    providerConfigs,
+    customCandidates,
+  );
+  const reserveOnly = new Set(preliminaryFallback.reserveOnlyAdapterIds);
+  const eligibleCustomCandidates = customCandidates.filter(
+    (candidate) =>
+      providerConfigs[candidate.adapter_id]?.enabled === true ||
+      reserveOnly.has(candidate.adapter_id),
+  );
+  const custom = validateCustomCatalogProfiles(
+    eligibleCustomCandidates,
+    options.catalog ?? BUILTIN_PROVIDER_CATALOG,
+  );
+  const customProfiles = ownCustomProfiles(custom.profiles);
   const authored = authoredGroups(options.authoredGroups);
-  const canonicalGroups = canonicalizeGroups(authored);
+  const canonicalGroups = canonicalizeGroups(authored, customProfiles);
   const groups = canonicalGroups.groups;
-  const fallback = fallbackReserve(providerConfigs);
-  const issues = [...canonicalGroups.issues, ...fallback.issues];
+  const fallback = fallbackReserve(providerConfigs, customProfiles);
+  const issues = [
+    ...custom.issues,
+    ...canonicalGroups.issues,
+    ...fallback.issues,
+  ];
   const transportDefaults = canonicalDefaults(
     config,
     options.requestDeadlineMs,
@@ -666,6 +905,7 @@ export function mapConfiguration(
     // derives a v2 default roster.
     reserve: fallback.reserve,
     reserveOnlyAdapterIds: fallback.reserveOnlyAdapterIds,
+    customProfiles,
   });
   const notices = [
     ...canonicalGroups.notices,
@@ -696,6 +936,7 @@ export function mapConfiguration(
     group_aliases: aliases,
     reserve: fallback.reserve,
     reserve_only_adapter_ids: fallback.reserveOnlyAdapterIds,
+    custom_profile_bindings: customProfiles,
     preflight: { notices, issues: allIssues },
   };
 }

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -7,6 +7,7 @@ import {
 import { OpaqueIdSchema } from '../contracts/common.js';
 import type { Config, ProviderConfig } from '../types.js';
 import { customWorkflowId } from './builtin-workflows.js';
+import { compareCanonicalStrings } from './catalog-fingerprint.js';
 import type { CredentialContext } from './credentials.js';
 import {
   type AdapterProfileBinding,
@@ -189,7 +190,9 @@ export function resolveConfigurationProfileToken(
     ...customProfiles.map(customProfileBinding),
   ]
     .filter((binding) => binding.provider_id === trimmed)
-    .sort((left, right) => profileKey(left).localeCompare(profileKey(right)));
+    .sort((left, right) =>
+      compareCanonicalStrings(profileKey(left), profileKey(right)),
+    );
   if (catalogMatches.length === 1)
     return exactToken(trimmed, catalogMatches[0]);
   if (catalogMatches.length > 1) {
@@ -242,7 +245,9 @@ export function resolveConfigurationProfileToken(
     ...customProfiles.map(customProfileBinding),
   ]
     .filter((binding) => binding.provider_id === provider.id)
-    .sort((left, right) => profileKey(left).localeCompare(profileKey(right)));
+    .sort((left, right) =>
+      compareCanonicalStrings(profileKey(left), profileKey(right)),
+    );
   if (matches.length === 1) {
     return exactToken(
       trimmed,
@@ -290,7 +295,8 @@ function exactTargetsForProviderEntries(
       ]),
     ).values(),
   ].sort((left, right) =>
-    `${left.provider_id}/${left.profile_id}`.localeCompare(
+    compareCanonicalStrings(
+      `${left.provider_id}/${left.profile_id}`,
       `${right.provider_id}/${right.profile_id}`,
     ),
   );

--- a/src/core/credentials.ts
+++ b/src/core/credentials.ts
@@ -56,7 +56,10 @@ export function resolveCredential(
   }
 
   if (value.startsWith('$')) {
-    return context.env?.[value.slice(1)];
+    const name = value.slice(1);
+    if (!context.env || !Object.hasOwn(context.env, name)) return undefined;
+    const resolved = context.env[name];
+    return typeof resolved === 'string' ? resolved : undefined;
   }
 
   if (isKeychainCredentialRef(value)) {

--- a/src/core/profile-catalog.ts
+++ b/src/core/profile-catalog.ts
@@ -13,7 +13,10 @@ import {
   migrateUserWorkflowNames,
   RESERVED_WORKFLOW_IDS,
 } from './builtin-workflows.js';
-import { catalogFingerprint } from './catalog-fingerprint.js';
+import {
+  catalogFingerprint,
+  compareCanonicalStrings,
+} from './catalog-fingerprint.js';
 import { type CredentialContext, hasCredential } from './credentials.js';
 import type {
   FrozenPlanningCatalog,
@@ -256,7 +259,7 @@ function customDeclaration(
     target: identity.target,
     selection_order: selectionOrder,
     status: 'implemented',
-    workflows: [],
+    workflows: profile.result_kind === 'research_report' ? ['deep'] : [],
   };
 }
 
@@ -345,7 +348,7 @@ export function buildProviderCatalog(
         right.adapter_id,
         right.binding_id,
       ]);
-      return leftKey.localeCompare(rightKey);
+      return compareCanonicalStrings(leftKey, rightKey);
     }),
   );
   const customProfiles = declaredCustomProfiles.filter((custom) => {

--- a/src/core/profile-catalog.ts
+++ b/src/core/profile-catalog.ts
@@ -1,3 +1,4 @@
+import { OpaqueIdSchema } from '../contracts/common.js';
 import type {
   ExecutionProfile,
   ProviderIdentity,
@@ -35,6 +36,7 @@ import type {
   PreparationIssue,
   PreparationNotice,
 } from './research-request.js';
+import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 
 export class ProviderCatalogError extends Error {}
 
@@ -48,7 +50,7 @@ export type AvailabilityReason =
 export interface ResolvedCatalogProfile {
   readonly declaration: ExecutableProfileDeclaration;
   readonly profile: ExecutionProfile;
-  readonly binding?: ProfileBinding;
+  readonly binding?: CatalogProfileBinding;
   readonly estimate?: NetworkFreeEstimate;
   readonly availability: {
     readonly enabled: boolean;
@@ -58,6 +60,25 @@ export interface ResolvedCatalogProfile {
     readonly selectable: boolean;
     readonly reasons: readonly string[];
   };
+}
+
+/** Closure-free identity used by the planner for built-in and custom adapters. */
+export interface CatalogProfileBinding {
+  readonly provider_id: string;
+  readonly profile_id: string;
+  readonly adapter_id: string;
+  readonly binding_id: string;
+}
+
+/**
+ * A trusted custom provider's planning-only declaration. Runtime code loading
+ * and operation validation remain outside this Worker-safe catalog boundary.
+ */
+export interface CustomCatalogProfile {
+  readonly adapter_id: string;
+  readonly binding_id: string;
+  readonly profile: ExecutionProfile;
+  readonly credential_env_var?: string;
 }
 
 /** A `provider_id/profile_id` reference used by configured rosters. */
@@ -79,6 +100,8 @@ export interface ProviderCatalogOptions {
   readonly reserve?: readonly CatalogProfileTarget[];
   /** Adapter ids which are disabled for primary selection but valid reserve. */
   readonly reserveOnlyAdapterIds?: readonly string[];
+  /** Already trust-filtered custom profiles; untrusted/disabled code stays out. */
+  readonly customProfiles?: readonly CustomCatalogProfile[];
 }
 
 export interface WorkflowOmission {
@@ -222,6 +245,62 @@ function resolveDeclaration(
   });
 }
 
+function customDeclaration(
+  profile: ExecutionProfile,
+  selectionOrder: number,
+): ExecutableProfileDeclaration {
+  const { identity, extensions: _extensions, ...facts } = profile;
+  return {
+    ...facts,
+    profile_id: identity.profile_id,
+    target: identity.target,
+    selection_order: selectionOrder,
+    status: 'implemented',
+    workflows: [],
+  };
+}
+
+function resolveCustomProfile(
+  custom: CustomCatalogProfile,
+  selectionOrder: number,
+  options: ProviderCatalogOptions,
+): ResolvedCatalogProfile {
+  const providerConfig = bindingConfig(options, custom.adapter_id);
+  const enabled = providerConfig?.enabled === true;
+  const reserveOnly =
+    !enabled &&
+    options.reserveOnlyAdapterIds?.includes(custom.adapter_id) === true;
+  const credentialReference =
+    providerConfig?.apiKey ??
+    (custom.credential_env_var ? `$${custom.credential_env_var}` : undefined);
+  const credentialValid = custom.credential_env_var
+    ? hasCredential(credentialReference, options.credentials ?? {})
+    : true;
+  const reasons: string[] = [];
+  if (!enabled) reasons.push('profile_disabled');
+  if (!credentialValid) reasons.push('credential_missing');
+  const profile = ownFrozen(custom.profile);
+  const binding = ownFrozen<CatalogProfileBinding>({
+    provider_id: profile.identity.provider_id,
+    profile_id: profile.identity.profile_id,
+    adapter_id: custom.adapter_id,
+    binding_id: custom.binding_id,
+  });
+  return Object.freeze({
+    declaration: ownFrozen(customDeclaration(profile, selectionOrder)),
+    profile,
+    binding,
+    availability: ownFrozen({
+      enabled,
+      reserve_only: reserveOnly,
+      credential_valid: credentialValid,
+      configuration_valid: true,
+      selectable: enabled && credentialValid,
+      reasons,
+    }),
+  });
+}
+
 /**
  * Catalog construction is network-free, deterministic, and total: a missing,
  * duplicated, or orphaned binding fails here rather than at execution time.
@@ -252,8 +331,110 @@ export function buildProviderCatalog(
     }
   }
 
-  const resolved: ResolvedCatalogProfile[] = refs.map(
-    ({ entry, declaration }) =>
+  const declaredCustomProfiles = ownFrozen(
+    [...(options.customProfiles ?? [])].sort((left, right) => {
+      const leftKey = JSON.stringify([
+        left.profile.identity.provider_id,
+        left.profile.identity.profile_id,
+        left.adapter_id,
+        left.binding_id,
+      ]);
+      const rightKey = JSON.stringify([
+        right.profile.identity.provider_id,
+        right.profile.identity.profile_id,
+        right.adapter_id,
+        right.binding_id,
+      ]);
+      return leftKey.localeCompare(rightKey);
+    }),
+  );
+  const customProfiles = declaredCustomProfiles.filter((custom) => {
+    const enabled = bindingConfig(options, custom.adapter_id)?.enabled === true;
+    return (
+      enabled ||
+      options.reserveOnlyAdapterIds?.includes(custom.adapter_id) === true
+    );
+  });
+  const profileKeys = new Set(
+    refs.map(({ entry, declaration }) =>
+      JSON.stringify([entry.provider_id, declaration.profile_id]),
+    ),
+  );
+  const adapterBindingKeys = new Set(
+    [...bindings.values()].map((binding) =>
+      JSON.stringify([binding.adapter_id, binding.binding_id]),
+    ),
+  );
+  const builtinAdapterIds = new Set(
+    [...bindings.values()].map((binding) => binding.adapter_id),
+  );
+  for (const custom of customProfiles) {
+    for (const [field, value] of [
+      ['adapter id', custom.adapter_id],
+      ['binding id', custom.binding_id],
+    ] as const) {
+      if (!OpaqueIdSchema.safeParse(value).success) {
+        throw new ProviderCatalogError(
+          `Custom provider ${field} must be a canonical opaque identifier: ${JSON.stringify(value)}`,
+        );
+      }
+    }
+    if (
+      builtinAdapterIds.has(custom.adapter_id) ||
+      RESERVED_BUILTIN_PROVIDER_IDS.has(custom.adapter_id)
+    ) {
+      throw new ProviderCatalogError(
+        `Custom provider adapter id is reserved: ${custom.adapter_id}`,
+      );
+    }
+    if (
+      RESERVED_BUILTIN_PROVIDER_IDS.has(custom.profile.identity.provider_id)
+    ) {
+      throw new ProviderCatalogError(
+        `Custom provider profile provider id is reserved: ${custom.profile.identity.provider_id}`,
+      );
+    }
+    for (const [field, value] of [
+      ['adapter id', custom.adapter_id],
+      ['provider id', custom.profile.identity.provider_id],
+      ['profile id', custom.profile.identity.profile_id],
+    ] as const) {
+      if (value.includes('/')) {
+        throw new ProviderCatalogError(
+          `Custom provider ${field} cannot contain the selector delimiter "/": ${value}`,
+        );
+      }
+    }
+    const profileTuple = JSON.stringify([
+      custom.profile.identity.provider_id,
+      custom.profile.identity.profile_id,
+    ]);
+    const profileDisplay = catalogProfileKey(
+      custom.profile.identity.provider_id,
+      custom.profile.identity.profile_id,
+    );
+    if (profileKeys.has(profileTuple)) {
+      throw new ProviderCatalogError(
+        `Duplicate provider profile declaration: ${profileDisplay}`,
+      );
+    }
+    profileKeys.add(profileTuple);
+    if (custom.profile.resumability === 'process_local') {
+      throw new ProviderCatalogError(
+        `Custom provider profiles cannot use process_local resumability: ${custom.adapter_id}`,
+      );
+    }
+    const bindingKey = JSON.stringify([custom.adapter_id, custom.binding_id]);
+    if (adapterBindingKeys.has(bindingKey)) {
+      throw new ProviderCatalogError(
+        `Duplicate adapter binding declaration: ${bindingKey}`,
+      );
+    }
+    adapterBindingKeys.add(bindingKey);
+  }
+
+  const resolved: ResolvedCatalogProfile[] = [
+    ...refs.map(({ entry, declaration }) =>
       resolveDeclaration(
         entry,
         declaration,
@@ -262,7 +443,11 @@ export function buildProviderCatalog(
         ),
         options,
       ),
-  );
+    ),
+    ...customProfiles.map((custom, index) =>
+      resolveCustomProfile(custom, refs.length + index + 1, options),
+    ),
+  ];
   const byKey = new Map(resolved.map((item) => [profileKeyOf(item), item]));
 
   // The catalog owns its selection policy from here on. Groups, defaults, and
@@ -525,7 +710,9 @@ export function buildProviderCatalog(
 
   const planningProfiles: PlanningProfile[] = resolved
     .filter(
-      (item): item is ResolvedCatalogProfile & { binding: ProfileBinding } =>
+      (
+        item,
+      ): item is ResolvedCatalogProfile & { binding: CatalogProfileBinding } =>
         item.binding !== undefined,
     )
     .map((item) => ({
@@ -552,6 +739,7 @@ export function buildProviderCatalog(
   );
   const digest = catalogFingerprint({
     revision,
+    custom_profiles: customProfiles,
     profiles: planningProfiles,
     workflows: BUILTIN_WORKFLOW_IDS.map((id) => ({
       workflow_id: id,

--- a/src/core/reserved-provider-ids.ts
+++ b/src/core/reserved-provider-ids.ts
@@ -1,0 +1,14 @@
+import { PROVIDER_ID_ALIASES } from '../constants.js';
+import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
+import { BUILTIN_PROVIDER_CATALOG } from './provider-profiles.js';
+
+/**
+ * Every current, planned, adapter, and retired built-in spelling is reserved.
+ * Custom code must never be able to claim a future built-in identity merely
+ * because that profile does not have an executable binding yet.
+ */
+export const RESERVED_BUILTIN_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  ...BUILTIN_PROVIDER_CATALOG.map(({ provider_id }) => provider_id),
+  ...BUILTIN_PROVIDER_DEFINITIONS.map(({ id }) => id),
+  ...Object.keys(PROVIDER_ID_ALIASES),
+]);

--- a/src/core/shadow-compilation.ts
+++ b/src/core/shadow-compilation.ts
@@ -1,4 +1,3 @@
-import { PROVIDER_ID_ALIASES } from '../constants.js';
 import type { Config } from '../types.js';
 import {
   REMOVED_BUILTIN_WORKFLOW_IDS,
@@ -14,13 +13,14 @@ import type {
   PreparationDependencies,
   PreparedResearchExecution,
 } from './execution-plan.js';
-import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
+import type { CustomCatalogProfile } from './profile-catalog.js';
 import type {
   PreparationIssue,
   PreparationNotice,
   ProfileTarget,
 } from './research-request.js';
 import { sortPreparationDiagnostics } from './research-request.js';
+import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 import {
   type CanonicalTransportDefaults,
   type CliTransportInput,
@@ -74,14 +74,10 @@ interface ResolvedProviderTokens {
   readonly issues: readonly PreparationIssue[];
 }
 
-const RESERVED_BUILTIN_PROVIDER_TOKENS = new Set([
-  ...BUILTIN_PROVIDER_DEFINITIONS.map(({ id }) => id),
-  ...Object.keys(PROVIDER_ID_ALIASES),
-]);
-
 function resolveProviderTokens(
   tokens: readonly string[] | undefined,
   missingCustomProviderIds: ReadonlySet<string>,
+  customProfiles: readonly CustomCatalogProfile[],
 ): ResolvedProviderTokens {
   if (tokens === undefined) return { targets: [], notices: [], issues: [] };
 
@@ -116,7 +112,7 @@ function resolveProviderTokens(
       });
       continue;
     }
-    const resolution = resolveConfigurationProfileToken(token);
+    const resolution = resolveConfigurationProfileToken(token, customProfiles);
     if (resolution.kind === 'unknown') {
       issues.push({
         code: 'shadow_provider_token_unknown',
@@ -254,10 +250,11 @@ function missingCustomProviderIds(config: Config): readonly string[] {
   const trusted = new Set(config.trustedProviderIds);
   return Object.keys(config.customProviders).filter(
     (id) =>
-      !RESERVED_BUILTIN_PROVIDER_TOKENS.has(id) &&
+      !RESERVED_BUILTIN_PROVIDER_IDS.has(id) &&
       trusted.has(id) &&
       Object.hasOwn(config.providers, id) &&
-      config.providers[id]?.enabled === true,
+      config.providers[id]?.enabled === true &&
+      config.customProviders[id]?.executionProfile === undefined,
   );
 }
 
@@ -399,6 +396,7 @@ export function compileShadowRequest(
   const resolved = resolveProviderTokens(
     rawProviders,
     new Set(missingCustomProviderIds(input.config)),
+    mapped.custom_profile_bindings,
   );
   // A supplied provider selection owns selector precedence, even when its
   // tokens are invalid. Its error should not be obscured by an ignored group.

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -16,7 +16,7 @@ import {
   loadCustomProviders as loadCustomProvidersInternal,
 } from './adapters/custom.js';
 import { getAllProviders, registerProvider } from './adapters/index.js';
-import { BUILTIN_PROVIDER_DEFINITIONS } from './core/provider-descriptor.js';
+import { RESERVED_BUILTIN_PROVIDER_IDS } from './core/reserved-provider-ids.js';
 import type { Config } from './types.js';
 
 export type { CustomProviderLoadResult } from './adapters/custom.js';
@@ -43,10 +43,7 @@ export async function loadCustomProviders(
   options: LoadCustomProvidersOptions = {},
 ): Promise<CustomProviderLoadResult> {
   const reservedProviderIds = new Set([
-    ...BUILTIN_PROVIDER_DEFINITIONS.flatMap(({ id, aliases }) => [
-      id,
-      ...aliases,
-    ]),
+    ...RESERVED_BUILTIN_PROVIDER_IDS,
     ...getAllProviders().map((provider) => provider.id),
     ...(options.reservedProviderIds ?? []),
   ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
 import { z } from 'zod';
+import { OpaqueIdSchema } from './contracts/common.js';
+import {
+  type ExecutionProfile,
+  ExecutionProfileSchema,
+} from './contracts/domain/index.js';
 
 // Provider tiers
 export type ProviderTier =
@@ -255,11 +260,44 @@ export const ProjectProviderConfigSchema = z.object({
 });
 export type ProjectProviderConfig = z.infer<typeof ProjectProviderConfigSchema>;
 
+export interface CustomProviderExecutionProfile {
+  bindingId: string;
+  profile: ExecutionProfile;
+  credential?: { envVar: string };
+}
+
+export const CustomProviderExecutionProfileSchema: z.ZodType<CustomProviderExecutionProfile> =
+  z.strictObject({
+    bindingId: z.custom<string>(
+      (value) => OpaqueIdSchema.safeParse(value).success,
+      'Custom-provider bindingId must be a canonical opaque identifier',
+    ),
+    // The legacy config layer uses Zod 3 while the canonical contract uses
+    // Zod 4. Validate with the canonical schema at this boundary and retain its
+    // exact inferred type without weakening or duplicating the contract.
+    profile: z.custom<ExecutionProfile>(
+      (value) => ExecutionProfileSchema.safeParse(value).success,
+      'Invalid canonical execution profile',
+    ),
+    credential: z
+      .strictObject({
+        envVar: z
+          .string()
+          .trim()
+          .regex(
+            /^[A-Za-z_][A-Za-z0-9_]*$/,
+            'Custom-provider credential envVar must be a valid environment variable name',
+          ),
+      })
+      .optional(),
+  });
+
 export const NpmProviderSourceSchema = z.object({
   type: z.literal('npm'),
   module: z.string().min(1),
   export: z.string().optional(),
   options: z.record(z.unknown()).optional(),
+  executionProfile: CustomProviderExecutionProfileSchema.optional(),
 });
 export type NpmProviderSource = z.infer<typeof NpmProviderSourceSchema>;
 
@@ -270,6 +308,7 @@ export const ScriptProviderSourceSchema = z.object({
   cwd: z.string().optional(),
   env: z.record(z.string()).optional(),
   options: z.record(z.unknown()).optional(),
+  executionProfile: CustomProviderExecutionProfileSchema.optional(),
 });
 export type ScriptProviderSource = z.infer<typeof ScriptProviderSourceSchema>;
 

--- a/tests/catalog-fingerprint.test.ts
+++ b/tests/catalog-fingerprint.test.ts
@@ -3,6 +3,7 @@ import {
   CATALOG_FINGERPRINT_PREFIX,
   canonicalJson,
   catalogFingerprint,
+  compareCanonicalStrings,
   isCatalogFingerprint,
 } from '../src/core/catalog-fingerprint.js';
 
@@ -32,6 +33,15 @@ describe('catalog fingerprint -- shape', () => {
 });
 
 describe('catalog fingerprint -- insertion-order independence', () => {
+  it('uses locale-independent string ordering', () => {
+    const values = ['éclair', 'alpha', 'Beta'];
+    expect([...values].sort(compareCanonicalStrings)).toEqual([
+      'Beta',
+      'alpha',
+      'éclair',
+    ]);
+  });
+
   it('sorts object keys so declaration order cannot change the value', () => {
     expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
     expect(catalogFingerprint({ b: 1, a: 2, c: { z: 1, y: 2 } })).toBe(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,7 +11,23 @@ import {
   resolveEnvVar,
   validateFallbacks,
 } from '../src/core/config.js';
-import type { Config, ProjectConfig } from '../src/types.js';
+import { type Config, ConfigSchema, type ProjectConfig } from '../src/types.js';
+
+const CUSTOM_EXECUTION_PROFILE = {
+  identity: {
+    provider_id: 'acme',
+    profile_id: 'search',
+    target: { primary: { model_selection: 'not_applicable' as const } },
+  },
+  result_kind: 'search_results' as const,
+  observation_mode: 'api_output' as const,
+  corpora: ['web' as const],
+  retrieval_method: 'search_endpoint' as const,
+  access_mode: 'direct' as const,
+  operator_id: 'acme',
+  invocation: 'inline' as const,
+  resumability: 'none' as const,
+};
 
 const PRIOR_COMPREHENSIVE = [
   'perplexity-sonar-deep',
@@ -331,6 +347,72 @@ describe('loadConfig', () => {
   });
 });
 
+describe('custom-provider execution profile config', () => {
+  it('validates the strict canonical profile and credential declaration', () => {
+    const parsed = ConfigSchema.safeParse({
+      ...storedConfig(),
+      customProviders: {
+        acme: {
+          type: 'npm',
+          module: 'acme-provider',
+          executionProfile: {
+            bindingId: 'acme.search.v1',
+            profile: CUSTOM_EXECUTION_PROFILE,
+            credential: { envVar: 'ACME_API_KEY' },
+          },
+        },
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects malformed metadata even when the provider is untrusted', () => {
+    const unknownProfileField = ConfigSchema.safeParse({
+      ...storedConfig(),
+      customProviders: {
+        acme: {
+          type: 'npm',
+          module: 'acme-provider',
+          executionProfile: {
+            bindingId: 'acme.search.v1',
+            profile: { ...CUSTOM_EXECUTION_PROFILE, unexpected: true },
+          },
+        },
+      },
+    });
+    const invalidEnv = ConfigSchema.safeParse({
+      ...storedConfig(),
+      customProviders: {
+        acme: {
+          type: 'npm',
+          module: 'acme-provider',
+          executionProfile: {
+            bindingId: 'acme.search.v1',
+            profile: CUSTOM_EXECUTION_PROFILE,
+            credential: { envVar: 'not-valid!' },
+          },
+        },
+      },
+    });
+    const invalidBinding = ConfigSchema.safeParse({
+      ...storedConfig(),
+      customProviders: {
+        acme: {
+          type: 'npm',
+          module: 'acme-provider',
+          executionProfile: {
+            bindingId: ' invalid ',
+            profile: CUSTOM_EXECUTION_PROFILE,
+          },
+        },
+      },
+    });
+    expect(unknownProfileField.success).toBe(false);
+    expect(invalidEnv.success).toBe(false);
+    expect(invalidBinding.success).toBe(false);
+  });
+});
+
 describe('mergeConfigs', () => {
   const baseGlobal: Config = {
     version: 1,
@@ -553,18 +635,35 @@ describe('mergeConfigs', () => {
       {
         ...baseGlobal,
         customProviders: {
-          overridden: { type: 'npm', module: 'global-provider' },
+          overridden: {
+            type: 'npm',
+            module: 'global-provider',
+            executionProfile: {
+              bindingId: 'global.v1',
+              profile: CUSTOM_EXECUTION_PROFILE,
+            },
+          },
         },
         trustedProviderIds: ['overridden'],
       },
       {
         customProviders: {
-          overridden: { type: 'npm', module: 'project-provider' },
+          overridden: {
+            type: 'npm',
+            module: 'project-provider',
+            executionProfile: {
+              bindingId: 'project.v1',
+              profile: CUSTOM_EXECUTION_PROFILE,
+            },
+          },
         },
       },
     );
 
     expect(merged.trustedProviderIds).toEqual([]);
+    expect(merged.customProviders.overridden?.executionProfile?.bindingId).toBe(
+      'project.v1',
+    );
   });
 
   it('keeps a project override trusted when the project explicitly trusts it', () => {

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -83,6 +83,79 @@ function keys(values: readonly { provider_id: string; profile_id: string }[]) {
   return values.map((value) => `${value.provider_id}/${value.profile_id}`);
 }
 
+function customProviderConfig(
+  overrides: Partial<Config> & { defaults?: Partial<Config['defaults']> } = {},
+): Config {
+  return config({
+    providers: { 'acme-adapter': { enabled: true } },
+    customProviders: {
+      'acme-adapter': {
+        type: 'npm',
+        module: 'acme-provider',
+        executionProfile: {
+          bindingId: 'acme.search.v1',
+          profile: {
+            identity: {
+              provider_id: 'acme-provider',
+              profile_id: 'search',
+              target: { primary: { model_selection: 'not_applicable' } },
+            },
+            result_kind: 'search_results',
+            observation_mode: 'api_output',
+            corpora: ['web'],
+            retrieval_method: 'search_endpoint',
+            access_mode: 'direct',
+            operator_id: 'acme-provider',
+            invocation: 'inline',
+            resumability: 'none',
+          },
+        },
+      },
+    },
+    trustedProviderIds: ['acme-adapter'],
+    ...overrides,
+  });
+}
+
+const PLANNED_PROVIDER_IDS = [
+  'grok-x-only',
+  'grok-combined',
+  'parallel',
+  'valyu',
+] as const;
+
+function customIdentityConfig(
+  adapterId: string,
+  providerId: string,
+  profileId = 'search',
+  enabled = true,
+): Config {
+  const base = customProviderConfig();
+  const metadata = base.customProviders['acme-adapter']?.executionProfile;
+  if (!metadata) throw new Error('missing custom metadata fixture');
+  return config({
+    providers: { [adapterId]: { enabled } },
+    customProviders: {
+      [adapterId]: {
+        type: 'npm',
+        module: 'must-not-load',
+        executionProfile: {
+          ...metadata,
+          profile: {
+            ...metadata.profile,
+            identity: {
+              ...metadata.profile.identity,
+              provider_id: providerId,
+              profile_id: profileId,
+            },
+          },
+        },
+      },
+    },
+    trustedProviderIds: [adapterId],
+  });
+}
+
 function map(
   config: Config,
   options: Omit<ConfigurationMappingOptions, 'authoredGroups'> & {
@@ -96,6 +169,161 @@ function map(
 }
 
 describe('configuration mapping', () => {
+  it('maps only trusted enabled custom metadata into exact groups and reserves', () => {
+    const source = customProviderConfig({
+      providers: {
+        exa: { enabled: true, fallback: 'acme-adapter' },
+        'acme-adapter': { enabled: true },
+      },
+      groups: { team: ['acme-adapter'] },
+    });
+    const mapped = map(source, {
+      requestDeadlineMs: 300_000,
+      credentials: credentials(),
+    });
+    expect(mapped.preflight.issues).toEqual([]);
+    expect(mapped.custom_profile_bindings).toEqual([
+      expect.objectContaining({
+        adapter_id: 'acme-adapter',
+        binding_id: 'acme.search.v1',
+      }),
+    ]);
+    expect(mapped.groups.team).toEqual(['acme-provider/search']);
+    expect(keys(mapped.reserve)).toEqual(['acme-provider/search']);
+    expect(mapped.catalog.resolveGroup('custom:team')).toEqual([
+      expect.objectContaining({
+        provider_id: 'acme-provider',
+        profile_id: 'search',
+      }),
+    ]);
+
+    for (const filtered of [
+      customProviderConfig({ trustedProviderIds: [] }),
+      customProviderConfig({
+        providers: { 'acme-adapter': { enabled: false } },
+      }),
+    ]) {
+      const result = map(filtered, { requestDeadlineMs: 300_000 });
+      expect(result.custom_profile_bindings).toEqual([]);
+      expect(result.catalog.get('acme-provider', 'search')).toBeUndefined();
+    }
+  });
+
+  it.each(PLANNED_PROVIDER_IDS)(
+    'keeps planned built-in adapter id %s reserved during mapping',
+    (providerId) => {
+      const source = customIdentityConfig(
+        providerId,
+        'custom-identity',
+        'search',
+      );
+      const mapped = map(source, { requestDeadlineMs: 300_000 });
+      expect(mapped.custom_profile_bindings).toEqual([]);
+      expect(mapped.preflight.issues).not.toContainEqual(
+        expect.objectContaining({ code: 'custom_provider_profile_missing' }),
+      );
+    },
+  );
+
+  it.each([...PLANNED_PROVIDER_IDS, 'openai-deep'])(
+    'rejects custom metadata claiming reserved provider identity %s',
+    (providerId) => {
+      const mapped = map(customIdentityConfig('acme-adapter', providerId), {
+        requestDeadlineMs: 300_000,
+      });
+      expect(mapped.custom_profile_bindings).toEqual([]);
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'custom_provider_profile_provider_id_reserved',
+          path: '/customProviders/acme-adapter/executionProfile/profile/identity/provider_id',
+        }),
+      );
+    },
+  );
+
+  it.each([
+    {
+      source: customIdentityConfig('acme/adapter', 'acme-provider'),
+      code: 'custom_provider_adapter_id_unaddressable',
+      path: '/customProviders/acme~1adapter',
+    },
+    {
+      source: customIdentityConfig('acme-adapter', 'acme/provider'),
+      code: 'custom_provider_profile_id_unaddressable',
+      path: '/customProviders/acme-adapter/executionProfile/profile/identity/provider_id',
+    },
+    {
+      source: customIdentityConfig(
+        'acme-adapter',
+        'acme-provider',
+        'search/v2',
+      ),
+      code: 'custom_provider_profile_id_unaddressable',
+      path: '/customProviders/acme-adapter/executionProfile/profile/identity/profile_id',
+    },
+  ])(
+    'returns a stable $code issue instead of throwing',
+    ({ source, code, path }) => {
+      expect(() => map(source, { requestDeadlineMs: 300_000 })).not.toThrow();
+      const mapped = map(source, { requestDeadlineMs: 300_000 });
+      expect(mapped.custom_profile_bindings).toEqual([]);
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({ code, path }),
+      );
+    },
+  );
+
+  it.each(['', ' acme-adapter', 'acme\u0001adapter'])(
+    'rejects invalid eligible adapter record key %j without throwing',
+    (adapterId) => {
+      const mapped = map(customIdentityConfig(adapterId, 'acme-provider'), {
+        requestDeadlineMs: 300_000,
+      });
+      expect(mapped.custom_profile_bindings).toEqual([]);
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({ code: 'custom_provider_adapter_id_invalid' }),
+      );
+    },
+  );
+
+  it('admits a trusted disabled custom profile only as a configured reserve', () => {
+    const source = customProviderConfig({
+      providers: {
+        exa: { enabled: true, fallback: 'acme-adapter' },
+        'acme-adapter': { enabled: false },
+      },
+    });
+    const mapped = map(source, {
+      requestDeadlineMs: 300_000,
+      credentials: credentials(),
+    });
+    expect(mapped.preflight.issues).toEqual([]);
+    expect(mapped.custom_profile_bindings).toHaveLength(1);
+    expect(mapped.reserve_only_adapter_ids).toEqual(['acme-adapter']);
+    expect(keys(mapped.reserve)).toEqual(['acme-provider/search']);
+    expect(
+      mapped.catalog.get('acme-provider', 'search')?.availability,
+    ).toMatchObject({ enabled: false, reserve_only: true, selectable: false });
+    expect(keys(mapped.catalog.resolveDefault())).toEqual(['exa/search']);
+  });
+
+  it('owns and freezes custom profile bindings independently of caller config', () => {
+    const source = customProviderConfig();
+    const mapped = map(source, { requestDeadlineMs: 300_000 });
+    const digest = mapped.catalog.digest;
+    expect(Object.isFrozen(mapped.custom_profile_bindings)).toBe(true);
+    expect(Object.isFrozen(mapped.custom_profile_bindings[0]?.profile)).toBe(
+      true,
+    );
+    const metadata = source.customProviders['acme-adapter']?.executionProfile;
+    if (!metadata) throw new Error('missing custom metadata fixture');
+    metadata.profile.identity.provider_id = 'mutated';
+    expect(
+      mapped.custom_profile_bindings[0]?.profile.identity.provider_id,
+    ).toBe('acme-provider');
+    expect(mapped.catalog.digest).toBe(digest);
+  });
+
   it('orders preflight diagnostics by phase, path, code, and profile key', () => {
     const sorted = sortPreparationDiagnostics([
       {

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -117,12 +117,9 @@ function customProviderConfig(
   });
 }
 
-const PLANNED_PROVIDER_IDS = [
-  'grok-x-only',
-  'grok-combined',
-  'parallel',
-  'valyu',
-] as const;
+const PLANNED_PROVIDER_IDS = BUILTIN_PROVIDER_CATALOG.filter((entry) =>
+  entry.profiles.some((profile) => profile.status === 'planned'),
+).map((entry) => entry.provider_id);
 
 function customIdentityConfig(
   adapterId: string,
@@ -246,6 +243,11 @@ describe('configuration mapping', () => {
       source: customIdentityConfig('acme/adapter', 'acme-provider'),
       code: 'custom_provider_adapter_id_unaddressable',
       path: '/customProviders/acme~1adapter',
+    },
+    {
+      source: customIdentityConfig('acme~adapter', 'acme/provider'),
+      code: 'custom_provider_profile_id_unaddressable',
+      path: '/customProviders/acme~0adapter/executionProfile/profile/identity/provider_id',
     },
     {
       source: customIdentityConfig('acme-adapter', 'acme/provider'),

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -56,4 +56,23 @@ describe('credential references', () => {
     ).toBeUndefined();
     expect(hasCredential('keychain:BRAVE_API_KEY', context)).toBe(false);
   });
+
+  it('never resolves inherited environment properties as credentials', () => {
+    expect(Object.hasOwn(process.env, 'hasOwnProperty')).toBe(false);
+    expect(
+      resolveCredential('$hasOwnProperty', { env: process.env }),
+    ).toBeUndefined();
+    expect(hasCredential('$hasOwnProperty', { env: process.env })).toBe(false);
+
+    const inherited = Object.create({
+      ACME_API_KEY: 'prototype-key',
+    }) as Record<string, string>;
+    expect(
+      resolveCredential('$ACME_API_KEY', { env: inherited }),
+    ).toBeUndefined();
+    inherited.ACME_API_KEY = 'own-key';
+    expect(resolveCredential('$ACME_API_KEY', { env: inherited })).toBe(
+      'own-key',
+    );
+  });
 });

--- a/tests/node-entry.test.ts
+++ b/tests/node-entry.test.ts
@@ -3,13 +3,11 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BUILTIN_PROVIDER_CATALOG } from '../src/core/provider-profiles.js';
 
-const PLANNED_PROVIDER_IDS = [
-  'grok-x-only',
-  'grok-combined',
-  'parallel',
-  'valyu',
-] as const;
+const PLANNED_PROVIDER_IDS = BUILTIN_PROVIDER_CATALOG.filter((entry) =>
+  entry.profiles.some((profile) => profile.status === 'planned'),
+).map((entry) => entry.provider_id);
 
 // The `librarium/node` entry point is the documented Node-only bridge that lets
 // library consumers (not just the CLI) load npm/script custom providers and

--- a/tests/node-entry.test.ts
+++ b/tests/node-entry.test.ts
@@ -4,6 +4,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const PLANNED_PROVIDER_IDS = [
+  'grok-x-only',
+  'grok-combined',
+  'parallel',
+  'valyu',
+] as const;
+
 // The `librarium/node` entry point is the documented Node-only bridge that lets
 // library consumers (not just the CLI) load npm/script custom providers and
 // register them into the core registry.
@@ -190,4 +197,54 @@ describe('librarium/node entry', () => {
     expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
     expect(existsSync(markerPath)).toBe(false);
   });
+
+  it.each(PLANNED_PROVIDER_IDS)(
+    'rejects planned built-in id %s before importing npm code',
+    async (providerId) => {
+      const markerPath = join(tmpDir, `${providerId}-npm-loaded`);
+      writeNpmProvider(providerId, markerPath);
+      const result = await loadCustomProviders({
+        providers: { [providerId]: { enabled: true } },
+        customProviders: {
+          [providerId]: { type: 'npm', module: providerId },
+        },
+        trustedProviderIds: [providerId],
+      });
+      expect(result.loadedIds).not.toContain(providerId);
+      expect(result.skippedIds).toContain(providerId);
+      expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
+      expect(existsSync(markerPath)).toBe(false);
+    },
+  );
+
+  it.each(PLANNED_PROVIDER_IDS)(
+    'rejects planned built-in id %s before spawning script describe code',
+    async (providerId) => {
+      const markerPath = join(tmpDir, `${providerId}-script-described`);
+      const scriptPath = join(tmpDir, `${providerId}-provider-script.mjs`);
+      writeFileSync(
+        scriptPath,
+        [
+          "import { writeFileSync } from 'node:fs';",
+          `writeFileSync(${JSON.stringify(markerPath)}, 'described');`,
+        ].join('\n'),
+        'utf-8',
+      );
+      const result = await loadCustomProviders({
+        providers: { [providerId]: { enabled: true } },
+        customProviders: {
+          [providerId]: {
+            type: 'script',
+            command: process.execPath,
+            args: [scriptPath],
+          },
+        },
+        trustedProviderIds: [providerId],
+      });
+      expect(result.loadedIds).not.toContain(providerId);
+      expect(result.skippedIds).toContain(providerId);
+      expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
+      expect(existsSync(markerPath)).toBe(false);
+    },
+  );
 });

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -529,6 +529,26 @@ describe('provider catalog -- trusted custom planning profiles', () => {
     expect(keychain.get('acme', 'search')?.availability.selectable).toBe(true);
   });
 
+  it('does not treat inherited environment properties as custom credentials', () => {
+    const inheritedName = customProfile({
+      credential_env_var: 'hasOwnProperty',
+    });
+    const built = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [inheritedName],
+      credentials: { env: process.env },
+    });
+
+    expect(Object.hasOwn(process.env, 'hasOwnProperty')).toBe(false);
+    expect(built.get('acme', 'search')?.availability).toEqual(
+      expect.objectContaining({
+        credential_valid: false,
+        selectable: false,
+        reasons: expect.arrayContaining(['credential_missing']),
+      }),
+    );
+  });
+
   it('keeps custom bindings closure-free, immutable, and in the digest', () => {
     const input = customProfile();
     const built = buildProviderCatalog({
@@ -578,6 +598,93 @@ describe('provider catalog -- trusted custom planning profiles', () => {
         result.prepared.request.slots.map((slot) => slot.primary.identity),
       ),
     ).toEqual(['acme/search']);
+  });
+
+  it('derives deep workflow membership for custom research profiles', () => {
+    const research = customProfile({
+      binding_id: 'acme.research.v1',
+      profile: {
+        identity: {
+          provider_id: 'acme',
+          profile_id: 'research',
+          target: { primary: { model_selection: 'not_applicable' } },
+        },
+        result_kind: 'research_report',
+        grounding_policy: 'required',
+        retrieval_method: 'research_agent',
+        invocation: 'background',
+        resumability: 'durable',
+      },
+    });
+    const built = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [research],
+    });
+
+    expect(keysOf(built.workflow('deep').members)).toContain('acme/research');
+    expect(built.get('acme', 'research')?.declaration.workflows).toEqual([
+      'deep',
+    ]);
+  });
+
+  it('orders custom profiles with locale-independent canonical strings', () => {
+    const mixedCase = customProfile({
+      adapter_id: 'adapter-Beta',
+      binding_id: 'binding-Beta',
+      profile: {
+        identity: {
+          provider_id: 'Beta',
+          profile_id: 'search',
+          target: { primary: { model_selection: 'not_applicable' } },
+        },
+      },
+    });
+    const nonAscii = customProfile({
+      adapter_id: 'adapter-éclair',
+      binding_id: 'binding-éclair',
+      profile: {
+        identity: {
+          provider_id: 'éclair',
+          profile_id: 'search',
+          target: { primary: { model_selection: 'not_applicable' } },
+        },
+      },
+    });
+    const lowerCase = customProfile({
+      adapter_id: 'adapter-alpha',
+      binding_id: 'binding-alpha',
+      profile: {
+        identity: {
+          provider_id: 'alpha',
+          profile_id: 'search',
+          target: { primary: { model_selection: 'not_applicable' } },
+        },
+      },
+    });
+    const inputs = [nonAscii, lowerCase, mixedCase];
+    const options = {
+      providerConfigs: Object.fromEntries(
+        inputs.map((item) => [item.adapter_id, { enabled: true }]),
+      ),
+      customProfiles: inputs,
+    };
+
+    const built = buildProviderCatalog(options);
+    expect(
+      keysOf(
+        built
+          .workflow('all')
+          .members.filter(({ provider_id }) =>
+            ['Beta', 'alpha', 'éclair'].includes(provider_id),
+          ),
+      ),
+    ).toEqual(['Beta/search', 'alpha/search', 'éclair/search']);
+    expect(
+      buildProviderCatalog({
+        ...options,
+        customProfiles: [...inputs].reverse(),
+      }).digest,
+    ).toBe(built.digest);
   });
 
   it('rejects reserved ids, duplicate identities/bindings, and process-local profiles', () => {

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { ExecutionProfileSchema } from '../src/contracts/domain/index.js';
+import {
+  type ExecutionProfile,
+  ExecutionProfileSchema,
+} from '../src/contracts/domain/index.js';
 import { fallbackCompatibilityIssues } from '../src/contracts/interchange/compatibility.js';
 import type { CredentialContext } from '../src/core/credentials.js';
 import {
@@ -13,6 +16,7 @@ import {
 } from '../src/core/profile-bindings.js';
 import {
   buildProviderCatalog,
+  type CustomCatalogProfile,
   type ProviderCatalog,
   type ProviderCatalogOptions,
 } from '../src/core/profile-catalog.js';
@@ -51,6 +55,35 @@ function catalog(options: ProviderCatalogOptions = {}): ProviderCatalog {
     credentials: allCredentials(),
     ...options,
   });
+}
+
+function customProfile(
+  overrides: Partial<CustomCatalogProfile> & {
+    profile?: Partial<ExecutionProfile>;
+  } = {},
+): CustomCatalogProfile {
+  const profile: ExecutionProfile = {
+    identity: {
+      provider_id: 'acme',
+      profile_id: 'search',
+      target: { primary: { model_selection: 'not_applicable' } },
+    },
+    result_kind: 'search_results',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'search_endpoint',
+    access_mode: 'direct',
+    operator_id: 'acme',
+    invocation: 'inline',
+    resumability: 'none',
+    ...overrides.profile,
+  };
+  return {
+    adapter_id: 'acme-adapter',
+    binding_id: 'acme.search.v1',
+    ...overrides,
+    profile,
+  };
 }
 
 function keysOf(
@@ -106,6 +139,10 @@ const PLANNED_MATRIX = [
   ['valyu', 'search'],
   ['valyu', 'research'],
 ] as const;
+
+const PLANNED_PROVIDER_IDS = [
+  ...new Set(PLANNED_MATRIX.map(([providerId]) => providerId)),
+];
 
 const SURFACE_PROFILES = [
   'searchapi-chatgpt/surface',
@@ -446,6 +483,316 @@ describe('provider catalog -- determinism and immutability', () => {
     expect(Object.isFrozen(entries[0])).toBe(false);
     expect(built.entries).not.toBe(entries);
     expect(built.entries).toEqual(entries);
+  });
+});
+
+describe('provider catalog -- trusted custom planning profiles', () => {
+  it('derives keyless, env, literal, and keychain credential availability', () => {
+    const keyless = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [customProfile()],
+    });
+    expect(keyless.get('acme', 'search')?.availability.selectable).toBe(true);
+
+    const credentialed = customProfile({ credential_env_var: 'ACME_API_KEY' });
+    const missing = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [credentialed],
+      credentials: { env: {} },
+    });
+    expect(missing.get('acme', 'search')?.availability.reasons).toContain(
+      'credential_missing',
+    );
+    const fromEnv = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [credentialed],
+      credentials: { env: { ACME_API_KEY: 'env-key' } },
+    });
+    expect(fromEnv.get('acme', 'search')?.availability.selectable).toBe(true);
+    const literal = buildProviderCatalog({
+      providerConfigs: {
+        'acme-adapter': { enabled: true, apiKey: 'literal-key' },
+      },
+      customProfiles: [credentialed],
+    });
+    expect(literal.get('acme', 'search')?.availability.selectable).toBe(true);
+    const keychain = buildProviderCatalog({
+      providerConfigs: {
+        'acme-adapter': { enabled: true, apiKey: 'keychain:acme' },
+      },
+      customProfiles: [credentialed],
+      credentials: {
+        resolveCredential: (reference) =>
+          reference === 'keychain:acme' ? 'keychain-key' : undefined,
+      },
+    });
+    expect(keychain.get('acme', 'search')?.availability.selectable).toBe(true);
+  });
+
+  it('keeps custom bindings closure-free, immutable, and in the digest', () => {
+    const input = customProfile();
+    const built = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [input],
+    });
+    const resolved = built.get('acme', 'search');
+    expect(resolved?.binding).toEqual({
+      provider_id: 'acme',
+      profile_id: 'search',
+      adapter_id: 'acme-adapter',
+      binding_id: 'acme.search.v1',
+    });
+    expect(resolved?.binding).not.toHaveProperty('resolve');
+    const digest = built.digest;
+    input.profile.identity.provider_id = 'mutated';
+    expect(built.get('acme', 'search')).toBe(resolved);
+    expect(built.digest).toBe(digest);
+
+    const changed = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [customProfile({ binding_id: 'acme.search.v2' })],
+    });
+    expect(changed.revision).toBe(built.revision);
+    expect(changed.digest).not.toBe(built.digest);
+  });
+
+  it('selects custom profiles through capabilities and the all workflow', () => {
+    const built = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [customProfile()],
+    });
+    expect(keysOf(built.workflow('all').members)).toContain('acme/search');
+    const result = prepare(
+      {
+        selector: {
+          kind: 'capabilities',
+          requirements: { result_kind: 'search_results', corpora: ['web'] },
+        },
+      },
+      built,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      keysOf(
+        result.prepared.request.slots.map((slot) => slot.primary.identity),
+      ),
+    ).toEqual(['acme/search']);
+  });
+
+  it('rejects reserved ids, duplicate identities/bindings, and process-local profiles', () => {
+    expect(() =>
+      buildProviderCatalog({
+        providerConfigs: { exa: { enabled: true } },
+        customProfiles: [customProfile({ adapter_id: 'exa' })],
+      }),
+    ).toThrow(/reserved/i);
+    expect(() =>
+      buildProviderCatalog({
+        providerConfigs: { 'openai-deep': { enabled: true } },
+        customProfiles: [customProfile({ adapter_id: 'openai-deep' })],
+      }),
+    ).toThrow(/reserved/i);
+    expect(() =>
+      buildProviderCatalog({
+        providerConfigs: {
+          'acme-adapter': { enabled: true },
+          'acme-other': { enabled: true },
+        },
+        customProfiles: [
+          customProfile(),
+          customProfile({ adapter_id: 'acme-other' }),
+        ],
+      }),
+    ).toThrow(/duplicate provider profile/i);
+    expect(() =>
+      buildProviderCatalog({
+        providerConfigs: { 'acme-adapter': { enabled: true } },
+        customProfiles: [
+          customProfile(),
+          customProfile({
+            profile: {
+              identity: {
+                provider_id: 'acme-two',
+                profile_id: 'search',
+                target: {
+                  primary: { model_selection: 'not_applicable' },
+                },
+              },
+            },
+          }),
+        ],
+      }),
+    ).toThrow(/duplicate adapter binding/i);
+    expect(() =>
+      buildProviderCatalog({
+        providerConfigs: { 'acme-adapter': { enabled: true } },
+        customProfiles: [
+          customProfile({
+            profile: {
+              invocation: 'background',
+              resumability: 'process_local',
+            },
+          }),
+        ],
+      }),
+    ).toThrow(/process_local/i);
+  });
+
+  it.each([...PLANNED_PROVIDER_IDS, 'openai-deep'])(
+    'reserves the adapter and declared provider identity %s',
+    (reservedId) => {
+      expect(() =>
+        buildProviderCatalog({
+          providerConfigs: { [reservedId]: { enabled: true } },
+          customProfiles: [customProfile({ adapter_id: reservedId })],
+        }),
+      ).toThrow(/reserved/i);
+      expect(() =>
+        buildProviderCatalog({
+          providerConfigs: { 'acme-adapter': { enabled: true } },
+          customProfiles: [
+            customProfile({
+              profile: {
+                identity: {
+                  provider_id: reservedId,
+                  profile_id: 'novel',
+                  target: {
+                    primary: { model_selection: 'not_applicable' },
+                  },
+                },
+              },
+            }),
+          ],
+        }),
+      ).toThrow(/provider id is reserved/i);
+    },
+  );
+
+  it('excludes ordinary disabled declarations but preserves reserve-only availability', () => {
+    const declaration = customProfile();
+    const disabled = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: false } },
+      customProfiles: [declaration],
+    });
+    expect(disabled.get('acme', 'search')).toBeUndefined();
+    expect(keysOf(disabled.workflow('all').members)).not.toContain(
+      'acme/search',
+    );
+
+    const reserveOnly = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: false } },
+      customProfiles: [declaration],
+      reserveOnlyAdapterIds: ['acme-adapter'],
+      reserve: [{ provider_id: 'acme', profile_id: 'search' }],
+    });
+    expect(reserveOnly.get('acme', 'search')?.availability).toMatchObject({
+      enabled: false,
+      reserve_only: true,
+      selectable: false,
+    });
+    expect(reserveOnly.resolveDefault()).toEqual([]);
+    expect(keysOf(reserveOnly.workflow('all').members)).not.toContain(
+      'acme/search',
+    );
+    expect(keysOf(reserveOnly.resolveConfiguredReserve([]))).toEqual([
+      'acme/search',
+    ]);
+  });
+
+  it('keeps slash-capable binding ids opaque without global false collisions', () => {
+    const built = buildProviderCatalog({
+      providerConfigs: {
+        'acme-adapter': { enabled: true },
+        'other-adapter': { enabled: true },
+      },
+      customProfiles: [
+        customProfile({ binding_id: 'binding/with/slashes' }),
+        customProfile({
+          adapter_id: 'other-adapter',
+          binding_id: 'binding/with/slashes',
+          profile: {
+            identity: {
+              provider_id: 'other-provider',
+              profile_id: 'search',
+              target: { primary: { model_selection: 'not_applicable' } },
+            },
+          },
+        }),
+      ],
+    });
+    expect(built.get('acme', 'search')?.binding?.binding_id).toBe(
+      'binding/with/slashes',
+    );
+    expect(built.get('other-provider', 'search')?.binding?.binding_id).toBe(
+      'binding/with/slashes',
+    );
+  });
+
+  it.each([
+    customProfile({ adapter_id: '' }),
+    customProfile({ adapter_id: ' acme-adapter' }),
+    customProfile({ adapter_id: 'acme\u0001adapter' }),
+    customProfile({ binding_id: ' invalid ' }),
+  ])('rejects invalid direct adapter/binding identity %#', (declaration) => {
+    expect(() =>
+      buildProviderCatalog({
+        providerConfigs: { [declaration.adapter_id]: { enabled: true } },
+        customProfiles: [declaration],
+      }),
+    ).toThrow(/canonical opaque identifier/i);
+  });
+
+  it.each([
+    customProfile({ adapter_id: 'acme/adapter' }),
+    customProfile({
+      profile: {
+        identity: {
+          provider_id: 'acme/provider',
+          profile_id: 'search',
+          target: { primary: { model_selection: 'not_applicable' } },
+        },
+      },
+    }),
+    customProfile({
+      profile: {
+        identity: {
+          provider_id: 'acme',
+          profile_id: 'search/v2',
+          target: { primary: { model_selection: 'not_applicable' } },
+        },
+      },
+    }),
+  ])(
+    'rejects direct custom identities containing selector delimiters %#',
+    (declaration) => {
+      expect(() =>
+        buildProviderCatalog({
+          providerConfigs: { [declaration.adapter_id]: { enabled: true } },
+          customProfiles: [declaration],
+        }),
+      ).toThrow(/selector delimiter/i);
+    },
+  );
+
+  it('rejects a custom profile with unknown cost under a hard budget', () => {
+    const built = buildProviderCatalog({
+      providerConfigs: { 'acme-adapter': { enabled: true } },
+      customProfiles: [customProfile()],
+      defaults: [{ provider_id: 'acme', profile_id: 'search' }],
+    });
+    const result = prepare(
+      { budgets: { max_estimated_cost_microusd: '1000000' } },
+      built,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'budget_estimate_required',
+        profile_key: expect.stringContaining('acme'),
+      }),
+    );
   });
 });
 

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -95,12 +95,9 @@ function customSource(
   });
 }
 
-const PLANNED_PROVIDER_IDS = [
-  'grok-x-only',
-  'grok-combined',
-  'parallel',
-  'valyu',
-] as const;
+const PLANNED_PROVIDER_IDS = BUILTIN_PROVIDER_CATALOG.filter((entry) =>
+  entry.profiles.some((profile) => profile.status === 'planned'),
+).map((entry) => entry.provider_id);
 
 function preparation() {
   const counts = new Map<string, number>();

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -45,6 +45,63 @@ function credentials() {
   };
 }
 
+function customExecutionProfile(
+  invocation: 'inline' | 'background' = 'inline',
+) {
+  return {
+    identity: {
+      provider_id: 'acme',
+      profile_id: invocation === 'inline' ? 'search' : 'research',
+      target: { primary: { model_selection: 'not_applicable' as const } },
+    },
+    result_kind:
+      invocation === 'inline'
+        ? ('search_results' as const)
+        : ('research_report' as const),
+    ...(invocation === 'background' && {
+      grounding_policy: 'required' as const,
+    }),
+    observation_mode: 'api_output' as const,
+    corpora: ['web' as const],
+    retrieval_method:
+      invocation === 'inline'
+        ? ('search_endpoint' as const)
+        : ('research_agent' as const),
+    access_mode: 'direct' as const,
+    operator_id: 'acme',
+    invocation,
+    resumability:
+      invocation === 'inline' ? ('none' as const) : ('durable' as const),
+  };
+}
+
+function customSource(
+  overrides: Partial<Config> & { defaults?: Partial<Config['defaults']> } = {},
+): Config {
+  return config({
+    providers: { 'acme-adapter': { enabled: true } },
+    customProviders: {
+      'acme-adapter': {
+        type: 'npm',
+        module: 'must-not-be-imported',
+        executionProfile: {
+          bindingId: 'acme.search.v1',
+          profile: customExecutionProfile(),
+        },
+      },
+    },
+    trustedProviderIds: ['acme-adapter'],
+    ...overrides,
+  });
+}
+
+const PLANNED_PROVIDER_IDS = [
+  'grok-x-only',
+  'grok-combined',
+  'parallel',
+  'valyu',
+] as const;
+
 function preparation() {
   const counts = new Map<string, number>();
   return {
@@ -447,11 +504,293 @@ describe('private shadow compilation', () => {
     }
   });
 
+  it('plans trusted custom profiles by adapter, qualified identity, group, and default without loading code', () => {
+    const source = customSource({ groups: { team: ['acme-adapter'] } });
+    for (const transport of [
+      {
+        kind: 'mcp' as const,
+        input: { query: 'adapter', providers: ['acme-adapter'] },
+      },
+      {
+        kind: 'mcp' as const,
+        input: { query: 'qualified', providers: ['acme/search'] },
+      },
+      {
+        kind: 'mcp' as const,
+        input: { query: 'group', group: 'team' },
+      },
+      { kind: 'mcp' as const, input: { query: 'default' } },
+    ]) {
+      const result = compile(source, transport);
+      expect(profileKeys(result)).toEqual(['acme/search']);
+      if (!result.ok) continue;
+      expect(result.prepared.profile_plans_by_identity).toEqual(
+        expect.objectContaining({
+          [JSON.stringify([
+            'acme',
+            'search',
+            'not_applicable',
+            null,
+            null,
+            null,
+            null,
+            null,
+          ])]: expect.objectContaining({
+            binding: {
+              adapter_id: 'acme-adapter',
+              binding_id: 'acme.search.v1',
+            },
+          }),
+        }),
+      );
+    }
+  });
+
+  it('plans a compatible custom fallback and durable async profile', () => {
+    const fallbackSource = customSource({
+      providers: {
+        exa: { enabled: true, fallback: 'acme-adapter' },
+        'acme-adapter': { enabled: true },
+      },
+    });
+    const fallback = compile(fallbackSource, {
+      kind: 'mcp',
+      input: { query: 'fallback', providers: ['exa'] },
+    });
+    expect(fallback.ok).toBe(true);
+    if (fallback.ok) {
+      expect(
+        fallback.prepared.request.fallback_reserve.map(
+          (candidate) =>
+            `${candidate.profile.identity.provider_id}/${candidate.profile.identity.profile_id}`,
+        ),
+      ).toEqual(['acme/search']);
+    }
+
+    const durable = customSource({
+      defaults: { mode: 'async' },
+      customProviders: {
+        'acme-adapter': {
+          type: 'script',
+          command: 'must-not-run',
+          executionProfile: {
+            bindingId: 'acme.research.v1',
+            profile: customExecutionProfile('background'),
+          },
+        },
+      },
+    });
+    const asyncResult = compile(durable, {
+      kind: 'mcp',
+      input: {
+        query: 'durable',
+        mode: 'async',
+        providers: ['acme-adapter'],
+      },
+    });
+    expect(profileKeys(asyncResult)).toEqual(['acme/research']);
+  });
+
+  it('keeps untrusted and disabled custom declarations out and rejects process-local planning', () => {
+    const untrusted = customSource({ trustedProviderIds: [] });
+    const disabled = customSource({
+      providers: { 'acme-adapter': { enabled: false } },
+    });
+    for (const source of [untrusted, disabled]) {
+      const result = compile(source, {
+        kind: 'mcp',
+        input: { query: 'not eligible', providers: ['acme-adapter'] },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toContainEqual(
+          expect.objectContaining({ code: 'shadow_provider_token_unknown' }),
+        );
+      }
+    }
+
+    const processLocal = customSource({
+      customProviders: {
+        'acme-adapter': {
+          type: 'npm',
+          module: 'must-not-import',
+          executionProfile: {
+            bindingId: 'acme.local.v1',
+            profile: {
+              ...customExecutionProfile('background'),
+              resumability: 'process_local',
+            },
+          },
+        },
+      },
+    });
+    const result = compile(processLocal, {
+      kind: 'mcp',
+      input: { query: 'local', providers: ['acme-adapter'] },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'custom_provider_process_local_unsupported',
+        }),
+      );
+    }
+  });
+
+  it.each(PLANNED_PROVIDER_IDS)(
+    'keeps planned built-in adapter id %s reserved in shadow compilation',
+    (providerId) => {
+      const result = compile(
+        config({
+          providers: { [providerId]: { enabled: true } },
+          customProviders: {
+            [providerId]: {
+              type: 'npm',
+              module: 'must-not-import',
+              executionProfile: {
+                bindingId: 'malicious.v1',
+                profile: customExecutionProfile(),
+              },
+            },
+          },
+          trustedProviderIds: [providerId],
+        }),
+        {
+          kind: 'mcp',
+          input: { query: providerId, providers: [providerId] },
+        },
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toContainEqual(
+          expect.objectContaining({ code: 'shadow_provider_token_unknown' }),
+        );
+        expect(result.issues).not.toContainEqual(
+          expect.objectContaining({ code: 'custom_provider_profile_missing' }),
+        );
+      }
+    },
+  );
+
+  it('returns structured reserved-provider and slash diagnostics without throwing', () => {
+    const cases = [
+      {
+        source: customSource({
+          customProviders: {
+            'acme-adapter': {
+              type: 'npm',
+              module: 'must-not-import',
+              executionProfile: {
+                bindingId: 'acme.v1',
+                profile: {
+                  ...customExecutionProfile(),
+                  identity: {
+                    ...customExecutionProfile().identity,
+                    provider_id: 'parallel',
+                  },
+                },
+              },
+            },
+          },
+        }),
+        code: 'custom_provider_profile_provider_id_reserved',
+      },
+      {
+        source: config({
+          providers: { 'acme/adapter': { enabled: true } },
+          customProviders: {
+            'acme/adapter': {
+              type: 'npm',
+              module: 'must-not-import',
+              executionProfile: {
+                bindingId: 'acme.v1',
+                profile: customExecutionProfile(),
+              },
+            },
+          },
+          trustedProviderIds: ['acme/adapter'],
+        }),
+        code: 'custom_provider_adapter_id_unaddressable',
+      },
+      {
+        source: customSource({
+          customProviders: {
+            'acme-adapter': {
+              type: 'npm',
+              module: 'must-not-import',
+              executionProfile: {
+                bindingId: 'acme.v1',
+                profile: {
+                  ...customExecutionProfile(),
+                  identity: {
+                    ...customExecutionProfile().identity,
+                    provider_id: 'acme/provider',
+                  },
+                },
+              },
+            },
+          },
+        }),
+        code: 'custom_provider_profile_id_unaddressable',
+      },
+      {
+        source: customSource({
+          customProviders: {
+            'acme-adapter': {
+              type: 'npm',
+              module: 'must-not-import',
+              executionProfile: {
+                bindingId: 'acme.v1',
+                profile: {
+                  ...customExecutionProfile(),
+                  identity: {
+                    ...customExecutionProfile().identity,
+                    profile_id: 'search/v2',
+                  },
+                },
+              },
+            },
+          },
+        }),
+        code: 'custom_provider_profile_id_unaddressable',
+      },
+    ];
+    for (const { source, code } of cases) {
+      expect(() =>
+        compile(source, {
+          kind: 'mcp',
+          input: {
+            query: code,
+            providers: [Object.keys(source.providers)[0]!],
+          },
+        }),
+      ).not.toThrow();
+      const result = compile(source, {
+        kind: 'mcp',
+        input: { query: code, providers: [Object.keys(source.providers)[0]!] },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toContainEqual(expect.objectContaining({ code }));
+      }
+    }
+  });
+
   it('never treats built-in ids or aliases as missing custom profiles', () => {
     const canonical = compile(
       config({
         providers: { exa: { enabled: true } },
-        customProviders: { exa: { type: 'npm', module: 'malicious-exa' } },
+        customProviders: {
+          exa: {
+            type: 'npm',
+            module: 'malicious-exa',
+            executionProfile: {
+              bindingId: 'malicious.v1',
+              profile: customExecutionProfile(),
+            },
+          },
+        },
         trustedProviderIds: ['exa'],
       }),
       {
@@ -468,7 +807,14 @@ describe('private shadow compilation', () => {
       config({
         providers: { 'openai-deep': { enabled: true } },
         customProviders: {
-          'openai-deep': { type: 'npm', module: 'malicious-openai' },
+          'openai-deep': {
+            type: 'npm',
+            module: 'malicious-openai',
+            executionProfile: {
+              bindingId: 'malicious.v1',
+              profile: customExecutionProfile(),
+            },
+          },
         },
         trustedProviderIds: ['openai-deep'],
         defaults: { mode: 'async' },

--- a/tests/workers/shadow-compilation.test.ts
+++ b/tests/workers/shadow-compilation.test.ts
@@ -51,4 +51,58 @@ describe('private shadow compiler in workerd', () => {
       profile_id: 'search',
     });
   });
+
+  it('plans trusted custom metadata without importing provider code', () => {
+    const custom: Config = {
+      ...config,
+      providers: { 'edge-custom': { enabled: true } },
+      customProviders: {
+        'edge-custom': {
+          type: 'npm',
+          module: 'node-only-module-that-must-not-load',
+          executionProfile: {
+            bindingId: 'edge.search.v1',
+            profile: {
+              identity: {
+                provider_id: 'edge-provider',
+                profile_id: 'search',
+                target: {
+                  primary: { model_selection: 'not_applicable' },
+                },
+              },
+              result_kind: 'search_results',
+              observation_mode: 'api_output',
+              corpora: ['web'],
+              retrieval_method: 'search_endpoint',
+              access_mode: 'direct',
+              operator_id: 'edge-provider',
+              invocation: 'inline',
+              resumability: 'none',
+            },
+          },
+        },
+      },
+      trustedProviderIds: ['edge-custom'],
+    };
+    const result = compileShadowRequest({
+      config: custom,
+      authoredGroups: { global: {}, project: {} },
+      credentials: {},
+      requestDeadlineMs: 300_000,
+      transport: {
+        kind: 'silent_mcp',
+        input: { query: 'worker custom plan', providers: ['edge-custom'] },
+      },
+      preparation: {
+        clock: { now: () => Date.parse('2026-08-09T12:00:00Z') },
+        ids: { next: (scope) => `edge-${scope}` },
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.prepared.request.slots[0]?.primary.identity).toMatchObject({
+      provider_id: 'edge-provider',
+      profile_id: 'search',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add a planning-only execution profile contract for trusted custom providers so canonical selection can include them without importing or executing custom code.

## What’s New

- Add strict execution profile metadata for npm and script custom providers, with credential, identity, and resumability validation.
- Include eligible custom profiles in deterministic catalog selection, groups, workflows, capabilities, defaults, and fallback reserves.
- Reserve every current, planned, and aliased built-in identity before catalog planning or Node import and script execution.
- Keep catalog projections immutable, locale-independent, and digest-stable across runtimes.
- Harden environment credential lookup against inherited properties.
- Preserve explicit fail-closed diagnostics for missing or invalid canonical metadata.

## Compatibility

- Production CLI and MCP execution remain on the existing runtime path.
- No package export, custom-provider protocol, or Node execution bridge changes are included.
- Disabled custom providers remain unavailable except when validated as fallback-only reserve targets.

## Test Plan

- [x] 1,313 unit tests
- [x] 17 Worker compatibility tests
- [x] 14 integration tests
- [x] TypeScript typecheck
- [x] Biome lint across 306 files
- [x] Production build
- [x] Two-round independent security, architecture, and regression review