### PR TITLE
feat(core): derive bounded v1 migration deadlines

### DIFF
--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -25,23 +25,29 @@ import {
   BUILTIN_PROVIDER_CATALOG,
   type ProviderCatalogEntry,
 } from './provider-profiles.js';
+import type { V1RequestDeadlineMigrationContext } from './request-deadline-migration.js';
 import type {
   PreparationIssue,
   PreparationNotice,
 } from './research-request.js';
-import { comparePreparationDiagnostics } from './research-request.js';
+import {
+  comparePreparationDiagnostics,
+  RESEARCH_REQUEST_LIMITS,
+} from './research-request.js';
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 import type {
   CanonicalTransportDefaults,
   ConfigurationTransportInput,
+  UnresolvedV1TransportDefaults,
 } from './transport-normalization.js';
 import { exactUsdBudgets } from './transport-normalization.js';
 
 /** Dependencies are injected so mapping stays pure and network-free. */
 export interface ConfigurationMappingOptions {
   /**
-   * The v1 total request deadline has no approved conversion formula yet.
-   * Callers must supply the already-approved canonical deadline explicitly.
+   * An explicit canonical total deadline. When omitted, mapping exposes only
+   * the validated v1 migration context; a caller must derive the total after
+   * concrete primary/reserve selection and perform final schema validation.
    */
   readonly requestDeadlineMs?: number;
   /** Required to prevent injected v1 DEFAULT_GROUPS entering the catalog. */
@@ -66,8 +72,16 @@ export interface ConfigurationPreflight {
  */
 export interface ConfigurationMappingResult {
   readonly catalog: ProviderCatalog;
-  /** Omitted until the caller supplies the explicitly approved request limit. */
+  /** Omitted until the caller supplies a valid explicit request limit. */
   readonly transport_defaults?: CanonicalTransportDefaults;
+  /**
+   * Validated timing facts for the later two-phase deadline migration. This is
+   * not a canonical policy and cannot be dispatched without plan derivation
+   * and final schema validation.
+   */
+  readonly deadline_migration?: V1RequestDeadlineMigrationContext;
+  /** Private two-phase defaults which intentionally omit unresolved limits. */
+  readonly unresolved_transport_defaults?: UnresolvedV1TransportDefaults;
   readonly transport_input: ConfigurationTransportInput;
   readonly groups: Readonly<Record<string, readonly string[]>>;
   /** v1 group spelling to the exact catalog group id. */
@@ -820,40 +834,218 @@ function profileKey(binding: AdapterProfileBinding): string {
   return `${binding.provider_id}/${binding.profile_id}`;
 }
 
-function canonicalDefaults(
-  config: Config,
-  requestDeadlineMs: number | undefined,
+function timingIntegerIssue(path: string, label: string): PreparationIssue {
+  return {
+    code: 'configuration_deadline_invalid_integer',
+    phase: 'migration',
+    path,
+    message: `${label} must be a positive safe integer.`,
+  };
+}
+
+function millisecondsFromV1Seconds(
+  value: number,
+  path: string,
+  label: string,
   issues: PreparationIssue[],
-): CanonicalTransportDefaults | undefined {
-  if (requestDeadlineMs === undefined) {
+): number | undefined {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    issues.push(timingIntegerIssue(path, label));
+    return undefined;
+  }
+  const exact = BigInt(value) * 1_000n;
+  if (exact > BigInt(Number.MAX_SAFE_INTEGER)) {
     issues.push({
-      code: 'configuration_request_deadline_required',
+      code: 'configuration_deadline_arithmetic_overflow',
       phase: 'migration',
-      path: '/defaults/requestDeadlineMs',
-      message:
-        'The v1 total request-deadline conversion is not approved. Supply requestDeadlineMs explicitly when mapping this configuration.',
+      path,
+      message: `${label} cannot be represented exactly in milliseconds.`,
     });
     return undefined;
   }
-  const budgets = exactUsdBudgets(
-    config.defaults.maxCostUsd,
-    config.defaults.maxEstimatedCostUsd,
-    '/defaults',
+  if (exact > BigInt(RESEARCH_REQUEST_LIMITS.maxDeadlineMs)) {
+    issues.push({
+      code: 'configuration_deadline_contract_maximum_exceeded',
+      phase: 'migration',
+      path,
+      message: `${label} exceeds the ${RESEARCH_REQUEST_LIMITS.maxDeadlineMs}ms contract maximum.`,
+    });
+    return undefined;
+  }
+  return Number(exact);
+}
+
+function pollIntervalMillisecondsFromV1Seconds(
+  value: number,
+  issues: PreparationIssue[],
+): number | undefined {
+  const path = '/defaults/asyncPollInterval';
+  if (!Number.isSafeInteger(value) || value < 1) {
+    issues.push({
+      code: 'configuration_poll_interval_invalid_integer',
+      phase: 'migration',
+      path,
+      message:
+        'Background poll interval must be a positive safe integer in seconds.',
+    });
+    return undefined;
+  }
+  const exact = BigInt(value) * 1_000n;
+  if (exact > BigInt(Number.MAX_SAFE_INTEGER)) {
+    issues.push({
+      code: 'configuration_poll_interval_arithmetic_overflow',
+      phase: 'migration',
+      path,
+      message:
+        'Background poll interval cannot be represented exactly in milliseconds.',
+    });
+    return undefined;
+  }
+  if (
+    exact < BigInt(RESEARCH_REQUEST_LIMITS.minPollIntervalMs) ||
+    exact > BigInt(RESEARCH_REQUEST_LIMITS.maxPollIntervalMs)
+  ) {
+    issues.push({
+      code: 'configuration_poll_interval_out_of_bounds',
+      phase: 'migration',
+      path,
+      message: `Background poll interval must resolve within ${RESEARCH_REQUEST_LIMITS.minPollIntervalMs} through ${RESEARCH_REQUEST_LIMITS.maxPollIntervalMs} milliseconds.`,
+    });
+    return undefined;
+  }
+  return Number(exact);
+}
+
+function deadlineMigrationContext(
+  config: Config,
+  requestDeadlineMs: number | undefined,
+  issues: PreparationIssue[],
+): V1RequestDeadlineMigrationContext | undefined {
+  const issueCount = issues.length;
+  const maxParallel = config.defaults.maxParallel;
+  if (
+    !Number.isSafeInteger(maxParallel) ||
+    maxParallel < RESEARCH_REQUEST_LIMITS.minConcurrency ||
+    maxParallel > RESEARCH_REQUEST_LIMITS.maxConcurrency
+  ) {
+    issues.push({
+      code: 'configuration_deadline_concurrency_out_of_bounds',
+      phase: 'migration',
+      path: '/defaults/maxParallel',
+      message: `Deadline derivation concurrency must be an integer from ${RESEARCH_REQUEST_LIMITS.minConcurrency} through ${RESEARCH_REQUEST_LIMITS.maxConcurrency}.`,
+    });
+  }
+  const inlineAttemptDeadlineMs = millisecondsFromV1Seconds(
+    config.defaults.timeout,
+    '/defaults/timeout',
+    'Inline attempt timeout',
+    issues,
   );
-  issues.push(...budgets.issues);
-  if (budgets.issues.length > 0) return undefined;
+  const backgroundAttemptDeadlineMs = millisecondsFromV1Seconds(
+    config.defaults.asyncTimeout,
+    '/defaults/asyncTimeout',
+    'Background attempt timeout',
+    issues,
+  );
+  const pollIntervalMs = pollIntervalMillisecondsFromV1Seconds(
+    config.defaults.asyncPollInterval,
+    issues,
+  );
+  if (
+    pollIntervalMs !== undefined &&
+    backgroundAttemptDeadlineMs !== undefined &&
+    pollIntervalMs > backgroundAttemptDeadlineMs
+  ) {
+    issues.push({
+      code: 'configuration_poll_interval_exceeds_background_attempt',
+      phase: 'migration',
+      path: '/defaults/asyncPollInterval',
+      message:
+        'Background poll interval cannot exceed the background attempt timeout.',
+    });
+  }
+  if (
+    requestDeadlineMs !== undefined &&
+    (!Number.isSafeInteger(requestDeadlineMs) ||
+      requestDeadlineMs < RESEARCH_REQUEST_LIMITS.minDeadlineMs)
+  ) {
+    issues.push(
+      timingIntegerIssue(
+        '/defaults/requestDeadlineMs',
+        `Explicit request deadline in milliseconds (minimum ${RESEARCH_REQUEST_LIMITS.minDeadlineMs})`,
+      ),
+    );
+  } else if (
+    requestDeadlineMs !== undefined &&
+    requestDeadlineMs > RESEARCH_REQUEST_LIMITS.maxDeadlineMs
+  ) {
+    issues.push({
+      code: 'configuration_deadline_contract_maximum_exceeded',
+      phase: 'migration',
+      path: '/defaults/requestDeadlineMs',
+      message: `Explicit request deadline exceeds the ${RESEARCH_REQUEST_LIMITS.maxDeadlineMs}ms contract maximum.`,
+    });
+  }
+  if (
+    requestDeadlineMs !== undefined &&
+    inlineAttemptDeadlineMs !== undefined &&
+    backgroundAttemptDeadlineMs !== undefined &&
+    (requestDeadlineMs < inlineAttemptDeadlineMs ||
+      requestDeadlineMs < backgroundAttemptDeadlineMs)
+  ) {
+    issues.push({
+      code: 'configuration_request_deadline_less_than_attempt_deadline',
+      phase: 'migration',
+      path: '/defaults/requestDeadlineMs',
+      message:
+        'The explicit request deadline cannot be shorter than either v1 attempt timeout.',
+    });
+  }
+
+  if (
+    issues.length !== issueCount ||
+    inlineAttemptDeadlineMs === undefined ||
+    backgroundAttemptDeadlineMs === undefined ||
+    pollIntervalMs === undefined
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    kind: 'v1_request_deadline_migration',
+    max_parallel: maxParallel,
+    inline_attempt_deadline_ms: inlineAttemptDeadlineMs,
+    raw_background_attempt_deadline_ms: backgroundAttemptDeadlineMs,
+    poll_interval_ms: pollIntervalMs,
+    legacy_mode: config.defaults.mode,
+    ...(requestDeadlineMs !== undefined && {
+      explicit_request_deadline_ms: requestDeadlineMs,
+    }),
+  });
+}
+
+function canonicalDefaults(
+  config: Config,
+  deadlineMigration: V1RequestDeadlineMigrationContext | undefined,
+  budgets: ReturnType<typeof exactUsdBudgets>['budgets'],
+): CanonicalTransportDefaults | undefined {
+  if (deadlineMigration?.explicit_request_deadline_ms === undefined) {
+    return undefined;
+  }
   return {
     mode: config.defaults.mode,
     limits: {
-      max_concurrency: config.defaults.maxParallel,
-      request_deadline_ms: requestDeadlineMs,
-      inline_attempt_deadline_ms: config.defaults.timeout * 1_000,
-      background_attempt_deadline_ms: config.defaults.asyncTimeout * 1_000,
-      poll_interval_ms: config.defaults.asyncPollInterval * 1_000,
+      max_concurrency: deadlineMigration.max_parallel,
+      request_deadline_ms: deadlineMigration.explicit_request_deadline_ms,
+      inline_attempt_deadline_ms: deadlineMigration.inline_attempt_deadline_ms,
+      // Native explicit defaults retain the raw v1 timeout; the migrated
+      // shadow path expands it with selected-provider transport overhead.
+      background_attempt_deadline_ms:
+        deadlineMigration.raw_background_attempt_deadline_ms,
+      poll_interval_ms: deadlineMigration.poll_interval_ms,
     },
     fallback: { kind: 'configured' },
     refinement: { kind: 'disabled' },
-    ...(budgets.budgets && { budgets: budgets.budgets }),
+    ...(budgets && { budgets }),
   };
 }
 
@@ -897,11 +1089,36 @@ export function mapConfiguration(
     ...canonicalGroups.issues,
     ...fallback.issues,
   ];
-  const transportDefaults = canonicalDefaults(
+  const deadlineMigration = deadlineMigrationContext(
     config,
     options.requestDeadlineMs,
     issues,
   );
+  const budgetResult = exactUsdBudgets(
+    config.defaults.maxCostUsd,
+    config.defaults.maxEstimatedCostUsd,
+    '/defaults',
+  );
+  issues.push(...budgetResult.issues);
+  const unresolvedTransportDefaults =
+    deadlineMigration && budgetResult.issues.length === 0
+      ? deepFreeze({
+          mode: config.defaults.mode,
+          limits: {
+            max_concurrency: deadlineMigration.max_parallel,
+            inline_attempt_deadline_ms:
+              deadlineMigration.inline_attempt_deadline_ms,
+            poll_interval_ms: deadlineMigration.poll_interval_ms,
+          },
+          fallback: { kind: 'configured' as const },
+          refinement: { kind: 'disabled' as const },
+          ...(budgetResult.budgets && { budgets: budgetResult.budgets }),
+        })
+      : undefined;
+  const transportDefaults =
+    budgetResult.issues.length === 0
+      ? canonicalDefaults(config, deadlineMigration, budgetResult.budgets)
+      : undefined;
   const catalog = buildProviderCatalog({
     ...(options.catalog && { catalog: options.catalog }),
     providerConfigs,
@@ -927,6 +1144,10 @@ export function mapConfiguration(
   return {
     catalog,
     ...(transportDefaults && { transport_defaults: transportDefaults }),
+    ...(deadlineMigration && { deadline_migration: deadlineMigration }),
+    ...(unresolvedTransportDefaults && {
+      unresolved_transport_defaults: unresolvedTransportDefaults,
+    }),
     transport_input: {
       defaults: {
         mode: config.defaults.mode,

--- a/src/core/execution-plan.ts
+++ b/src/core/execution-plan.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod/v4';
 import {
   CONTRACT_LIMITS,
   OpaqueIdSchema,
@@ -134,10 +135,84 @@ export type PreparationResult =
       readonly notices: readonly PreparationNotice[];
     };
 
-interface SelectedProfile {
+type ResearchAdmissionRequest = Omit<CanonicalResearchRequest, 'limits'>;
+
+export interface AdmittedSelectedProfile {
   readonly entry: PlanningProfile;
   readonly path: string;
   readonly requirements?: EvidenceRequirements;
+}
+
+const RESEARCH_ADMISSION_BRAND: unique symbol = Symbol(
+  'librarium.research-admission',
+);
+const MINTED_RESEARCH_ADMISSIONS = new WeakSet<object>();
+
+/**
+ * Opaque, deeply frozen result of catalog validation, exact selection,
+ * fallback compatibility, and budget admission. Only this module can mint it.
+ */
+export interface ResearchExecutionAdmission {
+  readonly [RESEARCH_ADMISSION_BRAND]: true;
+  readonly request: ResearchAdmissionRequest;
+  readonly primaries: readonly AdmittedSelectedProfile[];
+  readonly reserve: readonly AdmittedSelectedProfile[];
+  readonly provisional_slots: readonly RequestSlot[];
+  readonly catalog: {
+    readonly revision: string;
+    readonly digest: string;
+  };
+  readonly notices: readonly PreparationNotice[];
+}
+
+export type ResearchAdmissionResult =
+  | {
+      readonly ok: true;
+      readonly admission: ResearchExecutionAdmission;
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+const UnresolvedV1ResearchRequestSchema = CanonicalResearchRequestSchema.omit({
+  limits: true,
+}).extend({
+  // The total and effective background attempt limit do not exist until the
+  // exact frozen plan has been admitted. This strict private shape carries
+  // only limits which are independently knowable before selection.
+  limits: z.strictObject({
+    max_concurrency: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minConcurrency)
+      .max(RESEARCH_REQUEST_LIMITS.maxConcurrency),
+    inline_attempt_deadline_ms: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minDeadlineMs)
+      .max(RESEARCH_REQUEST_LIMITS.maxDeadlineMs),
+    poll_interval_ms: z
+      .number()
+      .int()
+      .min(RESEARCH_REQUEST_LIMITS.minPollIntervalMs)
+      .max(RESEARCH_REQUEST_LIMITS.maxPollIntervalMs),
+  }),
+});
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+  Object.freeze(value);
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return value;
+}
+
+function ownFrozen<T>(value: T): T {
+  return deepFreeze(structuredClone(value));
 }
 
 function escapeJsonPointerToken(token: string): string {
@@ -237,7 +312,7 @@ function duplicateTargetIssues(
 }
 
 function canonicalSetIssues(
-  request: CanonicalResearchRequest,
+  request: ResearchAdmissionRequest,
 ): PreparationIssue[] {
   const issues = duplicateTargetIssues(
     request.exclusions,
@@ -314,8 +389,8 @@ function resolveTargets(
   catalog: FrozenPlanningCatalog,
   basePath: string,
   issues: PreparationIssue[],
-): SelectedProfile[] {
-  const selected: SelectedProfile[] = [];
+): AdmittedSelectedProfile[] {
+  const selected: AdmittedSelectedProfile[] = [];
   for (const [index, target] of targets.entries()) {
     const path = `${basePath}/${index}`;
     const matches = catalog.profiles.filter(({ profile }) =>
@@ -355,8 +430,8 @@ function resolveIdentities(
   byKey: ReadonlyMap<string, PlanningProfile>,
   path: string,
   issues: PreparationIssue[],
-): SelectedProfile[] {
-  const selected: SelectedProfile[] = [];
+): AdmittedSelectedProfile[] {
+  const selected: AdmittedSelectedProfile[] = [];
   for (const identity of identities) {
     const entry = findCatalogEntry(byKey, identity);
     if (!entry) {
@@ -375,7 +450,7 @@ function resolveIdentities(
 }
 
 function profileAvailabilityIssues(
-  selection: SelectedProfile,
+  selection: AdmittedSelectedProfile,
   mode: CanonicalResearchRequest['mode'],
   allowReserveOnly = false,
 ): PreparationIssue[] {
@@ -431,7 +506,7 @@ function profileAvailabilityIssues(
 
 function isUsableCapabilityMatch(
   entry: PlanningProfile,
-  request: CanonicalResearchRequest,
+  request: ResearchAdmissionRequest,
   requirements: EvidenceRequirements,
 ): boolean {
   return (
@@ -446,12 +521,12 @@ function isUsableCapabilityMatch(
 }
 
 function selectPrimaries(
-  request: CanonicalResearchRequest,
+  request: ResearchAdmissionRequest,
   catalog: FrozenPlanningCatalog,
   byKey: ReadonlyMap<string, PlanningProfile>,
   issues: PreparationIssue[],
-): SelectedProfile[] {
-  let selected: SelectedProfile[];
+): AdmittedSelectedProfile[] {
+  let selected: AdmittedSelectedProfile[];
   switch (request.selector.kind) {
     case 'targets':
       selected = resolveTargets(
@@ -512,7 +587,7 @@ function selectPrimaries(
   }
 
   if (request.selector.kind !== 'capabilities') {
-    const retained: SelectedProfile[] = [];
+    const retained: AdmittedSelectedProfile[] = [];
     for (const selection of selected) {
       if (isExcluded(selection.entry.profile.identity, request.exclusions)) {
         if (request.selector.kind === 'targets') {
@@ -723,14 +798,14 @@ function validateCatalogIdentity(
 }
 
 function resolveReserve(
-  request: CanonicalResearchRequest,
+  request: ResearchAdmissionRequest,
   catalog: FrozenPlanningCatalog,
   byKey: ReadonlyMap<string, PlanningProfile>,
-  primaries: readonly SelectedProfile[],
+  primaries: readonly AdmittedSelectedProfile[],
   slots: readonly RequestSlot[],
   issues: PreparationIssue[],
   notices: PreparationNotice[],
-): SelectedProfile[] {
+): AdmittedSelectedProfile[] {
   if (request.fallback.kind === 'disabled') return [];
 
   const fallback = request.fallback;
@@ -748,7 +823,7 @@ function resolveReserve(
         );
 
   const used = new Set(primaries.map(({ entry }) => profileKey(entry.profile)));
-  const retained: SelectedProfile[] = [];
+  const retained: AdmittedSelectedProfile[] = [];
   for (const selection of reserve) {
     const key = profileKey(selection.entry.profile);
     const diagnosticKey = profileIdentityKey(selection.entry.profile.identity);
@@ -851,9 +926,9 @@ function profilePlan(entry: PlanningProfile): PreparedProfilePlan {
 }
 
 function validatePrimaryBudgetAdmission(
-  request: CanonicalResearchRequest,
-  primaries: readonly SelectedProfile[],
-  reserve: readonly SelectedProfile[],
+  request: ResearchAdmissionRequest,
+  primaries: readonly AdmittedSelectedProfile[],
+  reserve: readonly AdmittedSelectedProfile[],
   issues: PreparationIssue[],
 ): void {
   if (!request.budgets) return;
@@ -890,32 +965,26 @@ function validatePrimaryBudgetAdmission(
   }
 }
 
-export function prepareResearchExecution(
-  input: unknown,
-  catalog: FrozenPlanningCatalog,
-  dependencies: PreparationDependencies,
-): PreparationResult {
-  const migration = migrateLegacyResearchRequest(input);
-  const notices: PreparationNotice[] = [...migration.notices];
-  const canonical = CanonicalResearchRequestSchema.safeParse(migration.input);
-  if (!canonical.success) {
-    const issues = canonical.error.issues.map((issue) => {
-      const path = jsonPointer(issue.path);
-      return {
-        code: canonicalIssueCode(path, issue.message),
-        phase: 'canonicalization' as const,
-        path,
-        message: issue.message,
-      };
-    });
+function canonicalizationIssues(error: {
+  readonly issues: readonly { path: PropertyKey[]; message: string }[];
+}): PreparationIssue[] {
+  return error.issues.map((issue) => {
+    const path = jsonPointer(issue.path);
     return {
-      ok: false,
-      issues: sortDiagnostics(issues),
-      notices: sortDiagnostics(notices),
+      code: canonicalIssueCode(path, issue.message),
+      phase: 'canonicalization' as const,
+      path,
+      message: issue.message,
     };
-  }
+  });
+}
 
-  const request = canonical.data;
+function admitValidatedResearchExecution(
+  request: ResearchAdmissionRequest,
+  catalog: FrozenPlanningCatalog,
+  initialNotices: readonly PreparationNotice[],
+): ResearchAdmissionResult {
+  const notices: PreparationNotice[] = [...initialNotices];
   const issues = canonicalSetIssues(request);
   if (issues.length > 0) {
     return {
@@ -973,6 +1042,162 @@ export function prepareResearchExecution(
     };
   }
 
+  const frozenRequest = ownFrozen(request);
+  const frozenPrimaries = ownFrozen(primaries);
+  const frozenReserve = ownFrozen(reserve);
+  const frozenSlots = ownFrozen(provisionalSlots);
+  const frozenCatalogIdentity = ownFrozen(catalogIdentity);
+  const sortedNotices = ownFrozen(sortDiagnostics(notices));
+  const admission = deepFreeze({
+    [RESEARCH_ADMISSION_BRAND]: true as const,
+    request: frozenRequest,
+    primaries: frozenPrimaries,
+    reserve: frozenReserve,
+    provisional_slots: frozenSlots,
+    catalog: frozenCatalogIdentity,
+    notices: sortedNotices,
+  });
+  // Registration is the final minting step. A branded or frozen lookalike is
+  // not an admission unless this module completed every validation and freeze.
+  MINTED_RESEARCH_ADMISSIONS.add(admission);
+  return { ok: true, admission, notices: sortedNotices };
+}
+
+export type CanonicalResearchAdmissionResult =
+  | {
+      readonly ok: true;
+      readonly admission: ResearchExecutionAdmission;
+      readonly limits: CanonicalResearchRequest['limits'];
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+/** Pure canonical validation, catalog selection, and admission; no clock/IDs. */
+export function admitResearchExecution(
+  input: unknown,
+  catalog: FrozenPlanningCatalog,
+): CanonicalResearchAdmissionResult {
+  const migration = migrateLegacyResearchRequest(input);
+  const notices = [...migration.notices];
+  const canonical = CanonicalResearchRequestSchema.safeParse(migration.input);
+  if (!canonical.success) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(canonicalizationIssues(canonical.error)),
+      notices: sortDiagnostics(notices),
+    };
+  }
+  const { limits, ...request } = canonical.data;
+  const admitted = admitValidatedResearchExecution(request, catalog, notices);
+  return admitted.ok ? { ...admitted, limits } : admitted;
+}
+
+/**
+ * Strict two-phase v1 admission. Missing total/effective background limits are
+ * intentional and cannot be mistaken for a canonical request.
+ */
+export function admitUnresolvedV1ResearchExecution(
+  input: unknown,
+  catalog: FrozenPlanningCatalog,
+):
+  | {
+      readonly ok: true;
+      readonly admission: ResearchExecutionAdmission;
+      readonly unresolved_limits: z.infer<
+        typeof UnresolvedV1ResearchRequestSchema
+      >['limits'];
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    } {
+  const migration = migrateLegacyResearchRequest(input);
+  const notices = [...migration.notices];
+  const unresolved = UnresolvedV1ResearchRequestSchema.safeParse(
+    migration.input,
+  );
+  if (!unresolved.success) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(canonicalizationIssues(unresolved.error)),
+      notices: sortDiagnostics(notices),
+    };
+  }
+  const { limits, ...request } = unresolved.data;
+  const admitted = admitValidatedResearchExecution(request, catalog, notices);
+  return admitted.ok ? { ...admitted, unresolved_limits: limits } : admitted;
+}
+
+export function isMintedResearchExecutionAdmission(
+  admission: unknown,
+): admission is ResearchExecutionAdmission {
+  if (typeof admission !== 'object' || admission === null) return false;
+  const candidate = admission as Partial<ResearchExecutionAdmission>;
+  return (
+    MINTED_RESEARCH_ADMISSIONS.has(admission) &&
+    candidate[RESEARCH_ADMISSION_BRAND] === true &&
+    Object.isFrozen(admission) &&
+    candidate.primaries !== undefined &&
+    Object.isFrozen(candidate.primaries) &&
+    candidate.reserve !== undefined &&
+    Object.isFrozen(candidate.reserve)
+  );
+}
+
+/**
+ * Inject final limits, rerun canonical/set validation, then cross the sole
+ * clock/ID boundary without repeating catalog selection.
+ */
+export function materializeResearchExecution(
+  admission: ResearchExecutionAdmission,
+  limits: CanonicalResearchRequest['limits'],
+  dependencies: PreparationDependencies,
+): PreparationResult {
+  if (!isMintedResearchExecutionAdmission(admission)) {
+    return {
+      ok: false,
+      issues: [
+        {
+          code: 'research_admission_invalid',
+          phase: 'validation',
+          path: '/admission',
+          message:
+            'Execution materialization requires an opaque frozen admission produced by this planner.',
+        },
+      ],
+      notices: [],
+    };
+  }
+
+  const canonical = CanonicalResearchRequestSchema.safeParse({
+    ...admission.request,
+    limits,
+  });
+  if (!canonical.success) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(canonicalizationIssues(canonical.error)),
+      notices: admission.notices,
+    };
+  }
+  const setIssues = canonicalSetIssues(canonical.data);
+  if (setIssues.length > 0) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(setIssues),
+      notices: admission.notices,
+    };
+  }
+
+  const request = canonical.data;
+  const { primaries, reserve, provisional_slots: provisionalSlots } = admission;
+
   // Everything above is network-free admission and must remain free of caller
   // effects. Only a fully accepted plan may observe time or allocate IDs.
   const requestedAt = new Date(dependencies.clock.now()).toISOString();
@@ -1016,7 +1241,7 @@ export function prepareResearchExecution(
           message: issue.message,
         })),
       ),
-      notices: sortDiagnostics(notices),
+      notices: admission.notices,
     };
   }
 
@@ -1026,7 +1251,7 @@ export function prepareResearchExecution(
       return [plan.profile_key, plan];
     }),
   );
-  const sortedNotices = sortDiagnostics(notices);
+  const sortedNotices = sortDiagnostics(admission.notices);
   const prepared: PreparedResearchExecution = {
     request: compiled.data,
     policy: {
@@ -1037,10 +1262,24 @@ export function prepareResearchExecution(
       refinement: request.refinement,
     },
     profile_plans_by_identity: profilePlans,
-    catalog: catalogIdentity,
+    catalog: admission.catalog,
     notices: sortedNotices,
   };
   return { ok: true, prepared, notices: sortedNotices };
+}
+
+export function prepareResearchExecution(
+  input: unknown,
+  catalog: FrozenPlanningCatalog,
+  dependencies: PreparationDependencies,
+): PreparationResult {
+  const admitted = admitResearchExecution(input, catalog);
+  if (!admitted.ok) return admitted;
+  return materializeResearchExecution(
+    admitted.admission,
+    admitted.limits,
+    dependencies,
+  );
 }
 
 export { profileIdentityKey };

--- a/src/core/request-deadline-migration.ts
+++ b/src/core/request-deadline-migration.ts
@@ -50,33 +50,62 @@ export type V1RequestDeadlineDerivationResult =
 export interface BackgroundTransportOverheadPolicy {
   readonly submit_timeout_ms: number;
   readonly final_poll_sleep_ms: number;
-  readonly poll_timeout_ms: number;
-  readonly retrieve_timeout_ms: number;
+  readonly poll_attempt_timeout_ms: number;
+  readonly poll_ceiling_ms: number;
+  readonly retrieve_attempt_timeout_ms: number;
+  readonly retrieve_ceiling_ms: number;
   readonly total_ms: number;
+}
+
+/**
+ * Audited against `http-client.ts`: default safe GETs use MAX_RETRIES + 1 = 4
+ * attempts, three intervening delays, INITIAL_RETRY_DELAY_MS exponential
+ * jitter caps of 1s/2s/4s, and a 30s maxDelayMs cap for Retry-After. Because
+ * Retry-After replaces jitter when present, its 90s aggregate is the ceiling.
+ */
+export const V1_SAFE_GET_RETRY_CEILING = Object.freeze({
+  max_attempts: 4,
+  retry_delay_count: 3,
+  retry_after_cap_ms: 30_000,
+  jitter_caps_ms: Object.freeze([1_000, 2_000, 4_000] as const),
+  maximum_retry_delay_ms: 90_000,
+});
+
+function safeGetCeilingMs(attemptTimeoutMs: number): number {
+  return (
+    V1_SAFE_GET_RETRY_CEILING.max_attempts * attemptTimeoutMs +
+    V1_SAFE_GET_RETRY_CEILING.maximum_retry_delay_ms
+  );
 }
 
 const OPENAI_BACKGROUND_TRANSPORT = Object.freeze({
   submit_timeout_ms: 30_000,
   final_poll_sleep_ms: 5_000,
-  poll_timeout_ms: 15_000,
-  retrieve_timeout_ms: 30_000,
-  total_ms: 80_000,
+  poll_attempt_timeout_ms: 15_000,
+  poll_ceiling_ms: safeGetCeilingMs(15_000),
+  retrieve_attempt_timeout_ms: 30_000,
+  retrieve_ceiling_ms: safeGetCeilingMs(30_000),
+  total_ms: 395_000,
 });
 
 const GEMINI_BACKGROUND_TRANSPORT = Object.freeze({
   submit_timeout_ms: 30_000,
   final_poll_sleep_ms: 15_000,
-  poll_timeout_ms: 15_000,
-  retrieve_timeout_ms: 30_000,
-  total_ms: 90_000,
+  poll_attempt_timeout_ms: 15_000,
+  poll_ceiling_ms: safeGetCeilingMs(15_000),
+  retrieve_attempt_timeout_ms: 30_000,
+  retrieve_ceiling_ms: safeGetCeilingMs(30_000),
+  total_ms: 405_000,
 });
 
 const PERPLEXITY_BACKGROUND_TRANSPORT = Object.freeze({
   submit_timeout_ms: 30_000,
   final_poll_sleep_ms: 0,
-  poll_timeout_ms: 15_000,
-  retrieve_timeout_ms: 30_000,
-  total_ms: 75_000,
+  poll_attempt_timeout_ms: 15_000,
+  poll_ceiling_ms: safeGetCeilingMs(15_000),
+  retrieve_attempt_timeout_ms: 30_000,
+  retrieve_ceiling_ms: safeGetCeilingMs(30_000),
+  total_ms: 390_000,
 });
 
 /**

--- a/src/core/request-deadline-migration.ts
+++ b/src/core/request-deadline-migration.ts
@@ -1,0 +1,430 @@
+import {
+  type ExecutionProfile,
+  providerIdentityKey,
+} from '../contracts/domain/index.js';
+import {
+  isMintedResearchExecutionAdmission,
+  type ResearchExecutionAdmission,
+} from './execution-plan.js';
+import {
+  comparePreparationDiagnostics,
+  type PreparationIssue,
+  type PreparationNotice,
+  RESEARCH_REQUEST_LIMITS,
+} from './research-request.js';
+
+/**
+ * Validated v1 timing facts which are not yet a canonical execution policy.
+ *
+ * A caller must first resolve the concrete ordered primary and reserve plans,
+ * call {@link deriveV1RequestDeadline}, then construct and schema-validate the
+ * final canonical limits. This type deliberately cannot be mistaken for
+ * `CanonicalTransportDefaults` or a completed request.
+ */
+export interface V1RequestDeadlineMigrationContext {
+  readonly kind: 'v1_request_deadline_migration';
+  readonly max_parallel: number;
+  readonly inline_attempt_deadline_ms: number;
+  readonly raw_background_attempt_deadline_ms: number;
+  /** Final canonical limit data; polling cadence is excluded from arithmetic. */
+  readonly poll_interval_ms: number;
+  readonly legacy_mode: 'sync' | 'async' | 'mixed';
+  readonly explicit_request_deadline_ms?: number;
+}
+
+export type V1RequestDeadlineDerivationResult =
+  | {
+      readonly ok: true;
+      readonly request_deadline_ms: number;
+      readonly effective_background_attempt_deadline_ms: number;
+      readonly derived_full_plan_minimum_ms: number;
+      readonly source: 'explicit_override' | 'derived_v1_plan';
+      readonly notices: readonly PreparationNotice[];
+    }
+  | {
+      readonly ok: false;
+      readonly issues: readonly PreparationIssue[];
+      readonly notices: readonly PreparationNotice[];
+    };
+
+export interface BackgroundTransportOverheadPolicy {
+  readonly submit_timeout_ms: number;
+  readonly final_poll_sleep_ms: number;
+  readonly poll_timeout_ms: number;
+  readonly retrieve_timeout_ms: number;
+  readonly total_ms: number;
+}
+
+const OPENAI_BACKGROUND_TRANSPORT = Object.freeze({
+  submit_timeout_ms: 30_000,
+  final_poll_sleep_ms: 5_000,
+  poll_timeout_ms: 15_000,
+  retrieve_timeout_ms: 30_000,
+  total_ms: 80_000,
+});
+
+const GEMINI_BACKGROUND_TRANSPORT = Object.freeze({
+  submit_timeout_ms: 30_000,
+  final_poll_sleep_ms: 15_000,
+  poll_timeout_ms: 15_000,
+  retrieve_timeout_ms: 30_000,
+  total_ms: 90_000,
+});
+
+const PERPLEXITY_BACKGROUND_TRANSPORT = Object.freeze({
+  submit_timeout_ms: 30_000,
+  final_poll_sleep_ms: 0,
+  poll_timeout_ms: 15_000,
+  retrieve_timeout_ms: 30_000,
+  total_ms: 75_000,
+});
+
+/**
+ * Audited v1 adapter transport ceilings outside the configured remote-work
+ * allowance. `asyncPollInterval` is intentionally absent: it is cadence, not a
+ * timeout, and therefore is not request-deadline budget.
+ */
+export const V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE: Readonly<
+  Record<string, BackgroundTransportOverheadPolicy>
+> = Object.freeze({
+  'openai-research/research': OPENAI_BACKGROUND_TRANSPORT,
+  'gemini-deep/research': GEMINI_BACKGROUND_TRANSPORT,
+  'perplexity-sonar-deep/research': PERPLEXITY_BACKGROUND_TRANSPORT,
+});
+
+function sortDiagnostics<T extends PreparationIssue | PreparationNotice>(
+  diagnostics: readonly T[],
+): T[] {
+  return [...diagnostics].sort(comparePreparationDiagnostics);
+}
+
+export function v1BackgroundTransportOverheadMs(
+  profile: Pick<ExecutionProfile, 'identity' | 'invocation'>,
+): number {
+  if (profile.invocation !== 'background') return 0;
+  return (
+    V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE[
+      `${profile.identity.provider_id}/${profile.identity.profile_id}`
+    ]?.total_ms ?? 0
+  );
+}
+
+function invalidIntegerIssue(path: string, label: string): PreparationIssue {
+  return {
+    code: 'request_deadline_invalid_integer',
+    phase: 'migration',
+    path,
+    message: `${label} must be a safe integer of at least ${RESEARCH_REQUEST_LIMITS.minDeadlineMs} milliseconds.`,
+  };
+}
+
+function validateContext(
+  context: V1RequestDeadlineMigrationContext,
+  issues: PreparationIssue[],
+): void {
+  if (context.kind !== 'v1_request_deadline_migration') {
+    issues.push({
+      code: 'request_deadline_invalid_migration_context',
+      phase: 'migration',
+      path: '/deadline_migration/kind',
+      message:
+        'Deadline derivation requires an explicit v1 request-deadline migration context.',
+    });
+  }
+  if (!['sync', 'async', 'mixed'].includes(context.legacy_mode)) {
+    issues.push({
+      code: 'request_deadline_invalid_legacy_mode',
+      phase: 'migration',
+      path: '/deadline_migration/legacy_mode',
+      message: 'Legacy mode must be exactly sync, async, or mixed.',
+    });
+  }
+  if (
+    !Number.isSafeInteger(context.max_parallel) ||
+    context.max_parallel < RESEARCH_REQUEST_LIMITS.minConcurrency ||
+    context.max_parallel > RESEARCH_REQUEST_LIMITS.maxConcurrency
+  ) {
+    issues.push({
+      code: 'request_deadline_concurrency_out_of_bounds',
+      phase: 'migration',
+      path: '/deadline_migration/max_parallel',
+      message: `Deadline derivation concurrency must be an integer from ${RESEARCH_REQUEST_LIMITS.minConcurrency} through ${RESEARCH_REQUEST_LIMITS.maxConcurrency}.`,
+    });
+  }
+
+  for (const [field, label] of [
+    ['inline_attempt_deadline_ms', 'Inline attempt deadline'],
+    ['raw_background_attempt_deadline_ms', 'Raw background attempt deadline'],
+  ] as const) {
+    const value = context[field];
+    if (
+      !Number.isSafeInteger(value) ||
+      value < RESEARCH_REQUEST_LIMITS.minDeadlineMs
+    ) {
+      issues.push(invalidIntegerIssue(`/deadline_migration/${field}`, label));
+    }
+  }
+
+  if (
+    !Number.isSafeInteger(context.poll_interval_ms) ||
+    context.poll_interval_ms < RESEARCH_REQUEST_LIMITS.minPollIntervalMs ||
+    context.poll_interval_ms > RESEARCH_REQUEST_LIMITS.maxPollIntervalMs
+  ) {
+    issues.push({
+      code: 'request_deadline_poll_interval_out_of_bounds',
+      phase: 'migration',
+      path: '/deadline_migration/poll_interval_ms',
+      message: `Poll interval must be a safe integer from ${RESEARCH_REQUEST_LIMITS.minPollIntervalMs} through ${RESEARCH_REQUEST_LIMITS.maxPollIntervalMs} milliseconds.`,
+    });
+  } else if (
+    Number.isSafeInteger(context.raw_background_attempt_deadline_ms) &&
+    context.poll_interval_ms > context.raw_background_attempt_deadline_ms
+  ) {
+    issues.push({
+      code: 'request_deadline_poll_interval_exceeds_background_attempt',
+      phase: 'migration',
+      path: '/deadline_migration/poll_interval_ms',
+      message: 'Poll interval cannot exceed the background attempt deadline.',
+    });
+  }
+
+  const explicit = context.explicit_request_deadline_ms;
+  if (
+    explicit !== undefined &&
+    (!Number.isSafeInteger(explicit) ||
+      explicit < RESEARCH_REQUEST_LIMITS.minDeadlineMs)
+  ) {
+    issues.push(
+      invalidIntegerIssue(
+        '/deadline_migration/explicit_request_deadline_ms',
+        'Explicit request deadline',
+      ),
+    );
+  }
+}
+
+function allowanceMs(
+  profile: ExecutionProfile,
+  context: V1RequestDeadlineMigrationContext,
+  effectiveBackgroundAttemptDeadlineMs: bigint,
+): bigint {
+  return profile.invocation === 'inline'
+    ? BigInt(context.inline_attempt_deadline_ms)
+    : effectiveBackgroundAttemptDeadlineMs;
+}
+
+function overflowIssue(path: string): PreparationIssue {
+  return {
+    code: 'request_deadline_arithmetic_overflow',
+    phase: 'migration',
+    path,
+    message:
+      'The exact derived deadline value cannot be represented as a safe integer.',
+  };
+}
+
+function contractMaximumIssue(path: string): PreparationIssue {
+  return {
+    code: 'request_deadline_contract_maximum_exceeded',
+    phase: 'migration',
+    path,
+    message: `The deadline exceeds the ${RESEARCH_REQUEST_LIMITS.maxDeadlineMs}ms contract maximum.`,
+  };
+}
+
+/**
+ * Derive the bounded v2 request deadline from a fully selected v1 plan.
+ *
+ * Primaries use deterministic list scheduling in their supplied selection
+ * order. Every ordered unique reserve is then added sequentially because any
+ * one request slot may consume the complete reserve chain. Arithmetic remains
+ * exact in BigInt until the 7-day contract boundary has been checked.
+ */
+export function deriveV1RequestDeadline(
+  context: V1RequestDeadlineMigrationContext,
+  admission: ResearchExecutionAdmission,
+): V1RequestDeadlineDerivationResult {
+  if (!isMintedResearchExecutionAdmission(admission)) {
+    return {
+      ok: false,
+      issues: [
+        {
+          code: 'research_admission_invalid',
+          phase: 'validation',
+          path: '/admission',
+          message:
+            'Deadline derivation requires an admission minted by the execution planner.',
+        },
+      ],
+      notices: [],
+    };
+  }
+  const issues: PreparationIssue[] = [];
+  const notices: PreparationNotice[] =
+    context.legacy_mode === 'async' || context.legacy_mode === 'mixed'
+      ? [
+          {
+            code: 'legacy_wait_is_bounded_in_v2',
+            phase: 'migration',
+            path: '/deadline_migration/legacy_mode',
+            message:
+              'Legacy async and mixed status --wait behavior is migrated to a bounded v2 request deadline.',
+          },
+        ]
+      : [];
+
+  validateContext(context, issues);
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues: sortDiagnostics(issues),
+      notices: sortDiagnostics(notices),
+    };
+  }
+
+  const selected = [...admission.primaries, ...admission.reserve];
+  const maximumBackgroundOverheadMs = selected.reduce(
+    (maximum, selection) =>
+      selection.entry.profile.invocation === 'background'
+        ? Math.max(
+            maximum,
+            v1BackgroundTransportOverheadMs(selection.entry.profile),
+          )
+        : maximum,
+    0,
+  );
+  const effectiveBackgroundExact =
+    BigInt(context.raw_background_attempt_deadline_ms) +
+    BigInt(maximumBackgroundOverheadMs);
+  const effectivePath =
+    '/deadline_migration/effective_background_attempt_deadline_ms';
+  if (effectiveBackgroundExact > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return {
+      ok: false,
+      issues: [overflowIssue(effectivePath)],
+      notices: sortDiagnostics(notices),
+    };
+  }
+  if (
+    effectiveBackgroundExact > BigInt(RESEARCH_REQUEST_LIMITS.maxDeadlineMs)
+  ) {
+    return {
+      ok: false,
+      issues: [contractMaximumIssue(effectivePath)],
+      notices: sortDiagnostics(notices),
+    };
+  }
+
+  const workers = Array.from({ length: context.max_parallel }, () => 0n);
+  for (const { entry } of admission.primaries) {
+    let workerIndex = 0;
+    for (let index = 1; index < workers.length; index += 1) {
+      if (workers[index] < workers[workerIndex]) workerIndex = index;
+    }
+    workers[workerIndex] += allowanceMs(
+      entry.profile,
+      context,
+      effectiveBackgroundExact,
+    );
+  }
+  let fullPlanExact = workers.reduce(
+    (maximum, value) => (value > maximum ? value : maximum),
+    0n,
+  );
+
+  const seenReserve = new Set<string>();
+  for (const { entry } of admission.reserve) {
+    const key = providerIdentityKey(entry.profile.identity);
+    if (seenReserve.has(key)) continue;
+    seenReserve.add(key);
+    fullPlanExact += allowanceMs(
+      entry.profile,
+      context,
+      effectiveBackgroundExact,
+    );
+  }
+
+  const requestPath = '/deadline_migration/request_deadline_ms';
+  if (fullPlanExact > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return {
+      ok: false,
+      issues: [overflowIssue(requestPath)],
+      notices: sortDiagnostics(notices),
+    };
+  }
+  const fullPlanMinimum = Number(fullPlanExact);
+  const effectiveBackgroundAttemptDeadlineMs = Number(effectiveBackgroundExact);
+  const explicit = context.explicit_request_deadline_ms;
+  if (explicit !== undefined) {
+    if (explicit > RESEARCH_REQUEST_LIMITS.maxDeadlineMs) {
+      return {
+        ok: false,
+        issues: [
+          contractMaximumIssue(
+            '/deadline_migration/explicit_request_deadline_ms',
+          ),
+        ],
+        notices: sortDiagnostics(notices),
+      };
+    }
+    const attemptCap = Math.max(
+      context.inline_attempt_deadline_ms,
+      effectiveBackgroundAttemptDeadlineMs,
+    );
+    if (explicit < attemptCap) {
+      return {
+        ok: false,
+        issues: [
+          {
+            code: 'request_deadline_less_than_attempt_deadline',
+            phase: 'migration',
+            path: '/deadline_migration/explicit_request_deadline_ms',
+            message:
+              'The explicit request deadline cannot be shorter than the effective attempt deadline cap.',
+          },
+        ],
+        notices: sortDiagnostics(notices),
+      };
+    }
+    if (fullPlanExact > BigInt(explicit)) {
+      notices.push({
+        code: 'explicit_request_deadline_may_truncate_plan',
+        phase: 'migration',
+        path: '/deadline_migration/explicit_request_deadline_ms',
+        message:
+          'The explicit request deadline is shorter than the derived full-plan minimum; later primaries or reserves may be truncated.',
+      });
+    }
+    return {
+      ok: true,
+      request_deadline_ms: explicit,
+      effective_background_attempt_deadline_ms:
+        effectiveBackgroundAttemptDeadlineMs,
+      derived_full_plan_minimum_ms: fullPlanMinimum,
+      source: 'explicit_override',
+      notices: sortDiagnostics(notices),
+    };
+  }
+
+  const derivedRequestExact = [
+    fullPlanExact,
+    BigInt(context.inline_attempt_deadline_ms),
+    effectiveBackgroundExact,
+  ].reduce((maximum, value) => (value > maximum ? value : maximum));
+  if (derivedRequestExact > BigInt(RESEARCH_REQUEST_LIMITS.maxDeadlineMs)) {
+    return {
+      ok: false,
+      issues: [contractMaximumIssue(requestPath)],
+      notices: sortDiagnostics(notices),
+    };
+  }
+  return {
+    ok: true,
+    request_deadline_ms: Number(derivedRequestExact),
+    effective_background_attempt_deadline_ms:
+      effectiveBackgroundAttemptDeadlineMs,
+    derived_full_plan_minimum_ms: fullPlanMinimum,
+    source: 'derived_v1_plan',
+    notices: sortDiagnostics(notices),
+  };
+}

--- a/src/core/shadow-compilation.ts
+++ b/src/core/shadow-compilation.ts
@@ -13,7 +13,12 @@ import type {
   PreparationDependencies,
   PreparedResearchExecution,
 } from './execution-plan.js';
+import {
+  admitUnresolvedV1ResearchExecution,
+  materializeResearchExecution,
+} from './execution-plan.js';
 import type { CustomCatalogProfile } from './profile-catalog.js';
+import { deriveV1RequestDeadline } from './request-deadline-migration.js';
 import type {
   PreparationIssue,
   PreparationNotice,
@@ -22,14 +27,13 @@ import type {
 import { sortPreparationDiagnostics } from './research-request.js';
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 import {
-  type CanonicalTransportDefaults,
   type CliTransportInput,
-  compileNormalizedTransportRequest,
   type McpTransportInput,
-  normalizeCliRequest,
-  normalizeMcpRequest,
-  normalizeSilentMcpRequest,
+  normalizeCliRequestUnresolved,
+  normalizeMcpRequestUnresolved,
+  normalizeSilentMcpRequestUnresolved,
   type TransportNormalizationResult,
+  type UnresolvedV1TransportDefaults,
 } from './transport-normalization.js';
 
 /**
@@ -50,7 +54,7 @@ export interface ShadowCompilationInput {
   /** Preserves which group spellings were explicitly authored. */
   readonly authoredGroups: AuthoredGroupProvenance;
   readonly credentials: CredentialContext;
-  /** The v1 total request-deadline formula remains deliberately unresolved. */
+  /** Optional explicit total; otherwise the exact selected plan derives it. */
   readonly requestDeadlineMs?: number;
   readonly transport: ShadowCompilationTransport;
   readonly preparation: PreparationDependencies;
@@ -301,7 +305,7 @@ function collisionGroupDiagnostics(
 
 function normalizeTransport(
   transport: ShadowCompilationTransport,
-  defaults: CanonicalTransportDefaults,
+  defaults: UnresolvedV1TransportDefaults,
   targets: readonly ProfileTarget[] | undefined,
   group: string | undefined,
 ): TransportNormalizationResult {
@@ -319,7 +323,7 @@ function normalizeTransport(
         ...(targets !== undefined && { exactTargets: targets }),
         ...(group !== undefined && { group }),
       };
-      return normalizeCliRequest(projected, defaults);
+      return normalizeCliRequestUnresolved(projected, defaults);
     }
     case 'mcp': {
       const projected: McpTransportInput = {
@@ -329,7 +333,7 @@ function normalizeTransport(
         ...(targets !== undefined && { exactTargets: targets }),
         ...(group !== undefined && { group }),
       };
-      return normalizeMcpRequest(projected, defaults);
+      return normalizeMcpRequestUnresolved(projected, defaults);
     }
     case 'silent_mcp': {
       const projected: McpTransportInput = {
@@ -339,7 +343,7 @@ function normalizeTransport(
         ...(targets !== undefined && { exactTargets: targets }),
         ...(group !== undefined && { group }),
       };
-      return normalizeSilentMcpRequest(projected, defaults);
+      return normalizeSilentMcpRequestUnresolved(projected, defaults);
     }
   }
 }
@@ -364,7 +368,11 @@ export function compileShadowRequest(
 
   // Mapping is the gate: neither token conversion nor transport normalization
   // may run until collisions, catalog facts, and deadline policy are sound.
-  if (mapperIssues.length > 0 || mapped.transport_defaults === undefined) {
+  if (
+    mapperIssues.length > 0 ||
+    mapped.deadline_migration === undefined ||
+    mapped.unresolved_transport_defaults === undefined
+  ) {
     return {
       ok: false,
       issues: sortPreparationDiagnostics([
@@ -431,19 +439,88 @@ export function compileShadowRequest(
 
   const normalized = normalizeTransport(
     input.transport,
-    mapped.transport_defaults,
+    mapped.unresolved_transport_defaults,
     rawProviders === undefined ? undefined : resolved.targets,
     group.group,
   );
-  const compiled = compileNormalizedTransportRequest(
-    normalized,
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      issues: normalized.issues,
+      notices: sortPreparationDiagnostics([
+        ...mapperNotices,
+        ...effectiveGroupNotices,
+        ...resolved.notices,
+        ...normalized.notices,
+      ]),
+    };
+  }
+
+  const admitted = admitUnresolvedV1ResearchExecution(
+    normalized.request,
     mapped.catalog,
+  );
+  if (!admitted.ok) {
+    return {
+      ok: false,
+      issues: admitted.issues,
+      notices: sortPreparationDiagnostics([
+        ...mapperNotices,
+        ...effectiveGroupNotices,
+        ...resolved.notices,
+        ...normalized.notices,
+        ...admitted.notices,
+      ]),
+    };
+  }
+
+  const unresolvedMode = normalized.request.mode;
+  const derived = deriveV1RequestDeadline(
+    {
+      ...mapped.deadline_migration,
+      max_parallel: admitted.unresolved_limits.max_concurrency,
+      inline_attempt_deadline_ms:
+        admitted.unresolved_limits.inline_attempt_deadline_ms,
+      poll_interval_ms: admitted.unresolved_limits.poll_interval_ms,
+      legacy_mode:
+        unresolvedMode === 'mixed' ? 'mixed' : admitted.admission.request.mode,
+    },
+    admitted.admission,
+  );
+  if (!derived.ok) {
+    return {
+      ok: false,
+      issues: derived.issues,
+      notices: sortPreparationDiagnostics([
+        ...mapperNotices,
+        ...effectiveGroupNotices,
+        ...resolved.notices,
+        ...normalized.notices,
+        ...admitted.notices,
+        ...derived.notices,
+      ]),
+    };
+  }
+
+  const compiled = materializeResearchExecution(
+    admitted.admission,
+    {
+      max_concurrency: admitted.unresolved_limits.max_concurrency,
+      request_deadline_ms: derived.request_deadline_ms,
+      inline_attempt_deadline_ms:
+        admitted.unresolved_limits.inline_attempt_deadline_ms,
+      background_attempt_deadline_ms:
+        derived.effective_background_attempt_deadline_ms,
+      poll_interval_ms: admitted.unresolved_limits.poll_interval_ms,
+    },
     input.preparation,
   );
   const notices = sortPreparationDiagnostics([
     ...mapperNotices,
     ...effectiveGroupNotices,
     ...resolved.notices,
+    ...normalized.notices,
+    ...derived.notices,
     ...compiled.notices,
   ]);
   return compiled.ok

--- a/src/core/transport-normalization.ts
+++ b/src/core/transport-normalization.ts
@@ -57,6 +57,18 @@ export interface CanonicalTransportDefaults {
   readonly budgets?: ExactBudgetLimits;
 }
 
+/** @internal Private two-phase v1 defaults; never a canonical request. */
+export interface UnresolvedV1TransportDefaults {
+  readonly mode: 'sync' | 'async' | 'mixed';
+  readonly limits: Pick<
+    ResearchExecutionLimits,
+    'max_concurrency' | 'inline_attempt_deadline_ms' | 'poll_interval_ms'
+  >;
+  readonly fallback: FallbackIntent;
+  readonly refinement: RefinementIntent;
+  readonly budgets?: ExactBudgetLimits;
+}
+
 export type TransportNormalizationResult =
   | {
       readonly ok: true;
@@ -153,10 +165,10 @@ function presentSelectorCandidates(
 }
 
 function mergeLimits(
-  defaults: ResearchExecutionLimits,
+  defaults: ResearchExecutionLimits | UnresolvedV1TransportDefaults['limits'],
   overrides: Partial<ResearchExecutionLimits> | undefined,
-): ResearchExecutionLimits {
-  const merged = { ...defaults };
+): Partial<ResearchExecutionLimits> {
+  const merged: Partial<ResearchExecutionLimits> = { ...defaults };
   if (!overrides) return merged;
   for (const field of [
     'max_concurrency',
@@ -174,7 +186,7 @@ function mergeLimits(
 function normalizeTransportRequest(
   source: TransportSource,
   projection: TransportProjection,
-  defaults: CanonicalTransportDefaults,
+  defaults: CanonicalTransportDefaults | UnresolvedV1TransportDefaults,
 ): TransportNormalizationResult {
   const issues: PreparationIssue[] = [...(projection.issues ?? [])];
   const notices: PreparationNotice[] = [];
@@ -506,51 +518,59 @@ export function normalizeCliRequest(
   input: CliTransportInput,
   defaults: CanonicalTransportDefaults,
 ): TransportNormalizationResult {
+  return normalizeTransportRequest('cli', cliProjection(input), defaults);
+}
+
+function cliProjection(input: CliTransportInput): TransportProjection {
   const issues: PreparationIssue[] = [];
   const limits: Partial<ResearchExecutionLimits> = {};
   if (input.parallel !== undefined) limits.max_concurrency = input.parallel;
   if (input.timeoutSeconds !== undefined) {
     limits.inline_attempt_deadline_ms = input.timeoutSeconds * 1_000;
   }
-  return normalizeTransportRequest(
-    'cli',
-    {
-      fields: {
-        query: input.query,
-        mode: input.mode,
-        selector: {
-          targets: targetsFromRawOrExactTargets(
-            input.providers,
-            input.exactTargets,
-            issues,
-          ),
-          group:
-            input.group === undefined
-              ? undefined
-              : { value: input.group, raw_path: '/group' },
-        },
-        fallback: toggleIntent<FallbackIntent>(
-          input.fallback,
-          { kind: 'configured' },
-          { kind: 'disabled' },
-        ),
-        limits,
-        budgets: usdBudgets(
-          input.maxCostUsd,
-          input.maxEstimatedCostUsd,
-          '',
+  return {
+    fields: {
+      query: input.query,
+      mode: input.mode,
+      selector: {
+        targets: targetsFromRawOrExactTargets(
+          input.providers,
+          input.exactTargets,
           issues,
         ),
-        refinement: toggleIntent<RefinementIntent>(
-          input.refine,
-          { kind: 'requested' },
-          { kind: 'disabled' },
-        ),
+        group:
+          input.group === undefined
+            ? undefined
+            : { value: input.group, raw_path: '/group' },
       },
-      issues,
+      fallback: toggleIntent<FallbackIntent>(
+        input.fallback,
+        { kind: 'configured' },
+        { kind: 'disabled' },
+      ),
+      limits,
+      budgets: usdBudgets(
+        input.maxCostUsd,
+        input.maxEstimatedCostUsd,
+        '',
+        issues,
+      ),
+      refinement: toggleIntent<RefinementIntent>(
+        input.refine,
+        { kind: 'requested' },
+        { kind: 'disabled' },
+      ),
     },
-    defaults,
-  );
+    issues,
+  };
+}
+
+/** @internal Shadow-only normalization with deliberately unresolved limits. */
+export function normalizeCliRequestUnresolved(
+  input: CliTransportInput,
+  defaults: UnresolvedV1TransportDefaults,
+): TransportNormalizationResult {
+  return normalizeTransportRequest('cli', cliProjection(input), defaults);
 }
 
 /** Mirrors the MCP `research` tool arguments (and the silent pipeline args). */
@@ -598,9 +618,29 @@ export function normalizeMcpRequest(
   return normalizeTransportRequest('mcp', mcpProjection(input), defaults);
 }
 
+/** @internal Shadow-only normalization with deliberately unresolved limits. */
+export function normalizeMcpRequestUnresolved(
+  input: McpTransportInput,
+  defaults: UnresolvedV1TransportDefaults,
+): TransportNormalizationResult {
+  return normalizeTransportRequest('mcp', mcpProjection(input), defaults);
+}
+
 export function normalizeSilentMcpRequest(
   input: McpTransportInput,
   defaults: CanonicalTransportDefaults,
+): TransportNormalizationResult {
+  return normalizeTransportRequest(
+    'silent_mcp',
+    mcpProjection(input),
+    defaults,
+  );
+}
+
+/** @internal Shadow-only normalization with deliberately unresolved limits. */
+export function normalizeSilentMcpRequestUnresolved(
+  input: McpTransportInput,
+  defaults: UnresolvedV1TransportDefaults,
 ): TransportNormalizationResult {
   return normalizeTransportRequest(
     'silent_mcp',

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -175,7 +175,7 @@ describe('configuration mapping', () => {
       groups: { team: ['acme-adapter'] },
     });
     const mapped = map(source, {
-      requestDeadlineMs: 300_000,
+      requestDeadlineMs: 2_000_000,
       credentials: credentials(),
     });
     expect(mapped.preflight.issues).toEqual([]);
@@ -200,7 +200,7 @@ describe('configuration mapping', () => {
         providers: { 'acme-adapter': { enabled: false } },
       }),
     ]) {
-      const result = map(filtered, { requestDeadlineMs: 300_000 });
+      const result = map(filtered, { requestDeadlineMs: 2_000_000 });
       expect(result.custom_profile_bindings).toEqual([]);
       expect(result.catalog.get('acme-provider', 'search')).toBeUndefined();
     }
@@ -214,7 +214,7 @@ describe('configuration mapping', () => {
         'custom-identity',
         'search',
       );
-      const mapped = map(source, { requestDeadlineMs: 300_000 });
+      const mapped = map(source, { requestDeadlineMs: 2_000_000 });
       expect(mapped.custom_profile_bindings).toEqual([]);
       expect(mapped.preflight.issues).not.toContainEqual(
         expect.objectContaining({ code: 'custom_provider_profile_missing' }),
@@ -226,7 +226,7 @@ describe('configuration mapping', () => {
     'rejects custom metadata claiming reserved provider identity %s',
     (providerId) => {
       const mapped = map(customIdentityConfig('acme-adapter', providerId), {
-        requestDeadlineMs: 300_000,
+        requestDeadlineMs: 2_000_000,
       });
       expect(mapped.custom_profile_bindings).toEqual([]);
       expect(mapped.preflight.issues).toContainEqual(
@@ -266,8 +266,8 @@ describe('configuration mapping', () => {
   ])(
     'returns a stable $code issue instead of throwing',
     ({ source, code, path }) => {
-      expect(() => map(source, { requestDeadlineMs: 300_000 })).not.toThrow();
-      const mapped = map(source, { requestDeadlineMs: 300_000 });
+      expect(() => map(source, { requestDeadlineMs: 2_000_000 })).not.toThrow();
+      const mapped = map(source, { requestDeadlineMs: 2_000_000 });
       expect(mapped.custom_profile_bindings).toEqual([]);
       expect(mapped.preflight.issues).toContainEqual(
         expect.objectContaining({ code, path }),
@@ -279,7 +279,7 @@ describe('configuration mapping', () => {
     'rejects invalid eligible adapter record key %j without throwing',
     (adapterId) => {
       const mapped = map(customIdentityConfig(adapterId, 'acme-provider'), {
-        requestDeadlineMs: 300_000,
+        requestDeadlineMs: 2_000_000,
       });
       expect(mapped.custom_profile_bindings).toEqual([]);
       expect(mapped.preflight.issues).toContainEqual(
@@ -296,7 +296,7 @@ describe('configuration mapping', () => {
       },
     });
     const mapped = map(source, {
-      requestDeadlineMs: 300_000,
+      requestDeadlineMs: 2_000_000,
       credentials: credentials(),
     });
     expect(mapped.preflight.issues).toEqual([]);
@@ -311,7 +311,7 @@ describe('configuration mapping', () => {
 
   it('owns and freezes custom profile bindings independently of caller config', () => {
     const source = customProviderConfig();
-    const mapped = map(source, { requestDeadlineMs: 300_000 });
+    const mapped = map(source, { requestDeadlineMs: 2_000_000 });
     const digest = mapped.catalog.digest;
     expect(Object.isFrozen(mapped.custom_profile_bindings)).toBe(true);
     expect(Object.isFrozen(mapped.custom_profile_bindings[0]?.profile)).toBe(
@@ -501,7 +501,7 @@ describe('configuration mapping', () => {
   it('does not map injected v1 default groups as custom groups, but migrates explicit reserved groups', () => {
     const global = loadConfig('/definitely/missing/librarium-config.json');
     const direct = map(global, {
-      requestDeadlineMs: 300_000,
+      requestDeadlineMs: 2_000_000,
       credentials: credentials(),
       authoredGroups: configGroupProvenance(global),
     });
@@ -510,7 +510,7 @@ describe('configuration mapping', () => {
       groups: { quick: ['exa/search'] },
     });
     const mapped = map(merged, {
-      requestDeadlineMs: 300_000,
+      requestDeadlineMs: 2_000_000,
       credentials: credentials(),
       authoredGroups: configGroupProvenance(merged),
     });
@@ -645,7 +645,7 @@ describe('configuration mapping', () => {
         defaults: { llmWebSearch: false },
         providers: { 'openrouter-chat': { enabled: true } },
       }),
-      { requestDeadlineMs: 300_000, credentials: credentials() },
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
     );
     expect(
       defaultsOff.catalog.get('openrouter', 'chat')?.profile.result_kind,
@@ -658,7 +658,7 @@ describe('configuration mapping', () => {
           'openrouter-chat': { enabled: true, options: { webSearch: true } },
         },
       }),
-      { requestDeadlineMs: 300_000, credentials: credentials() },
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
     );
     expect(
       providerOverride.catalog.get('openrouter', 'chat')?.profile.result_kind,
@@ -675,7 +675,7 @@ describe('configuration mapping', () => {
           serpapi: { enabled: true, fallback: 'tavily' },
         },
       }),
-      { requestDeadlineMs: 300_000, credentials: credentials() },
+      { requestDeadlineMs: 2_000_000, credentials: credentials() },
     );
 
     expect(keys(mapped.reserve)).toEqual([
@@ -920,14 +920,41 @@ describe('configuration mapping', () => {
     });
     const missingDeadline = map(source);
     expect(missingDeadline.transport_defaults).toBeUndefined();
-    expect(missingDeadline.preflight.issues).toContainEqual(
-      expect.objectContaining({
-        code: 'configuration_request_deadline_required',
-        path: '/defaults/requestDeadlineMs',
-      }),
-    );
+    expect(missingDeadline.deadline_migration).toEqual({
+      kind: 'v1_request_deadline_migration',
+      max_parallel: 3,
+      inline_attempt_deadline_ms: 12_000,
+      raw_background_attempt_deadline_ms: 90_000,
+      poll_interval_ms: 7_000,
+      legacy_mode: 'sync',
+    });
+    expect(Object.isFrozen(missingDeadline.deadline_migration)).toBe(true);
+    expect(missingDeadline.preflight.issues).toEqual([]);
+    expect(missingDeadline.unresolved_transport_defaults).toEqual({
+      mode: 'sync',
+      limits: {
+        max_concurrency: 3,
+        inline_attempt_deadline_ms: 12_000,
+        poll_interval_ms: 7_000,
+      },
+      fallback: { kind: 'configured' },
+      refinement: { kind: 'disabled' },
+      budgets: {
+        max_estimated_cost_microusd: '100000',
+        max_actual_cost_microusd: '250000',
+      },
+    });
 
     const mapped = map(source, { requestDeadlineMs: 300_000 });
+    expect(mapped.deadline_migration).toEqual({
+      kind: 'v1_request_deadline_migration',
+      max_parallel: 3,
+      inline_attempt_deadline_ms: 12_000,
+      raw_background_attempt_deadline_ms: 90_000,
+      poll_interval_ms: 7_000,
+      legacy_mode: 'sync',
+      explicit_request_deadline_ms: 300_000,
+    });
     const normalized = normalizeConfigurationRequest(
       { query: 'v1 defaults', providers: ['exa'], ...mapped.transport_input },
       mapped.transport_defaults!,
@@ -957,11 +984,177 @@ describe('configuration mapping', () => {
     }
   });
 
+  it.each([
+    ['fractional maxParallel', { maxParallel: 1.5 }, '/defaults/maxParallel'],
+    ['negative timeout', { timeout: -1 }, '/defaults/timeout'],
+    ['fractional timeout', { timeout: 1.5 }, '/defaults/timeout'],
+    [
+      'unsafe asyncTimeout',
+      { asyncTimeout: Number.MAX_SAFE_INTEGER + 1 },
+      '/defaults/asyncTimeout',
+    ],
+  ])(
+    'withholds deadline migration context for %s',
+    (_label, defaults, path) => {
+      const mapped = map(config({ defaults }));
+      expect(mapped.deadline_migration).toBeUndefined();
+      expect(mapped.transport_defaults).toBeUndefined();
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({ path }),
+      );
+    },
+  );
+
+  it.each([1.5, -1, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid explicit request deadline %s at the config boundary',
+    (requestDeadlineMs) => {
+      const mapped = map(config(), { requestDeadlineMs });
+      expect(mapped.deadline_migration).toBeUndefined();
+      expect(mapped.transport_defaults).toBeUndefined();
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'configuration_deadline_invalid_integer',
+          path: '/defaults/requestDeadlineMs',
+        }),
+      );
+    },
+  );
+
+  it.each([
+    {
+      name: 'below inline attempt',
+      defaults: { timeout: 12, asyncTimeout: 10, asyncPollInterval: 5 },
+      requestDeadlineMs: 11_999,
+    },
+    {
+      name: 'below background attempt',
+      defaults: { timeout: 10, asyncTimeout: 12, asyncPollInterval: 5 },
+      requestDeadlineMs: 11_999,
+    },
+  ])('rejects an explicit deadline $name', (fixture) => {
+    const mapped = map(config({ defaults: fixture.defaults }), {
+      requestDeadlineMs: fixture.requestDeadlineMs,
+    });
+    expect(
+      mapped.preflight.issues.map(({ code, path }) => ({ code, path })),
+    ).toContainEqual({
+      code: 'configuration_request_deadline_less_than_attempt_deadline',
+      path: '/defaults/requestDeadlineMs',
+    });
+    expect(mapped.deadline_migration).toBeUndefined();
+    expect(mapped.transport_defaults).toBeUndefined();
+  });
+
+  it('accepts an explicit deadline equal to the larger attempt deadline', () => {
+    const mapped = map(
+      config({
+        defaults: { timeout: 10, asyncTimeout: 12, asyncPollInterval: 5 },
+      }),
+      { requestDeadlineMs: 12_000 },
+    );
+    expect(mapped.preflight.issues).toEqual([]);
+    expect(mapped.transport_defaults?.limits).toEqual({
+      max_concurrency: 6,
+      request_deadline_ms: 12_000,
+      inline_attempt_deadline_ms: 10_000,
+      background_attempt_deadline_ms: 12_000,
+      poll_interval_ms: 5_000,
+    });
+  });
+
+  it.each([
+    {
+      name: 'asyncTimeout above the 7-day contract maximum',
+      defaults: { asyncTimeout: 604_801 },
+      code: 'configuration_deadline_contract_maximum_exceeded',
+      path: '/defaults/asyncTimeout',
+    },
+    {
+      name: 'timeout seconds-to-milliseconds safe-integer overflow',
+      defaults: { timeout: Number.MAX_SAFE_INTEGER },
+      code: 'configuration_deadline_arithmetic_overflow',
+      path: '/defaults/timeout',
+    },
+    {
+      name: 'poll seconds-to-milliseconds safe-integer overflow',
+      defaults: { asyncPollInterval: Number.MAX_SAFE_INTEGER },
+      code: 'configuration_poll_interval_arithmetic_overflow',
+      path: '/defaults/asyncPollInterval',
+    },
+  ])('rejects $name with its exact diagnostic', (fixture) => {
+    const mapped = map(config({ defaults: fixture.defaults }));
+    expect(
+      mapped.preflight.issues.map(({ code, path }) => ({ code, path })),
+    ).toContainEqual({ code: fixture.code, path: fixture.path });
+    expect(mapped.deadline_migration).toBeUndefined();
+  });
+
+  it('rejects requestDeadlineMs one millisecond above seven days', () => {
+    const mapped = map(config(), { requestDeadlineMs: 604_800_001 });
+    expect(
+      mapped.preflight.issues.map(({ code, path }) => ({ code, path })),
+    ).toContainEqual({
+      code: 'configuration_deadline_contract_maximum_exceeded',
+      path: '/defaults/requestDeadlineMs',
+    });
+    expect(mapped.transport_defaults).toBeUndefined();
+  });
+
+  it.each([
+    ['fractional', 1.5, 'configuration_poll_interval_invalid_integer'],
+    ['negative', -1, 'configuration_poll_interval_invalid_integer'],
+    [
+      'unsafe',
+      Number.MAX_SAFE_INTEGER + 1,
+      'configuration_poll_interval_invalid_integer',
+    ],
+    ['out-of-range', 301, 'configuration_poll_interval_out_of_bounds'],
+  ])(
+    'rejects %s asyncPollInterval before canonical defaults',
+    (_label, asyncPollInterval, code) => {
+      const mapped = map(config({ defaults: { asyncPollInterval } }), {
+        requestDeadlineMs: 2_000_000,
+      });
+      expect(mapped.deadline_migration).toBeUndefined();
+      expect(mapped.transport_defaults).toBeUndefined();
+      expect(mapped.preflight.issues).toContainEqual(
+        expect.objectContaining({
+          code,
+          path: '/defaults/asyncPollInterval',
+        }),
+      );
+    },
+  );
+
+  it('rejects asyncPollInterval above the background attempt timeout', () => {
+    const mapped = map(
+      config({ defaults: { asyncTimeout: 2, asyncPollInterval: 3 } }),
+      { requestDeadlineMs: 2_000_000 },
+    );
+    expect(mapped.deadline_migration).toBeUndefined();
+    expect(mapped.transport_defaults).toBeUndefined();
+    expect(mapped.preflight.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'configuration_poll_interval_exceeds_background_attempt',
+        path: '/defaults/asyncPollInterval',
+      }),
+    );
+  });
+
+  it('accepts asyncPollInterval at the 300-second contract maximum', () => {
+    const mapped = map(
+      config({ defaults: { asyncTimeout: 300, asyncPollInterval: 300 } }),
+      { requestDeadlineMs: 300_000 },
+    );
+    expect(mapped.preflight.issues).toEqual([]);
+    expect(mapped.deadline_migration?.poll_interval_ms).toBe(300_000);
+  });
+
   it('withholds transport defaults when any configured budget is inexact', () => {
     const source = config({
       defaults: { maxCostUsd: 0.25, maxEstimatedCostUsd: 0.0000001 },
     });
-    const mapped = map(source, { requestDeadlineMs: 300_000 });
+    const mapped = map(source, { requestDeadlineMs: 2_000_000 });
     expect(mapped.transport_defaults).toBeUndefined();
     expect(mapped.preflight.issues).toContainEqual(
       expect.objectContaining({
@@ -1039,7 +1232,7 @@ describe('configuration mapping', () => {
         groups: { broken: ['nope/search'] },
         providers: { exa: { enabled: true, fallback: 'missing-adapter' } },
       }),
-      { requestDeadlineMs: 300_000 },
+      { requestDeadlineMs: 2_000_000 },
     );
     expect(
       mapped.preflight.issues.map(({ code, path }) => [code, path]),

--- a/tests/execution-plan-phases.test.ts
+++ b/tests/execution-plan-phases.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest';
+import type { ExecutionProfile } from '../src/contracts/domain/index.js';
+import {
+  admitResearchExecution,
+  type FrozenPlanningCatalog,
+  materializeResearchExecution,
+  type PlanningProfile,
+  type PreparationDependencies,
+  prepareResearchExecution,
+  type ResearchExecutionAdmission,
+} from '../src/core/execution-plan.js';
+import {
+  deriveV1RequestDeadline,
+  type V1RequestDeadlineMigrationContext,
+} from '../src/core/request-deadline-migration.js';
+
+function profile(providerId: string): ExecutionProfile {
+  return {
+    identity: {
+      provider_id: providerId,
+      profile_id: 'search',
+      target: { primary: { model_selection: 'not_applicable' } },
+    },
+    result_kind: 'search_results',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'search_endpoint',
+    access_mode: 'direct',
+    operator_id: providerId,
+    invocation: 'inline',
+    resumability: 'none',
+  };
+}
+
+function entry(candidate: ExecutionProfile, index: number): PlanningProfile {
+  return {
+    profile: candidate,
+    binding: {
+      adapter_id: `adapter-${index}`,
+      binding_id: `binding-${index}`,
+    },
+    enabled: true,
+    credentialed: true,
+    configuration_valid: true,
+  };
+}
+
+function request(overrides: Record<string, unknown> = {}) {
+  return {
+    query: 'phase parity',
+    mode: 'sync',
+    selector: { kind: 'default' },
+    fallback: { kind: 'configured' },
+    limits: {
+      max_concurrency: 2,
+      request_deadline_ms: 60_000,
+      inline_attempt_deadline_ms: 10_000,
+      background_attempt_deadline_ms: 20_000,
+      poll_interval_ms: 1_000,
+    },
+    exclusions: [],
+    refinement: { kind: 'disabled' },
+    ...overrides,
+  };
+}
+
+function dependencies() {
+  const counts = { clock: 0, ids: 0 };
+  const perScope = new Map<string, number>();
+  const value: PreparationDependencies = {
+    clock: {
+      now: () => {
+        counts.clock += 1;
+        return Date.parse('2026-08-09T12:00:00Z');
+      },
+    },
+    ids: {
+      next: (scope) => {
+        counts.ids += 1;
+        const next = (perScope.get(scope) ?? 0) + 1;
+        perScope.set(scope, next);
+        return `${scope}-${next}`;
+      },
+    },
+  };
+  return { counts, value };
+}
+
+function catalog(
+  primary: ExecutionProfile,
+  reserve?: ExecutionProfile,
+): FrozenPlanningCatalog {
+  return {
+    revision: 'phase-revision',
+    digest: 'phase-digest',
+    profiles: [entry(primary, 1), ...(reserve ? [entry(reserve, 2)] : [])],
+    resolveGroup: () => undefined,
+    resolveDefault: () => [primary.identity],
+    resolveConfiguredReserve: () => (reserve ? [reserve.identity] : []),
+  };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+  Object.freeze(value);
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return value;
+}
+
+function deadlineContext(): V1RequestDeadlineMigrationContext {
+  return {
+    kind: 'v1_request_deadline_migration',
+    max_parallel: 2,
+    inline_attempt_deadline_ms: 10_000,
+    raw_background_attempt_deadline_ms: 20_000,
+    poll_interval_ms: 1_000,
+    legacy_mode: 'sync',
+  };
+}
+
+describe('research execution admission phases', () => {
+  it('keeps native explicit-deadline preparation byte-equivalent', () => {
+    const built = catalog(profile('primary'), profile('reserve'));
+    const directDependencies = dependencies();
+    const phasedDependencies = dependencies();
+    const direct = prepareResearchExecution(
+      request(),
+      built,
+      directDependencies.value,
+    );
+    const admitted = admitResearchExecution(request(), built);
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+    const phased = materializeResearchExecution(
+      admitted.admission,
+      admitted.limits,
+      phasedDependencies.value,
+    );
+    expect(JSON.stringify(phased)).toBe(JSON.stringify(direct));
+    expect(phasedDependencies.counts).toEqual(directDependencies.counts);
+  });
+
+  it('does not reselect or drift after admission', () => {
+    const first = profile('first');
+    const second = profile('second');
+    let selections = 0;
+    const built: FrozenPlanningCatalog = {
+      revision: 'drift-revision',
+      digest: 'drift-digest',
+      profiles: [entry(first, 1), entry(second, 2)],
+      resolveGroup: () => undefined,
+      resolveDefault: () => {
+        selections += 1;
+        return [selections === 1 ? first.identity : second.identity];
+      },
+      resolveConfiguredReserve: () => [],
+    };
+    const admitted = admitResearchExecution(
+      request({ fallback: { kind: 'disabled' } }),
+      built,
+    );
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+
+    first.identity.provider_id = 'mutated-after-admission';
+    const effects = dependencies();
+    const materialized = materializeResearchExecution(
+      admitted.admission,
+      admitted.limits,
+      effects.value,
+    );
+    expect(materialized.ok).toBe(true);
+    if (!materialized.ok) return;
+    expect(selections).toBe(1);
+    expect(
+      materialized.prepared.request.slots[0]?.primary.identity.provider_id,
+    ).toBe('first');
+    expect(Object.isFrozen(admitted.admission)).toBe(true);
+    expect(
+      Object.isFrozen(admitted.admission.primaries[0]?.entry.profile),
+    ).toBe(true);
+  });
+
+  it('rejects invalid finalized limits before clock or ID effects', () => {
+    const admitted = admitResearchExecution(
+      request({ fallback: { kind: 'disabled' } }),
+      catalog(profile('primary')),
+    );
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+    const effects = dependencies();
+    const result = materializeResearchExecution(
+      admitted.admission,
+      { ...admitted.limits, request_deadline_ms: 500 },
+      effects.value,
+    );
+    expect(result.ok).toBe(false);
+    expect(effects.counts).toEqual({ clock: 0, ids: 0 });
+  });
+
+  it('rejects a forged admission before clock or ID effects', () => {
+    const effects = dependencies();
+    const result = materializeResearchExecution(
+      {} as ResearchExecutionAdmission,
+      request().limits,
+      effects.value,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [expect.objectContaining({ code: 'research_admission_invalid' })],
+    });
+    expect(effects.counts).toEqual({ clock: 0, ids: 0 });
+  });
+
+  it('rejects stolen-brand deep and partial admission forgeries at both boundaries', () => {
+    const admitted = admitResearchExecution(
+      request({ fallback: { kind: 'disabled' } }),
+      catalog(profile('primary')),
+    );
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+
+    const [stolenBrand] = Object.getOwnPropertySymbols(admitted.admission);
+    expect(stolenBrand).toBeDefined();
+    if (!stolenBrand) return;
+
+    const deepForgery = structuredClone({
+      request: admitted.admission.request,
+      primaries: admitted.admission.primaries,
+      reserve: admitted.admission.reserve,
+      provisional_slots: admitted.admission.provisional_slots,
+      catalog: admitted.admission.catalog,
+      notices: admitted.admission.notices,
+    }) as Record<PropertyKey, unknown>;
+    Object.defineProperty(deepForgery, stolenBrand, {
+      value: true,
+      enumerable: true,
+    });
+    deepFreeze(deepForgery);
+
+    const partialForgery = {
+      ...admitted.admission,
+      request: { ...admitted.admission.request, query: 'forged mutation' },
+    } as unknown as ResearchExecutionAdmission;
+    Object.freeze(partialForgery);
+    expect(Object.isFrozen(partialForgery)).toBe(true);
+    expect(Object.isFrozen(partialForgery.request)).toBe(false);
+
+    for (const forgery of [
+      deepForgery as unknown as ResearchExecutionAdmission,
+      partialForgery,
+    ]) {
+      const derived = deriveV1RequestDeadline(deadlineContext(), forgery);
+      expect(derived).toMatchObject({
+        ok: false,
+        issues: [
+          expect.objectContaining({ code: 'research_admission_invalid' }),
+        ],
+      });
+
+      const effects = dependencies();
+      const materialized = materializeResearchExecution(
+        forgery,
+        admitted.limits,
+        effects.value,
+      );
+      expect(materialized).toMatchObject({
+        ok: false,
+        issues: [
+          expect.objectContaining({ code: 'research_admission_invalid' }),
+        ],
+      });
+      expect(effects.counts).toEqual({ clock: 0, ids: 0 });
+    }
+  });
+});

--- a/tests/request-deadline-migration.test.ts
+++ b/tests/request-deadline-migration.test.ts
@@ -1,0 +1,592 @@
+import { describe, expect, it } from 'vitest';
+import type { ExecutionProfile } from '../src/contracts/domain/index.js';
+import {
+  admitResearchExecution,
+  type FrozenPlanningCatalog,
+  type PlanningProfile,
+  type ResearchExecutionAdmission,
+} from '../src/core/execution-plan.js';
+import {
+  BUILTIN_PROFILE_BINDING_SPECS,
+  buildProfileBindings,
+} from '../src/core/profile-bindings.js';
+import { BUILTIN_PROVIDER_DEFINITIONS } from '../src/core/provider-descriptor.js';
+import {
+  BUILTIN_PROVIDER_CATALOG,
+  catalogProfileRefs,
+} from '../src/core/provider-profiles.js';
+import {
+  deriveV1RequestDeadline,
+  V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE,
+  type V1RequestDeadlineMigrationContext,
+  v1BackgroundTransportOverheadMs,
+} from '../src/core/request-deadline-migration.js';
+import { RESEARCH_REQUEST_LIMITS } from '../src/core/research-request.js';
+
+function profile(
+  providerId: string,
+  invocation: 'inline' | 'background' = 'inline',
+): ExecutionProfile {
+  return {
+    identity: {
+      provider_id: providerId,
+      profile_id: invocation === 'inline' ? 'search' : 'research',
+      target: { primary: { model_selection: 'not_applicable' } },
+    },
+    result_kind: 'search_results',
+    observation_mode: 'api_output',
+    corpora: ['web'],
+    retrieval_method: 'search_endpoint',
+    access_mode: 'direct',
+    operator_id: providerId,
+    invocation,
+    resumability: invocation === 'inline' ? 'none' : 'durable',
+  };
+}
+
+function context(
+  overrides: Partial<V1RequestDeadlineMigrationContext> = {},
+): V1RequestDeadlineMigrationContext {
+  return {
+    kind: 'v1_request_deadline_migration',
+    max_parallel: 2,
+    inline_attempt_deadline_ms: 10_000,
+    raw_background_attempt_deadline_ms: 20_000,
+    poll_interval_ms: 1_000,
+    legacy_mode: 'sync',
+    ...overrides,
+  };
+}
+
+function admittedPlan(
+  primaries: readonly ExecutionProfile[],
+  reserve: readonly ExecutionProfile[] = [],
+): ResearchExecutionAdmission {
+  const entriesByIdentity = new Map<string, PlanningProfile>();
+  for (const candidate of [...primaries, ...reserve]) {
+    const key = JSON.stringify(candidate.identity);
+    if (entriesByIdentity.has(key)) continue;
+    const reserveOnly = candidate.identity.provider_id === 'disabled-reserve';
+    entriesByIdentity.set(key, {
+      profile: candidate,
+      binding: {
+        adapter_id: `adapter-${entriesByIdentity.size}`,
+        binding_id: `binding-${entriesByIdentity.size}`,
+      },
+      enabled: !reserveOnly,
+      credentialed: true,
+      configuration_valid: true,
+      ...(reserveOnly && { reserve_only: true }),
+    });
+  }
+  const catalog: FrozenPlanningCatalog = {
+    revision: 'deadline-test-revision',
+    digest: 'deadline-test-digest',
+    profiles: [...entriesByIdentity.values()],
+    resolveGroup: () => undefined,
+    resolveDefault: () => primaries.map((candidate) => candidate.identity),
+    resolveConfiguredReserve: () =>
+      reserve.map((candidate) => candidate.identity),
+  };
+  const admitted = admitResearchExecution(
+    {
+      query: 'deadline test',
+      mode: 'sync',
+      selector: { kind: 'default' },
+      fallback:
+        reserve.length === 0 ? { kind: 'disabled' } : { kind: 'configured' },
+      limits: {
+        max_concurrency: 2,
+        request_deadline_ms: 600_000,
+        inline_attempt_deadline_ms: 10_000,
+        background_attempt_deadline_ms: 20_000,
+        poll_interval_ms: 1_000,
+      },
+      exclusions: [],
+      refinement: { kind: 'disabled' },
+    },
+    catalog,
+  );
+  if (!admitted.ok) throw new Error(JSON.stringify(admitted.issues));
+  return admitted.admission;
+}
+
+describe('v1 total request-deadline migration', () => {
+  it('uses one primary attempt allowance when there is no reserve', () => {
+    expect(
+      deriveV1RequestDeadline(context(), admittedPlan([profile('inline-one')])),
+    ).toMatchObject({
+      ok: true,
+      request_deadline_ms: 20_000,
+      source: 'derived_v1_plan',
+    });
+  });
+
+  it('list-schedules primaries in selection order across max_parallel workers', () => {
+    const result = deriveV1RequestDeadline(
+      context({ max_parallel: 2 }),
+      admittedPlan([
+        profile('inline-one'),
+        profile('inline-two'),
+        profile('inline-three'),
+        profile('inline-four'),
+        profile('inline-five'),
+      ]),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 30_000 });
+  });
+
+  it('uses deterministic selection order when primary durations differ', () => {
+    const result = deriveV1RequestDeadline(
+      context({ max_parallel: 2 }),
+      admittedPlan([
+        profile('background-one', 'background'),
+        profile('inline-one'),
+        profile('inline-two'),
+        profile('background-two', 'background'),
+      ]),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 40_000 });
+  });
+
+  it('adds every unique reserve sequentially despite primary parallelism', () => {
+    const result = deriveV1RequestDeadline(
+      context({ max_parallel: 64 }),
+      admittedPlan(
+        [profile('primary')],
+        [profile('reserve-one'), profile('reserve-two')],
+      ),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 30_000 });
+  });
+
+  it('keeps inline and background allowances distinct and adds known transport overhead', () => {
+    const result = deriveV1RequestDeadline(
+      context({ max_parallel: 1 }),
+      admittedPlan([
+        profile('inline'),
+        profile('openai-research', 'background'),
+      ]),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 110_000 });
+  });
+
+  it('uses trusted custom profile invocation as the canonical attempt class', () => {
+    // Trusted custom executionProfile metadata is the contract assertion. A
+    // runtime adapter which disagrees with it violates that trust boundary.
+    const result = deriveV1RequestDeadline(
+      context(),
+      admittedPlan([profile('trusted-custom-inline')]),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 20_000 });
+  });
+
+  it('counts a selected disabled reserve-only profile but deduplicates reserve identities', () => {
+    // Availability is settled by selection before this API. A disabled v1
+    // fallback admitted as reserve-only is therefore a concrete candidate and
+    // must count exactly once even if defensive input repeats it.
+    const disabledReserve = profile('disabled-reserve');
+    const result = deriveV1RequestDeadline(
+      context(),
+      admittedPlan(
+        [profile('primary')],
+        [disabledReserve, disabledReserve, profile('reserve-two')],
+      ),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 30_000 });
+  });
+
+  it('deduplicates reserve identities with collision-free canonical tuple keys', () => {
+    const slashInProvider = {
+      ...profile('a/b'),
+      identity: {
+        ...profile('a/b').identity,
+        profile_id: 'c',
+      },
+    };
+    const slashInProfile = {
+      ...profile('a'),
+      identity: {
+        ...profile('a').identity,
+        profile_id: 'b/c',
+      },
+    };
+    const result = deriveV1RequestDeadline(
+      context(),
+      admittedPlan([profile('primary')], [slashInProvider, slashInProfile]),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 30_000 });
+  });
+
+  it('lets a valid explicit request deadline override the formula', () => {
+    const result = deriveV1RequestDeadline(
+      context({ explicit_request_deadline_ms: 300_000 }),
+      admittedPlan(
+        [profile('primary')],
+        [
+          profile('openai-research', 'background'),
+          profile('gemini-deep', 'background'),
+        ],
+      ),
+    );
+    expect(result).toEqual({
+      ok: true,
+      request_deadline_ms: 300_000,
+      effective_background_attempt_deadline_ms: 110_000,
+      derived_full_plan_minimum_ms: 230_000,
+      source: 'explicit_override',
+      notices: [],
+    });
+  });
+
+  it('warns when an authoritative explicit total may truncate the full plan', () => {
+    const result = deriveV1RequestDeadline(
+      context({
+        max_parallel: 1,
+        explicit_request_deadline_ms: 120_000,
+      }),
+      admittedPlan([
+        profile('openai-research', 'background'),
+        profile('background-two', 'background'),
+      ]),
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      request_deadline_ms: 120_000,
+      effective_background_attempt_deadline_ms: 100_000,
+      derived_full_plan_minimum_ms: 200_000,
+      source: 'explicit_override',
+      notices: [
+        expect.objectContaining({
+          code: 'explicit_request_deadline_may_truncate_plan',
+          path: '/deadline_migration/explicit_request_deadline_ms',
+        }),
+      ],
+    });
+  });
+
+  it('rejects an explicit total below the effective attempt cap', () => {
+    const result = deriveV1RequestDeadline(
+      context({ explicit_request_deadline_ms: 99_999 }),
+      admittedPlan([profile('openai-research', 'background')]),
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [
+        expect.objectContaining({
+          code: 'request_deadline_less_than_attempt_deadline',
+        }),
+      ],
+    });
+  });
+
+  it('uses the maximum selected overhead as one reachable global background attempt cap', () => {
+    const result = deriveV1RequestDeadline(
+      context(),
+      admittedPlan([
+        profile('openai-research', 'background'),
+        profile('gemini-deep', 'background'),
+        profile('unknown-background', 'background'),
+      ]),
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      effective_background_attempt_deadline_ms: 110_000,
+      derived_full_plan_minimum_ms: 220_000,
+      request_deadline_ms: 220_000,
+    });
+  });
+
+  it('does not treat legacy async polling cadence as deadline allowance', () => {
+    const plan = admittedPlan([profile('background', 'background')]);
+    const frequent = deriveV1RequestDeadline(
+      context({ poll_interval_ms: 1_000 }),
+      plan,
+    );
+    const sparse = deriveV1RequestDeadline(
+      context({ poll_interval_ms: 20_000 }),
+      plan,
+    );
+    expect(frequent).toMatchObject({ ok: true, request_deadline_ms: 20_000 });
+    expect(sparse).toEqual(frequent);
+  });
+
+  it.each(['async', 'mixed'] as const)(
+    'emits the bounded wait migration notice for legacy %s mode',
+    (legacyMode) => {
+      const result = deriveV1RequestDeadline(
+        context({ legacy_mode: legacyMode }),
+        admittedPlan([profile('primary')]),
+      );
+      expect(result.notices).toContainEqual(
+        expect.objectContaining({
+          code: 'legacy_wait_is_bounded_in_v2',
+          path: '/deadline_migration/legacy_mode',
+        }),
+      );
+    },
+  );
+
+  it.each([
+    {
+      label: 'invalid migration kind',
+      overrides: {
+        kind: 'forged-kind',
+      } as unknown as Partial<V1RequestDeadlineMigrationContext>,
+      code: 'request_deadline_invalid_migration_context',
+      path: '/deadline_migration/kind',
+    },
+    {
+      label: 'invalid legacy mode',
+      overrides: {
+        legacy_mode: 'forever',
+      } as unknown as Partial<V1RequestDeadlineMigrationContext>,
+      code: 'request_deadline_invalid_legacy_mode',
+      path: '/deadline_migration/legacy_mode',
+    },
+    {
+      label: 'fractional concurrency',
+      overrides: { max_parallel: 1.5 },
+      code: 'request_deadline_concurrency_out_of_bounds',
+      path: '/deadline_migration/max_parallel',
+    },
+    {
+      label: 'concurrency above the maximum',
+      overrides: { max_parallel: 65 },
+      code: 'request_deadline_concurrency_out_of_bounds',
+      path: '/deadline_migration/max_parallel',
+    },
+    {
+      label: 'fractional inline deadline',
+      overrides: { inline_attempt_deadline_ms: 1.5 },
+      code: 'request_deadline_invalid_integer',
+      path: '/deadline_migration/inline_attempt_deadline_ms',
+    },
+    {
+      label: 'negative background deadline',
+      overrides: { raw_background_attempt_deadline_ms: -1 },
+      code: 'request_deadline_invalid_integer',
+      path: '/deadline_migration/raw_background_attempt_deadline_ms',
+    },
+    {
+      label: 'unsafe inline deadline',
+      overrides: { inline_attempt_deadline_ms: Number.MAX_SAFE_INTEGER + 1 },
+      code: 'request_deadline_invalid_integer',
+      path: '/deadline_migration/inline_attempt_deadline_ms',
+    },
+    {
+      label: 'poll interval below its minimum',
+      overrides: { poll_interval_ms: 99 },
+      code: 'request_deadline_poll_interval_out_of_bounds',
+      path: '/deadline_migration/poll_interval_ms',
+    },
+    {
+      label: 'poll interval above the background attempt',
+      overrides: {
+        raw_background_attempt_deadline_ms: 1_000,
+        poll_interval_ms: 2_000,
+      },
+      code: 'request_deadline_poll_interval_exceeds_background_attempt',
+      path: '/deadline_migration/poll_interval_ms',
+    },
+    {
+      label: 'invalid explicit request deadline integer',
+      overrides: { explicit_request_deadline_ms: -1 },
+      code: 'request_deadline_invalid_integer',
+      path: '/deadline_migration/explicit_request_deadline_ms',
+    },
+  ])('rejects $label with the exact context diagnostic', (fixture) => {
+    const result = deriveV1RequestDeadline(
+      context(fixture.overrides),
+      admittedPlan([profile('primary')]),
+    );
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok) return;
+    expect(
+      result.issues.map(({ code, path }) => ({ code, path })),
+    ).toContainEqual({ code: fixture.code, path: fixture.path });
+  });
+
+  it('accepts the exact 7-day boundary', () => {
+    const half = RESEARCH_REQUEST_LIMITS.maxDeadlineMs / 2;
+    const result = deriveV1RequestDeadline(
+      context({
+        max_parallel: 1,
+        inline_attempt_deadline_ms: half,
+      }),
+      admittedPlan([profile('one'), profile('two')]),
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      request_deadline_ms: RESEARCH_REQUEST_LIMITS.maxDeadlineMs,
+    });
+  });
+
+  it('rejects one millisecond beyond the 7-day boundary without clamping', () => {
+    const plusOne = deriveV1RequestDeadline(
+      context({
+        max_parallel: 1,
+        inline_attempt_deadline_ms: 1_000,
+        raw_background_attempt_deadline_ms:
+          RESEARCH_REQUEST_LIMITS.maxDeadlineMs - 999,
+      }),
+      admittedPlan([profile('one', 'background')], [profile('one-ms-reserve')]),
+    );
+    expect(plusOne).toMatchObject({
+      ok: false,
+      issues: [
+        expect.objectContaining({
+          code: 'request_deadline_contract_maximum_exceeded',
+        }),
+      ],
+    });
+  });
+
+  it('reports safe-integer overflow separately from the contract maximum', () => {
+    const result = deriveV1RequestDeadline(
+      context({
+        max_parallel: 1,
+        raw_background_attempt_deadline_ms: Number.MAX_SAFE_INTEGER,
+      }),
+      admittedPlan([profile('openai-research', 'background')]),
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [
+        expect.objectContaining({
+          code: 'request_deadline_arithmetic_overflow',
+          path: '/deadline_migration/effective_background_attempt_deadline_ms',
+        }),
+      ],
+    });
+  });
+
+  it('classifies audited OpenAI, Gemini, and Perplexity background overhead explicitly', () => {
+    expect(V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE).toEqual({
+      'openai-research/research': {
+        submit_timeout_ms: 30_000,
+        final_poll_sleep_ms: 5_000,
+        poll_timeout_ms: 15_000,
+        retrieve_timeout_ms: 30_000,
+        total_ms: 80_000,
+      },
+      'gemini-deep/research': {
+        submit_timeout_ms: 30_000,
+        final_poll_sleep_ms: 15_000,
+        poll_timeout_ms: 15_000,
+        retrieve_timeout_ms: 30_000,
+        total_ms: 90_000,
+      },
+      'perplexity-sonar-deep/research': {
+        submit_timeout_ms: 30_000,
+        final_poll_sleep_ms: 0,
+        poll_timeout_ms: 15_000,
+        retrieve_timeout_ms: 30_000,
+        total_ms: 75_000,
+      },
+    });
+    expect(
+      v1BackgroundTransportOverheadMs(profile('openai-research', 'background')),
+    ).toBe(80_000);
+    expect(
+      v1BackgroundTransportOverheadMs(profile('gemini-deep', 'background')),
+    ).toBe(90_000);
+    expect(
+      v1BackgroundTransportOverheadMs(
+        profile('perplexity-sonar-deep', 'background'),
+      ),
+    ).toBe(75_000);
+    expect(
+      v1BackgroundTransportOverheadMs(
+        profile('unknown-background', 'background'),
+      ),
+    ).toBe(0);
+    expect(v1BackgroundTransportOverheadMs(profile('openai-research'))).toBe(0);
+  });
+
+  it('keeps target identity in reserve deduplication', () => {
+    const first = profile('targeted-reserve');
+    const second = profile('targeted-reserve');
+    first.identity.target.primary = {
+      model_selection: 'fixed',
+      kind: 'model',
+      target_id: 'model-one',
+    };
+    second.identity.target.primary = {
+      model_selection: 'fixed',
+      kind: 'model',
+      target_id: 'model-two',
+    };
+    const result = deriveV1RequestDeadline(
+      context(),
+      admittedPlan([profile('primary')], [first, second]),
+    );
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 30_000 });
+  });
+
+  it('matches v2 invocation to the v1 tier deadline class for every built-in adapter', () => {
+    const expectedAdapterIds = [
+      'perplexity-sonar-deep',
+      'perplexity-deep-research',
+      'perplexity-advanced-deep',
+      'openai-research',
+      'gemini-deep',
+      'perplexity-sonar-pro',
+      'perplexity-pro-search',
+      'gemini-grounded',
+      'grok',
+      'openrouter-online',
+      'brave-answers',
+      'you-research',
+      'kagi-fastgpt',
+      'exa',
+      'perplexity-search',
+      'brave-search',
+      'jina-search',
+      'firecrawl-search',
+      'searchapi',
+      'serpapi',
+      'tavily',
+      'searchapi-chatgpt',
+      'searchapi-gemini',
+      'searchapi-perplexity',
+      'searchapi-google-ai-mode',
+      'searchapi-bing-copilot',
+      'searchapi-google-ai-overview',
+      'claude',
+      'openai-chat',
+      'gemini-chat',
+      'openrouter-chat',
+    ];
+    expect(
+      BUILTIN_PROFILE_BINDING_SPECS.map((spec) => spec.adapter_id),
+    ).toEqual(expectedAdapterIds);
+    expect(new Set(expectedAdapterIds).size).toBe(31);
+    const declarations = new Map(
+      catalogProfileRefs(BUILTIN_PROVIDER_CATALOG).map(
+        ({ entry, declaration }) => [
+          `${entry.provider_id}/${declaration.profile_id}`,
+          declaration,
+        ],
+      ),
+    );
+    const bindings = buildProfileBindings(declarations);
+    const tiers = new Map(
+      BUILTIN_PROVIDER_DEFINITIONS.map((definition) => [
+        definition.id,
+        definition.tier,
+      ]),
+    );
+    for (const spec of BUILTIN_PROFILE_BINDING_SPECS) {
+      const resolved = bindings
+        .get(`${spec.provider_id}/${spec.profile_id}`)
+        ?.resolve().profile;
+      expect(resolved, spec.adapter_id).toBeDefined();
+      expect(resolved?.invocation, spec.adapter_id).toBe(
+        tiers.get(spec.adapter_id) === 'deep-research'
+          ? 'background'
+          : 'inline',
+      );
+    }
+  });
+});

--- a/tests/request-deadline-migration.test.ts
+++ b/tests/request-deadline-migration.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   deriveV1RequestDeadline,
   V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE,
+  V1_SAFE_GET_RETRY_CEILING,
   type V1RequestDeadlineMigrationContext,
   v1BackgroundTransportOverheadMs,
 } from '../src/core/request-deadline-migration.js';
@@ -168,7 +169,7 @@ describe('v1 total request-deadline migration', () => {
         profile('openai-research', 'background'),
       ]),
     );
-    expect(result).toMatchObject({ ok: true, request_deadline_ms: 110_000 });
+    expect(result).toMatchObject({ ok: true, request_deadline_ms: 425_000 });
   });
 
   it('uses trusted custom profile invocation as the canonical attempt class', () => {
@@ -220,7 +221,7 @@ describe('v1 total request-deadline migration', () => {
 
   it('lets a valid explicit request deadline override the formula', () => {
     const result = deriveV1RequestDeadline(
-      context({ explicit_request_deadline_ms: 300_000 }),
+      context({ explicit_request_deadline_ms: 1_000_000 }),
       admittedPlan(
         [profile('primary')],
         [
@@ -231,9 +232,9 @@ describe('v1 total request-deadline migration', () => {
     );
     expect(result).toEqual({
       ok: true,
-      request_deadline_ms: 300_000,
-      effective_background_attempt_deadline_ms: 110_000,
-      derived_full_plan_minimum_ms: 230_000,
+      request_deadline_ms: 1_000_000,
+      effective_background_attempt_deadline_ms: 425_000,
+      derived_full_plan_minimum_ms: 860_000,
       source: 'explicit_override',
       notices: [],
     });
@@ -243,7 +244,7 @@ describe('v1 total request-deadline migration', () => {
     const result = deriveV1RequestDeadline(
       context({
         max_parallel: 1,
-        explicit_request_deadline_ms: 120_000,
+        explicit_request_deadline_ms: 500_000,
       }),
       admittedPlan([
         profile('openai-research', 'background'),
@@ -252,9 +253,9 @@ describe('v1 total request-deadline migration', () => {
     );
     expect(result).toMatchObject({
       ok: true,
-      request_deadline_ms: 120_000,
-      effective_background_attempt_deadline_ms: 100_000,
-      derived_full_plan_minimum_ms: 200_000,
+      request_deadline_ms: 500_000,
+      effective_background_attempt_deadline_ms: 415_000,
+      derived_full_plan_minimum_ms: 830_000,
       source: 'explicit_override',
       notices: [
         expect.objectContaining({
@@ -267,7 +268,7 @@ describe('v1 total request-deadline migration', () => {
 
   it('rejects an explicit total below the effective attempt cap', () => {
     const result = deriveV1RequestDeadline(
-      context({ explicit_request_deadline_ms: 99_999 }),
+      context({ explicit_request_deadline_ms: 414_999 }),
       admittedPlan([profile('openai-research', 'background')]),
     );
     expect(result).toMatchObject({
@@ -291,9 +292,9 @@ describe('v1 total request-deadline migration', () => {
     );
     expect(result).toMatchObject({
       ok: true,
-      effective_background_attempt_deadline_ms: 110_000,
-      derived_full_plan_minimum_ms: 220_000,
-      request_deadline_ms: 220_000,
+      effective_background_attempt_deadline_ms: 425_000,
+      derived_full_plan_minimum_ms: 850_000,
+      request_deadline_ms: 850_000,
     });
   });
 
@@ -442,6 +443,39 @@ describe('v1 total request-deadline migration', () => {
     });
   });
 
+  it('applies selected retry overhead exactly at the 7-day boundary without clamping', () => {
+    const selected = admittedPlan([profile('gemini-deep', 'background')]);
+    const boundary = deriveV1RequestDeadline(
+      context({
+        max_parallel: 1,
+        raw_background_attempt_deadline_ms: 604_395_000,
+      }),
+      selected,
+    );
+    expect(boundary).toMatchObject({
+      ok: true,
+      request_deadline_ms: 604_800_000,
+      effective_background_attempt_deadline_ms: 604_800_000,
+    });
+
+    const plusOne = deriveV1RequestDeadline(
+      context({
+        max_parallel: 1,
+        raw_background_attempt_deadline_ms: 604_395_001,
+      }),
+      selected,
+    );
+    expect(plusOne).toMatchObject({
+      ok: false,
+      issues: [
+        expect.objectContaining({
+          code: 'request_deadline_contract_maximum_exceeded',
+          path: '/deadline_migration/effective_background_attempt_deadline_ms',
+        }),
+      ],
+    });
+  });
+
   it('reports safe-integer overflow separately from the contract maximum', () => {
     const result = deriveV1RequestDeadline(
       context({
@@ -461,41 +495,71 @@ describe('v1 total request-deadline migration', () => {
     });
   });
 
+  it('pins the audited safe-GET Retry-After ceiling above jitter backoff', () => {
+    expect(V1_SAFE_GET_RETRY_CEILING).toEqual({
+      max_attempts: 4,
+      retry_delay_count: 3,
+      retry_after_cap_ms: 30_000,
+      jitter_caps_ms: [1_000, 2_000, 4_000],
+      maximum_retry_delay_ms: 90_000,
+    });
+    expect(3 * 30_000).toBeGreaterThan(1_000 + 2_000 + 4_000);
+    expect(V1_SAFE_GET_RETRY_CEILING.maximum_retry_delay_ms).toBe(3 * 30_000);
+  });
+
   it('classifies audited OpenAI, Gemini, and Perplexity background overhead explicitly', () => {
     expect(V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE).toEqual({
       'openai-research/research': {
         submit_timeout_ms: 30_000,
         final_poll_sleep_ms: 5_000,
-        poll_timeout_ms: 15_000,
-        retrieve_timeout_ms: 30_000,
-        total_ms: 80_000,
+        poll_attempt_timeout_ms: 15_000,
+        poll_ceiling_ms: 150_000,
+        retrieve_attempt_timeout_ms: 30_000,
+        retrieve_ceiling_ms: 210_000,
+        total_ms: 395_000,
       },
       'gemini-deep/research': {
         submit_timeout_ms: 30_000,
         final_poll_sleep_ms: 15_000,
-        poll_timeout_ms: 15_000,
-        retrieve_timeout_ms: 30_000,
-        total_ms: 90_000,
+        poll_attempt_timeout_ms: 15_000,
+        poll_ceiling_ms: 150_000,
+        retrieve_attempt_timeout_ms: 30_000,
+        retrieve_ceiling_ms: 210_000,
+        total_ms: 405_000,
       },
       'perplexity-sonar-deep/research': {
         submit_timeout_ms: 30_000,
         final_poll_sleep_ms: 0,
-        poll_timeout_ms: 15_000,
-        retrieve_timeout_ms: 30_000,
-        total_ms: 75_000,
+        poll_attempt_timeout_ms: 15_000,
+        poll_ceiling_ms: 150_000,
+        retrieve_attempt_timeout_ms: 30_000,
+        retrieve_ceiling_ms: 210_000,
+        total_ms: 390_000,
       },
     });
+    for (const policy of Object.values(
+      V1_BACKGROUND_TRANSPORT_OVERHEAD_BY_PROFILE,
+    )) {
+      expect(policy.poll_ceiling_ms).toBe(4 * 15_000 + 3 * 30_000);
+      expect(policy.retrieve_ceiling_ms).toBe(4 * 30_000 + 3 * 30_000);
+      expect(policy.total_ms).toBe(
+        policy.submit_timeout_ms +
+          policy.final_poll_sleep_ms +
+          policy.poll_ceiling_ms +
+          policy.retrieve_ceiling_ms,
+      );
+    }
     expect(
       v1BackgroundTransportOverheadMs(profile('openai-research', 'background')),
-    ).toBe(80_000);
+    ).toBe(395_000);
     expect(
       v1BackgroundTransportOverheadMs(profile('gemini-deep', 'background')),
-    ).toBe(90_000);
+    ).toBe(405_000);
     expect(
       v1BackgroundTransportOverheadMs(
         profile('perplexity-sonar-deep', 'background'),
       ),
-    ).toBe(75_000);
+    ).toBe(390_000);
     expect(
       v1BackgroundTransportOverheadMs(
         profile('unknown-background', 'background'),

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -882,29 +882,6 @@ describe('private shadow compilation', () => {
     }
     expect(collisionDependencies.calls()).toBe(0);
 
-    const deadlineSource = config({ providers: { exa: { enabled: true } } });
-    const deadlineDependencies = countedPreparation();
-    const deadline = compileShadowRequest({
-      config: deadlineSource,
-      authoredGroups: { global: deadlineSource.groups, project: {} },
-      credentials: credentials(),
-      transport: {
-        kind: 'mcp',
-        input: { query: 'deadline', providers: ['exa'] },
-      },
-      preparation: deadlineDependencies.dependencies,
-    });
-    expect(deadline.ok).toBe(false);
-    if (!deadline.ok) {
-      expect(deadline.issues).toEqual([
-        expect.objectContaining({
-          code: 'configuration_request_deadline_required',
-          path: '/defaults/requestDeadlineMs',
-        }),
-      ]);
-    }
-    expect(deadlineDependencies.calls()).toBe(0);
-
     const inexactSource = config({
       providers: { exa: { enabled: true } },
       defaults: { maxEstimatedCostUsd: 0.0000001 },
@@ -925,6 +902,29 @@ describe('private shadow compilation', () => {
       );
     }
     expect(inexactDependencies.calls()).toBe(0);
+  });
+
+  it('derives a bounded shadow deadline before materialization effects', () => {
+    const source = config({ providers: { exa: { enabled: true } } });
+    const dependencies = countedPreparation();
+    const result = compileShadowRequest({
+      config: source,
+      authoredGroups: { global: source.groups, project: {} },
+      credentials: credentials(),
+      transport: {
+        kind: 'mcp',
+        input: { query: 'deadline', providers: ['exa'] },
+      },
+      preparation: dependencies.dependencies,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.prepared.policy.limits).toMatchObject({
+        request_deadline_ms: 300_000,
+        background_attempt_deadline_ms: 300_000,
+      });
+    }
+    expect(dependencies.calls()).toBe(3);
   });
 
   it('sorts merged diagnostics globally and prepares CLI, MCP, and silent MCP identically', () => {

--- a/tests/workers/shadow-compilation.test.ts
+++ b/tests/workers/shadow-compilation.test.ts
@@ -150,8 +150,8 @@ describe('private shadow compiler in workerd', () => {
     expect(result.ok, JSON.stringify(result)).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.policy.limits).toMatchObject({
-      request_deadline_ms: 210_000,
-      background_attempt_deadline_ms: 210_000,
+      request_deadline_ms: 525_000,
+      background_attempt_deadline_ms: 525_000,
     });
   });
 
@@ -173,7 +173,7 @@ describe('private shadow compiler in workerd', () => {
           GEMINI_API_KEY: 'worker-test-key',
         },
       },
-      requestDeadlineMs: 250_000,
+      requestDeadlineMs: 600_000,
       transport: {
         kind: 'silent_mcp',
         input: {
@@ -195,12 +195,13 @@ describe('private shadow compiler in workerd', () => {
     expect(result.ok, JSON.stringify(result)).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.policy.limits).toMatchObject({
-      request_deadline_ms: 250_000,
-      background_attempt_deadline_ms: 210_000,
+      request_deadline_ms: 600_000,
+      background_attempt_deadline_ms: 525_000,
     });
     expect(result.notices).toContainEqual(
       expect.objectContaining({
         code: 'explicit_request_deadline_may_truncate_plan',
+        path: '/deadline_migration/explicit_request_deadline_ms',
       }),
     );
   });

--- a/tests/workers/shadow-compilation.test.ts
+++ b/tests/workers/shadow-compilation.test.ts
@@ -26,7 +26,6 @@ describe('private shadow compiler in workerd', () => {
       config,
       authoredGroups: { global: {}, project: {} },
       credentials: { env: { EXA_API_KEY: 'worker-test-key' } },
-      requestDeadlineMs: 300_000,
       transport: {
         kind: 'silent_mcp',
         input: { query: 'worker-safe shadow plan', providers: ['Exa Search'] },
@@ -43,12 +42,19 @@ describe('private shadow compiler in workerd', () => {
       },
     });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok, JSON.stringify(result)).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.request.slots).toHaveLength(1);
     expect(result.prepared.request.slots[0]?.primary.identity).toMatchObject({
       provider_id: 'exa',
       profile_id: 'search',
+    });
+    expect(result.prepared.policy.limits).toEqual({
+      max_concurrency: 2,
+      request_deadline_ms: 120_000,
+      inline_attempt_deadline_ms: 30_000,
+      background_attempt_deadline_ms: 120_000,
+      poll_interval_ms: 5_000,
     });
   });
 
@@ -88,7 +94,6 @@ describe('private shadow compiler in workerd', () => {
       config: custom,
       authoredGroups: { global: {}, project: {} },
       credentials: {},
-      requestDeadlineMs: 300_000,
       transport: {
         kind: 'silent_mcp',
         input: { query: 'worker custom plan', providers: ['edge-custom'] },
@@ -104,5 +109,200 @@ describe('private shadow compiler in workerd', () => {
       provider_id: 'edge-provider',
       profile_id: 'search',
     });
+  });
+
+  it('injects the reachable maximum selected background attempt allowance', () => {
+    const background: Config = {
+      ...config,
+      providers: {
+        'openai-research': { enabled: true },
+        'gemini-deep': { enabled: true },
+      },
+    };
+    const ids = new Map<string, number>();
+    const result = compileShadowRequest({
+      config: background,
+      authoredGroups: { global: {}, project: {} },
+      credentials: {
+        env: {
+          OPENAI_API_KEY: 'worker-test-key',
+          GEMINI_API_KEY: 'worker-test-key',
+        },
+      },
+      transport: {
+        kind: 'silent_mcp',
+        input: {
+          query: 'effective background attempt',
+          providers: ['openai-research', 'gemini-deep'],
+        },
+      },
+      preparation: {
+        clock: { now: () => Date.parse('2026-08-09T12:00:00Z') },
+        ids: {
+          next: (scope) => {
+            const next = (ids.get(scope) ?? 0) + 1;
+            ids.set(scope, next);
+            return `background-${scope}-${next}`;
+          },
+        },
+      },
+    });
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+    if (!result.ok) return;
+    expect(result.prepared.policy.limits).toMatchObject({
+      request_deadline_ms: 210_000,
+      background_attempt_deadline_ms: 210_000,
+    });
+  });
+
+  it('keeps an explicit total authoritative and propagates truncation notice', () => {
+    const ids = new Map<string, number>();
+    const result = compileShadowRequest({
+      config: {
+        ...config,
+        defaults: { ...config.defaults, maxParallel: 1 },
+        providers: {
+          'openai-research': { enabled: true },
+          'gemini-deep': { enabled: true },
+        },
+      },
+      authoredGroups: { global: {}, project: {} },
+      credentials: {
+        env: {
+          OPENAI_API_KEY: 'worker-test-key',
+          GEMINI_API_KEY: 'worker-test-key',
+        },
+      },
+      requestDeadlineMs: 250_000,
+      transport: {
+        kind: 'silent_mcp',
+        input: {
+          query: 'explicit truncation warning',
+          providers: ['openai-research', 'gemini-deep'],
+        },
+      },
+      preparation: {
+        clock: { now: () => Date.parse('2026-08-09T12:00:00Z') },
+        ids: {
+          next: (scope) => {
+            const next = (ids.get(scope) ?? 0) + 1;
+            ids.set(scope, next);
+            return `explicit-${scope}-${next}`;
+          },
+        },
+      },
+    });
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+    if (!result.ok) return;
+    expect(result.prepared.policy.limits).toMatchObject({
+      request_deadline_ms: 250_000,
+      background_attempt_deadline_ms: 210_000,
+    });
+    expect(result.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'explicit_request_deadline_may_truncate_plan',
+      }),
+    );
+  });
+
+  it.each([
+    {
+      name: 'explicit total below the effective attempt cap',
+      config: {
+        ...config,
+        providers: { 'openai-research': { enabled: true } },
+      } satisfies Config,
+      credentials: { env: { OPENAI_API_KEY: 'worker-test-key' } },
+      providers: ['openai-research'],
+      requestDeadlineMs: 199_999,
+      code: 'request_deadline_less_than_attempt_deadline',
+    },
+    {
+      name: 'derived total above seven days',
+      config: {
+        ...config,
+        defaults: {
+          ...config.defaults,
+          maxParallel: 1,
+          timeout: 400_000,
+        },
+        providers: {
+          exa: { enabled: true },
+          'brave-search': { enabled: true },
+        },
+      } satisfies Config,
+      credentials: {
+        env: {
+          EXA_API_KEY: 'worker-test-key',
+          BRAVE_API_KEY: 'worker-test-key',
+        },
+      },
+      providers: ['exa', 'brave-search'],
+      requestDeadlineMs: undefined,
+      code: 'request_deadline_contract_maximum_exceeded',
+    },
+    {
+      name: 'unknown selected provider',
+      config,
+      credentials: { env: {} },
+      providers: ['not-a-provider'],
+      requestDeadlineMs: undefined,
+      code: 'shadow_provider_token_unknown',
+    },
+    {
+      name: 'async mode with an inline profile',
+      config: {
+        ...config,
+        defaults: { ...config.defaults, mode: 'async' },
+      } satisfies Config,
+      credentials: { env: { EXA_API_KEY: 'worker-test-key' } },
+      providers: ['exa'],
+      requestDeadlineMs: undefined,
+      code: 'async_requires_durable_profile',
+    },
+    {
+      name: 'hard budget without a network-free estimate',
+      config: {
+        ...config,
+        defaults: { ...config.defaults, maxEstimatedCostUsd: 1 },
+      } satisfies Config,
+      credentials: { env: { EXA_API_KEY: 'worker-test-key' } },
+      providers: ['exa'],
+      requestDeadlineMs: undefined,
+      code: 'budget_estimate_required',
+    },
+  ])('keeps clock and IDs untouched when $name is rejected', (fixture) => {
+    const counts = { clock: 0, ids: 0 };
+    const result = compileShadowRequest({
+      config: fixture.config,
+      authoredGroups: { global: {}, project: {} },
+      credentials: fixture.credentials,
+      ...(fixture.requestDeadlineMs !== undefined && {
+        requestDeadlineMs: fixture.requestDeadlineMs,
+      }),
+      transport: {
+        kind: 'silent_mcp',
+        input: { query: fixture.name, providers: fixture.providers },
+      },
+      preparation: {
+        clock: {
+          now: () => {
+            counts.clock += 1;
+            return Date.parse('2026-08-09T12:00:00Z');
+          },
+        },
+        ids: {
+          next: (scope) => {
+            counts.ids += 1;
+            return `rejected-${scope}`;
+          },
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [expect.objectContaining({ code: fixture.code })],
+    });
+    expect(counts).toEqual({ clock: 0, ids: 0 });
   });
 });


### PR DESCRIPTION
## Summary

Adds a bounded migration path from legacy timeout settings to Librarium v2 request deadlines. The deadline is derived from the exact admitted primary and fallback plan before time or IDs are observed, and it accounts for provider lifecycle overhead and safe GET retries.

## What's New

- Split execution preparation into pure admission and effectful materialization phases.
- Derive total request and effective background-attempt limits from the frozen selected plan.
- Budget primary concurrency, worst-case sequential fallback reserves, audited provider lifecycle overhead, and capped retry delays without clamping.
- Reject forged admissions and invalid limits before clock or ID effects.
- Preserve native explicit-deadline behavior and keep the new path private to shadow compilation; production CLI and MCP execution are unchanged.
- Add mutation-sensitive boundary, overflow, retry-policy, parity, and Worker compatibility tests.

## Design Decisions

**On retry accounting:** Legacy provider GET retry behavior remains unchanged. The migration formula includes all four safe GET attempts and three capped Retry-After delays so its declared ceiling bounds the behavior that actually runs.

**On rollout:** This PR does not cut over production ingress. It establishes the reviewed deadline and admission foundation for the subsequent diagnostic-only shadow wiring.

## Test Plan

- [x] TypeScript typecheck
- [x] Biome lint across 309 files
- [x] Unit suite: 81 files, 1,372 tests
- [x] Worker suite: 6 files, 24 tests
- [x] Production build and declarations
- [x] Git diff check
- [x] Independent architecture, security, regression, and Worker review
