### PR TITLE
feat(core): observe canonical shadow plans

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -22,6 +22,7 @@ import {
 } from '../core/provider-selection.js';
 import { executeResearchRun } from '../core/research-run.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
+import { emitProductionShadowDiagnostic } from '../node-shadow-diagnostics.js';
 import type {
   Config,
   DeduplicatedSource,
@@ -223,6 +224,28 @@ export async function executeRun(
       }
 
       const config = mergeConfigs(globalConfig, projectConfig, cliFlags);
+      emitProductionShadowDiagnostic(
+        {
+          config,
+          env: process.env,
+          transport: {
+            kind: 'cli',
+            input: {
+              query,
+              providers: opts.providers,
+              group: opts.group,
+              mode: opts.mode,
+              parallel: opts.parallel,
+              timeoutSeconds: opts.timeout,
+              maxCostUsd: opts.maxCost,
+              maxEstimatedCostUsd: opts.maxEstimatedCost,
+              fallback: opts.fallback,
+              refine: opts.refine,
+            },
+          },
+        },
+        (message) => process.stderr.write(`${message}\n`),
+      );
       const credentials = createNodeCredentialContext();
       const initResult = await initializeProviders({
         ...config,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -244,7 +244,15 @@ export async function executeRun(
             },
           },
         },
-        (message) => process.stderr.write(`${message}\n`),
+        (message) => {
+          const wasSpinning = spinner.isSpinning;
+          if (wasSpinning) spinner.stop();
+          try {
+            process.stderr.write(`${message}\n`);
+          } finally {
+            if (wasSpinning) spinner.start();
+          }
+        },
       );
       const credentials = createNodeCredentialContext();
       const initResult = await initializeProviders({

--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -20,6 +20,7 @@ import {
   executeResearchRun,
 } from '../core/research-run.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
+import { emitProductionShadowDiagnostic } from '../node-shadow-diagnostics.js';
 import type { Config, Defaults } from '../types.js';
 
 /**
@@ -101,13 +102,32 @@ export async function runResearchSilent(
 ): Promise<SilentRunResult> {
   const onWarn =
     deps.onWarn ?? ((message: string) => process.stderr.write(`${message}\n`));
-  const credentials = deps.credentials ?? createNodeCredentialContext();
 
   const cliFlags: Partial<Defaults> = {};
   if (args.mode) cliFlags.mode = args.mode;
   const config = deps.loadMergedConfig
     ? deps.loadMergedConfig()
     : defaultLoadMergedConfig(cliFlags);
+
+  emitProductionShadowDiagnostic(
+    {
+      config,
+      env: process.env,
+      transport: {
+        kind: 'silent_mcp',
+        input: {
+          query: args.query,
+          providers: args.providers,
+          group: args.group,
+          mode: args.mode,
+          refine: args.refine,
+        },
+      },
+    },
+    onWarn,
+  );
+
+  const credentials = deps.credentials ?? createNodeCredentialContext();
 
   const initialize = deps.initialize ?? initializeProviders;
   const initResult = await initialize({ ...config, credentials });

--- a/src/node-shadow-diagnostics.ts
+++ b/src/node-shadow-diagnostics.ts
@@ -1,0 +1,100 @@
+import { configGroupProvenance } from './core/config.js';
+import type { PreparationDependencies } from './core/execution-plan.js';
+import type {
+  PreparationIssue,
+  PreparationNotice,
+} from './core/research-request.js';
+import {
+  compileShadowRequest,
+  type ShadowCompilationInput,
+} from './core/shadow-compilation.js';
+
+type ProductionShadowDiagnosticInput = Omit<
+  ShadowCompilationInput,
+  'authoredGroups' | 'credentials' | 'preparation'
+> & {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+};
+
+type Diagnostic = PreparationIssue | PreparationNotice;
+type DiagnosticSink = (message: string) => void;
+
+const MAX_CODES_PER_KIND = 12;
+const SAFE_CODE = /^[a-z][a-z0-9_]{0,79}$/;
+
+function diagnosticPreparation(): PreparationDependencies {
+  const counts = new Map<string, number>();
+  return {
+    clock: { now: () => 0 },
+    ids: {
+      next: (scope) => {
+        const count = (counts.get(scope) ?? 0) + 1;
+        counts.set(scope, count);
+        return `shadow-${scope}-${count}`;
+      },
+    },
+  };
+}
+
+function boundedCodes(diagnostics: readonly Diagnostic[]): {
+  readonly codes: readonly string[];
+  readonly total: number;
+} {
+  const all = [
+    ...new Set(
+      diagnostics.map(({ code }) =>
+        SAFE_CODE.test(code) ? code : 'invalid_diagnostic_code',
+      ),
+    ),
+  ].sort();
+  return { codes: all.slice(0, MAX_CODES_PER_KIND), total: diagnostics.length };
+}
+
+function codeSummary(
+  kind: 'issues' | 'notices',
+  values: readonly Diagnostic[],
+) {
+  const { codes, total } = boundedCodes(values);
+  return `${kind}=${total} ${kind}_codes=${codes.join(',') || 'none'}`;
+}
+
+function emitSafely(onWarn: DiagnosticSink, message: string): void {
+  try {
+    onWarn(message);
+  } catch {
+    // Shadow diagnostics are observational; a broken sink cannot break v1.
+  }
+}
+
+/** Node-only, fail-open production ingress for the Worker-safe compiler. */
+export function emitProductionShadowDiagnostic(
+  input: ProductionShadowDiagnosticInput,
+  onWarn: DiagnosticSink,
+): void {
+  try {
+    const { env, ...compilerInput } = input;
+    const result = compileShadowRequest({
+      ...compilerInput,
+      authoredGroups: configGroupProvenance(input.config),
+      // Credential lookup reads only explicitly requested own keys. The
+      // diagnostic never constructs the keychain resolver or custom code.
+      credentials: { env },
+      preparation: diagnosticPreparation(),
+    });
+    if (result.ok) {
+      if (result.notices.length > 0) {
+        emitSafely(
+          onWarn,
+          `[librarium] shadow: ${codeSummary('notices', result.notices)}`,
+        );
+      }
+      return;
+    }
+    emitSafely(
+      onWarn,
+      `[librarium] shadow: ${codeSummary('issues', result.issues)}; ${codeSummary('notices', result.notices)}`,
+    );
+  } catch {
+    emitSafely(onWarn, '[librarium] shadow: diagnostic_failed');
+  }
+}

--- a/src/node-shadow-diagnostics.ts
+++ b/src/node-shadow-diagnostics.ts
@@ -1,9 +1,5 @@
 import { configGroupProvenance } from './core/config.js';
 import type { PreparationDependencies } from './core/execution-plan.js';
-import type {
-  PreparationIssue,
-  PreparationNotice,
-} from './core/research-request.js';
 import {
   compileShadowRequest,
   type ShadowCompilationInput,
@@ -16,7 +12,9 @@ type ProductionShadowDiagnosticInput = Omit<
   readonly env?: Readonly<Record<string, string | undefined>>;
 };
 
-type Diagnostic = PreparationIssue | PreparationNotice;
+interface DiagnosticCode {
+  readonly code: string;
+}
 type DiagnosticSink = (message: string) => void;
 
 const MAX_CODES_PER_KIND = 12;
@@ -36,7 +34,7 @@ function diagnosticPreparation(): PreparationDependencies {
   };
 }
 
-function boundedCodes(diagnostics: readonly Diagnostic[]): {
+function boundedCodes(diagnostics: readonly DiagnosticCode[]): {
   readonly codes: readonly string[];
   readonly total: number;
 } {
@@ -50,10 +48,10 @@ function boundedCodes(diagnostics: readonly Diagnostic[]): {
   return { codes: all.slice(0, MAX_CODES_PER_KIND), total: diagnostics.length };
 }
 
-function codeSummary(
+export function formatShadowDiagnosticCodes(
   kind: 'issues' | 'notices',
-  values: readonly Diagnostic[],
-) {
+  values: readonly DiagnosticCode[],
+): string {
   const { codes, total } = boundedCodes(values);
   return `${kind}=${total} ${kind}_codes=${codes.join(',') || 'none'}`;
 }
@@ -85,14 +83,14 @@ export function emitProductionShadowDiagnostic(
       if (result.notices.length > 0) {
         emitSafely(
           onWarn,
-          `[librarium] shadow: ${codeSummary('notices', result.notices)}`,
+          `[librarium] shadow: ${formatShadowDiagnosticCodes('notices', result.notices)}`,
         );
       }
       return;
     }
     emitSafely(
       onWarn,
-      `[librarium] shadow: ${codeSummary('issues', result.issues)}; ${codeSummary('notices', result.notices)}`,
+      `[librarium] shadow: ${formatShadowDiagnosticCodes('issues', result.issues)}; ${formatShadowDiagnosticCodes('notices', result.notices)}`,
     );
   } catch {
     emitSafely(onWarn, '[librarium] shadow: diagnostic_failed');

--- a/tests/mcp-research-manifest.test.ts
+++ b/tests/mcp-research-manifest.test.ts
@@ -61,6 +61,7 @@ describe('silent research live manifest', () => {
       });
       throw new Error('dispatch exploded');
     });
+    const warnings: string[] = [];
 
     await expect(
       runResearchSilent(
@@ -74,9 +75,16 @@ describe('silent research live manifest', () => {
           }),
           dispatch,
           credentials: { env: {} },
+          onWarn: (message) => warnings.push(message),
         },
       ),
     ).rejects.toThrow('dispatch exploded');
+
+    expect(warnings).toContainEqual(
+      expect.stringMatching(
+        /^\[librarium\] shadow: issues=\d+ issues_codes=[a-z0-9_,]+; notices=\d+ notices_codes=/,
+      ),
+    );
 
     const runDir = readdirSync(baseDir).map((entry) => join(baseDir, entry))[0];
     expect(readRunManifest(runDir as string)).toMatchObject({

--- a/tests/node-shadow-diagnostics.test.ts
+++ b/tests/node-shadow-diagnostics.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { emitProductionShadowDiagnostic } from '../src/node-shadow-diagnostics.js';
+import type { Config } from '../src/types.js';
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel: 2,
+      timeout: 30,
+      asyncTimeout: 300,
+      asyncPollInterval: 5,
+      mode: 'sync',
+      llmWebSearch: true,
+    },
+    providers: {},
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {},
+    ...overrides,
+  };
+}
+
+describe('Node production shadow diagnostic', () => {
+  it('uses own-key environment credentials and emits code-only bounded output', () => {
+    const inherited = Object.create({
+      EXA_API_KEY: 'inherited-secret',
+    }) as Record<string, string | undefined>;
+    const warnings: string[] = [];
+    emitProductionShadowDiagnostic(
+      {
+        config: config({ providers: { exa: { enabled: true } } }),
+        env: inherited,
+        transport: {
+          kind: 'cli',
+          input: {
+            query: 'private query text',
+            providers: ['exa'],
+          },
+        },
+      },
+      (message) => warnings.push(message),
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(
+      /^\[librarium\] shadow: issues=\d+ issues_codes=[a-z0-9_,]+; notices=\d+ notices_codes=(?:[a-z0-9_,]+|none)$/,
+    );
+    expect(warnings[0]).toContain('profile_uncredentialed');
+    expect(warnings[0]).not.toContain('/');
+    expect(warnings[0]).not.toContain('exa');
+    expect(warnings[0]).not.toContain('inherited-secret');
+    expect(warnings[0]).not.toContain('private query text');
+    expect(warnings[0]!.length).toBeLessThan(2_100);
+  });
+
+  it('does not enumerate the environment and admits an own credential', () => {
+    let ownKeysCalls = 0;
+    const env = new Proxy(
+      { EXA_API_KEY: 'own-secret' } as Record<string, string | undefined>,
+      {
+        ownKeys(target) {
+          ownKeysCalls += 1;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const warnings: string[] = [];
+    emitProductionShadowDiagnostic(
+      {
+        config: config({ providers: { exa: { enabled: true } } }),
+        env,
+        transport: {
+          kind: 'cli',
+          input: { query: 'q', providers: ['exa'] },
+        },
+      },
+      (message) => warnings.push(message),
+    );
+    expect(ownKeysCalls).toBe(0);
+    expect(warnings.join()).not.toContain('own-secret');
+  });
+
+  it('fails open when provenance lookup or the warning sink throws', () => {
+    const brokenConfig = new Proxy(config(), {
+      get(target, property, receiver) {
+        if (property === 'groups') throw new Error('secret provenance failure');
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const warnings: string[] = [];
+    expect(() =>
+      emitProductionShadowDiagnostic(
+        {
+          config: brokenConfig,
+          env: {},
+          transport: { kind: 'cli', input: { query: 'q' } },
+        },
+        (message) => warnings.push(message),
+      ),
+    ).not.toThrow();
+    expect(warnings).toEqual(['[librarium] shadow: diagnostic_failed']);
+    expect(warnings.join()).not.toContain('provenance');
+
+    expect(() =>
+      emitProductionShadowDiagnostic(
+        {
+          config: config({ providers: { exa: { enabled: true } } }),
+          env: {},
+          transport: {
+            kind: 'cli',
+            input: { query: 'q', providers: ['exa'] },
+          },
+        },
+        () => {
+          throw new Error('sink unavailable');
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  it('deduplicates codes and caps the number and length of emitted codes', () => {
+    const providers = Object.fromEntries(
+      Array.from({ length: 80 }, (_, index) => [
+        `unknown-provider-${index}`,
+        { enabled: true },
+      ]),
+    );
+    const warnings: string[] = [];
+    emitProductionShadowDiagnostic(
+      {
+        config: config({ providers }),
+        env: {},
+        transport: { kind: 'cli', input: { query: 'q' } },
+      },
+      (message) => warnings.push(message),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.length).toBeLessThan(2_100);
+    expect(warnings[0]).not.toContain('unknown-provider');
+  });
+});

--- a/tests/node-shadow-diagnostics.test.ts
+++ b/tests/node-shadow-diagnostics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { emitProductionShadowDiagnostic } from '../src/node-shadow-diagnostics.js';
+import {
+  emitProductionShadowDiagnostic,
+  formatShadowDiagnosticCodes,
+} from '../src/node-shadow-diagnostics.js';
 import type { Config } from '../src/types.js';
 
 function config(overrides: Partial<Config> = {}): Config {
@@ -120,24 +123,38 @@ describe('Node production shadow diagnostic', () => {
     ).not.toThrow();
   });
 
-  it('deduplicates codes and caps the number and length of emitted codes', () => {
-    const providers = Object.fromEntries(
-      Array.from({ length: 80 }, (_, index) => [
-        `unknown-provider-${index}`,
-        { enabled: true },
+  it('deduplicates diagnostic codes while retaining the occurrence count', () => {
+    expect(
+      formatShadowDiagnosticCodes('issues', [
+        { code: 'duplicate_code' },
+        { code: 'duplicate_code' },
+        { code: 'other_code' },
       ]),
+    ).toBe('issues=3 issues_codes=duplicate_code,other_code');
+  });
+
+  it('caps sorted diagnostic codes at twelve', () => {
+    const values = Array.from({ length: 15 }, (_, index) => ({
+      code: `code_${String(index).padStart(2, '0')}`,
+    }));
+    expect(formatShadowDiagnosticCodes('notices', values)).toBe(
+      `notices=15 notices_codes=${values
+        .slice(0, 12)
+        .map(({ code }) => code)
+        .join(',')}`,
     );
-    const warnings: string[] = [];
-    emitProductionShadowDiagnostic(
-      {
-        config: config({ providers }),
-        env: {},
-        transport: { kind: 'cli', input: { query: 'q' } },
-      },
-      (message) => warnings.push(message),
+  });
+
+  it('replaces invalid diagnostic codes without exposing their contents', () => {
+    const summary = formatShadowDiagnosticCodes('issues', [
+      { code: 'safe_code' },
+      { code: 'SECRET/path\nvalue' },
+      { code: 'also-invalid!' },
+    ]);
+    expect(summary).toBe(
+      'issues=3 issues_codes=invalid_diagnostic_code,safe_code',
     );
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]!.length).toBeLessThan(2_100);
-    expect(warnings[0]).not.toContain('unknown-provider');
+    expect(summary).not.toContain('SECRET');
+    expect(summary).not.toContain('path');
   });
 });

--- a/tests/run-shadow-diagnostics.test.ts
+++ b/tests/run-shadow-diagnostics.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Config } from '../src/types.js';
+
+const state = vi.hoisted(() => ({
+  events: [] as string[],
+  shadowInput: undefined as unknown,
+  selectionError: true,
+  dispatchInput: undefined as unknown,
+}));
+
+const fixtureConfig: Config = {
+  version: 1,
+  defaults: {
+    outputDir: './agents/librarium',
+    maxParallel: 2,
+    timeout: 30,
+    asyncTimeout: 1800,
+    asyncPollInterval: 10,
+    mode: 'mixed',
+    llmWebSearch: true,
+  },
+  providers: {},
+  customProviders: {},
+  trustedProviderIds: [],
+  groups: {},
+};
+
+vi.mock('../src/core/config.js', () => ({
+  loadConfig: () => {
+    state.events.push('load-global');
+    return fixtureConfig;
+  },
+  loadProjectConfig: () => {
+    state.events.push('load-project');
+    return null;
+  },
+  mergeConfigs: () => {
+    state.events.push('merge');
+    return fixtureConfig;
+  },
+  configGroupProvenance: () => ({
+    global: { authored: ['legacy-provider'] },
+    project: {},
+  }),
+}));
+
+vi.mock('../src/node-shadow-diagnostics.js', () => ({
+  emitProductionShadowDiagnostic: (
+    input: unknown,
+    onWarn: (message: string) => void,
+  ) => {
+    state.events.push('shadow');
+    state.shadowInput = input;
+    onWarn('[librarium] shadow: issues=1 issues_codes=fixture');
+  },
+}));
+
+vi.mock('../src/node-credentials.js', () => ({
+  createNodeCredentialContext: () => {
+    state.events.push('keychain-credentials');
+    return { env: {} };
+  },
+}));
+
+vi.mock('../src/adapters/node-registry.js', () => ({
+  getAllProviders: () => [],
+  initializeProviders: async () => {
+    state.events.push('initialize');
+    return {
+      warnings: [],
+      loadedCustomProviders: [],
+      skippedCustomProviders: [],
+    };
+  },
+}));
+
+vi.mock('../src/core/provider-selection.js', () => {
+  class ProviderSelectionError extends Error {}
+  return {
+    ProviderSelectionError,
+    resolveProviderSelection: () => {
+      state.events.push('legacy-selection');
+      if (state.selectionError) {
+        throw new ProviderSelectionError('no providers for fixture');
+      }
+      return ['legacy-provider'];
+    },
+  };
+});
+
+vi.mock('../src/core/prompt-builder.js', () => ({
+  generateSlug: () => 'fixture-slug',
+  resolveOutputDir: () => '/tmp/unused-cli-output',
+  createRunDir: () => '/tmp/unused-mcp-output',
+}));
+
+const silentResult = {
+  manifest: {
+    schemaVersion: 2,
+    revision: 0,
+    status: 'completed',
+    timestamp: 0,
+    slug: 'fixture-slug',
+    query: 'private query',
+    mode: 'mixed',
+    outputDir: '/tmp/unused-mcp-output',
+    providers: [],
+    sources: { total: 0, unique: 0, file: 'sources.json' },
+    exitCode: 0,
+  },
+  reports: [],
+  results: [],
+  sources: [],
+  totalCitations: 0,
+  totalDurationMs: 0,
+};
+
+vi.mock('../src/core/research-run.js', () => ({
+  executeResearchRun: async (input: unknown) => {
+    state.events.push('dispatch');
+    state.dispatchInput = input;
+    return silentResult;
+  },
+}));
+
+vi.mock('../src/commands/refine.js', () => ({
+  refineQuery: async () => {
+    state.events.push('refine');
+    return null;
+  },
+}));
+
+import { executeRun } from '../src/commands/run.js';
+import { runResearchSilent } from '../src/mcp/research.js';
+
+describe('CLI production shadow diagnostic', () => {
+  beforeEach(() => {
+    state.events.length = 0;
+    state.shadowInput = undefined;
+    state.selectionError = true;
+    state.dispatchInput = undefined;
+    process.exitCode = undefined;
+  });
+
+  it('runs exactly once after merge and before credentials/initialization without polluting JSON stdout', async () => {
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    const stdout = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    try {
+      const outcome = await executeRun('private query', {
+        providers: ['legacy-provider'],
+        group: 'ignored-group',
+        mode: 'async',
+        parallel: 4,
+        timeout: 45,
+        maxCost: 1.25,
+        maxEstimatedCost: 2.5,
+        fallback: false,
+        refine: true,
+        json: true,
+      });
+
+      expect(outcome).toEqual({ exitCode: 2 });
+      expect(state.events).toEqual([
+        'load-global',
+        'load-project',
+        'merge',
+        'shadow',
+        'keychain-credentials',
+        'initialize',
+        'legacy-selection',
+      ]);
+      expect(state.events.filter((event) => event === 'shadow')).toHaveLength(
+        1,
+      );
+      expect(state.shadowInput).toMatchObject({
+        config: fixtureConfig,
+        transport: {
+          kind: 'cli',
+          input: {
+            query: 'private query',
+            providers: ['legacy-provider'],
+            group: 'ignored-group',
+            mode: 'async',
+            parallel: 4,
+            timeoutSeconds: 45,
+            maxCostUsd: 1.25,
+            maxEstimatedCostUsd: 2.5,
+            fallback: false,
+            refine: true,
+          },
+        },
+      });
+      expect(stderr).toHaveBeenCalledWith(
+        '[librarium] shadow: issues=1 issues_codes=fixture\n',
+      );
+      expect(stdout).not.toHaveBeenCalled();
+    } finally {
+      stderr.mockRestore();
+      stdout.mockRestore();
+    }
+  });
+
+  it('keeps silent MCP results and dispatch inputs unchanged while warning only through onWarn', async () => {
+    state.selectionError = false;
+    const warnings: string[] = [];
+    const initialize = vi.fn(async () => {
+      state.events.push('initialize');
+      return {
+        warnings: [],
+        loadedCustomProviders: [],
+        skippedCustomProviders: [],
+      };
+    });
+    const stdout = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    try {
+      const result = await runResearchSilent(
+        {
+          query: 'private query',
+          providers: ['legacy-provider'],
+          mode: 'mixed',
+          refine: true,
+        },
+        {
+          loadMergedConfig: () => {
+            state.events.push('load-merged');
+            return fixtureConfig;
+          },
+          initialize,
+          credentials: { env: { LEGACY_API_KEY: 'legacy-secret' } },
+          onWarn: (message) => {
+            state.events.push('warning');
+            warnings.push(message);
+          },
+        },
+      );
+
+      expect(result).toBe(silentResult);
+      expect(state.events).toEqual([
+        'load-merged',
+        'shadow',
+        'warning',
+        'initialize',
+        'legacy-selection',
+        'refine',
+        'dispatch',
+      ]);
+      expect(state.events.filter((event) => event === 'shadow')).toHaveLength(
+        1,
+      );
+      expect(warnings).toEqual([
+        '[librarium] shadow: issues=1 issues_codes=fixture',
+      ]);
+      expect(state.shadowInput).toMatchObject({
+        config: fixtureConfig,
+        transport: {
+          kind: 'silent_mcp',
+          input: {
+            query: 'private query',
+            providers: ['legacy-provider'],
+            mode: 'mixed',
+            refine: true,
+          },
+        },
+      });
+      expect(state.dispatchInput).toMatchObject({
+        query: 'private query',
+        config: fixtureConfig,
+        providerIds: ['legacy-provider'],
+        outputDir: '/tmp/unused-mcp-output',
+        slug: 'fixture-slug',
+        credentials: { env: { LEGACY_API_KEY: 'legacy-secret' } },
+      });
+      expect(stdout).not.toHaveBeenCalled();
+      expect(state.events).not.toContain('keychain-credentials');
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+});

--- a/tests/run-shadow-diagnostics.test.ts
+++ b/tests/run-shadow-diagnostics.test.ts
@@ -61,7 +61,11 @@ vi.mock('../src/node-shadow-diagnostics.js', () => ({
   ) => {
     state.events.push('shadow');
     state.shadowInput = input;
-    onWarn('[librarium] shadow: issues=1 issues_codes=fixture');
+    try {
+      onWarn('[librarium] shadow: issues=1 issues_codes=fixture');
+    } catch {
+      // Mirrors the production observer's fail-open sink boundary.
+    }
   },
 }));
 
@@ -313,6 +317,44 @@ describe('CLI production shadow diagnostic', () => {
       expect(stdout).not.toHaveBeenCalled();
       expect(state.events).not.toContain('keychain-credentials');
     } finally {
+      stdout.mockRestore();
+    }
+  });
+
+  it('restarts the spinner and continues legacy execution when diagnostic stderr throws', async () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => {
+      state.events.push('stderr-write');
+      throw new Error('stderr unavailable');
+    });
+    const stdout = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    try {
+      const outcome = await executeRun('private query', {
+        providers: ['legacy-provider'],
+        json: true,
+      });
+
+      expect(outcome).toEqual({ exitCode: 2 });
+      expect(state.events).toEqual([
+        'spinner-start',
+        'load-global',
+        'load-project',
+        'merge',
+        'shadow',
+        'spinner-stop',
+        'stderr-write',
+        'spinner-start',
+        'keychain-credentials',
+        'initialize',
+        'legacy-selection',
+        'spinner-fail',
+      ]);
+      expect(state.spinner.stop).toHaveBeenCalledTimes(1);
+      expect(state.spinner.start).toHaveBeenCalledTimes(2);
+      expect(stdout).not.toHaveBeenCalled();
+    } finally {
+      stderr.mockRestore();
       stdout.mockRestore();
     }
   });

--- a/tests/run-shadow-diagnostics.test.ts
+++ b/tests/run-shadow-diagnostics.test.ts
@@ -6,6 +6,12 @@ const state = vi.hoisted(() => ({
   shadowInput: undefined as unknown,
   selectionError: true,
   dispatchInput: undefined as unknown,
+  spinner: {
+    isSpinning: false,
+    start: undefined as unknown,
+    stop: undefined as unknown,
+    fail: undefined as unknown,
+  },
 }));
 
 const fixtureConfig: Config = {
@@ -42,6 +48,10 @@ vi.mock('../src/core/config.js', () => ({
     global: { authored: ['legacy-provider'] },
     project: {},
   }),
+}));
+
+vi.mock('ora', () => ({
+  default: () => state.spinner,
 }));
 
 vi.mock('../src/node-shadow-diagnostics.js', () => ({
@@ -139,13 +149,30 @@ describe('CLI production shadow diagnostic', () => {
     state.shadowInput = undefined;
     state.selectionError = true;
     state.dispatchInput = undefined;
+    state.spinner.isSpinning = false;
+    state.spinner.start = vi.fn(() => {
+      state.events.push('spinner-start');
+      state.spinner.isSpinning = true;
+      return state.spinner;
+    });
+    state.spinner.stop = vi.fn(() => {
+      state.events.push('spinner-stop');
+      state.spinner.isSpinning = false;
+      return state.spinner;
+    });
+    state.spinner.fail = vi.fn(() => {
+      state.events.push('spinner-fail');
+      state.spinner.isSpinning = false;
+      return state.spinner;
+    });
     process.exitCode = undefined;
   });
 
   it('runs exactly once after merge and before credentials/initialization without polluting JSON stdout', async () => {
-    const stderr = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => {
+      state.events.push('stderr-write');
+      return true;
+    });
     const stdout = vi
       .spyOn(process.stdout, 'write')
       .mockImplementation(() => true);
@@ -165,13 +192,18 @@ describe('CLI production shadow diagnostic', () => {
 
       expect(outcome).toEqual({ exitCode: 2 });
       expect(state.events).toEqual([
+        'spinner-start',
         'load-global',
         'load-project',
         'merge',
         'shadow',
+        'spinner-stop',
+        'stderr-write',
+        'spinner-start',
         'keychain-credentials',
         'initialize',
         'legacy-selection',
+        'spinner-fail',
       ]);
       expect(state.events.filter((event) => event === 'shadow')).toHaveLength(
         1,
@@ -198,6 +230,8 @@ describe('CLI production shadow diagnostic', () => {
         '[librarium] shadow: issues=1 issues_codes=fixture\n',
       );
       expect(stdout).not.toHaveBeenCalled();
+      expect(state.spinner.stop).toHaveBeenCalledTimes(1);
+      expect(state.spinner.start).toHaveBeenCalledTimes(2);
     } finally {
       stderr.mockRestore();
       stdout.mockRestore();

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -1142,8 +1142,24 @@ describe('private shadow compilation', () => {
       write: false,
       logLevel: 'silent',
     });
-    expect(Object.keys(production.metafile.inputs).join('\n')).not.toContain(
-      'shadow-compilation',
-    );
+    const diagnosticImporters = Object.entries(production.metafile.inputs)
+      .filter(([, input]) =>
+        input.imports.some(({ path }) =>
+          path.includes('node-shadow-diagnostics'),
+        ),
+      )
+      .map(([path]) => path)
+      .sort();
+    expect(diagnosticImporters).toEqual([
+      'src/commands/run.ts',
+      'src/mcp/research.ts',
+    ]);
+    const shadowImporters = Object.entries(production.metafile.inputs)
+      .filter(([, input]) =>
+        input.imports.some(({ path }) => path.includes('shadow-compilation')),
+      )
+      .map(([path]) => path)
+      .sort();
+    expect(shadowImporters).toEqual(['src/node-shadow-diagnostics.ts']);
   });
 });


### PR DESCRIPTION
## Summary

Adds observational canonical-plan diagnostics to the existing CLI and silent MCP ingress without changing legacy provider selection or execution. The observer runs before credentials, initialization, refinement, and dispatch, then reports only bounded diagnostic codes and counts through stderr or the existing warning channel.

## What's New

- Compile the merged legacy configuration and raw transport input into a private canonical shadow plan exactly once per run.
- Keep shadow results observational; legacy selection, dispatch, artifacts, return values, exit codes, and errors remain authoritative.
- Use an environment-only credential view without keychain lookup, custom-provider loading, filesystem access, or network calls.
- Bound and sanitize output to fixed diagnostic codes and counts; omit paths, messages, queries, provider/profile IDs, configuration values, environment values, and stack traces.
- Preserve JSON stdout and MCP protocol output, and coordinate CLI stderr with the active spinner.
- Prove the Worker-safe compiler remains isolated behind one Node-only adapter.

## Design Decisions

**On failure:** Shadow compilation, provenance lookup, and warning sinks are fail-open. A canonical diagnostic failure can never prevent or change the existing legacy run.

**On rollout:** This PR observes canonical behavior only. It does not cut over provider execution or publish a new API.

## Test Plan

- [x] TypeScript typecheck
- [x] Biome lint across 312 files
- [x] Unit suite: 83 files, 1,381 tests
- [x] Worker suite: 6 files, 24 tests
- [x] Integration suite: 2 files, 14 tests
- [x] Production build and declarations
- [x] Independent privacy, architecture, regression, and mutation-test review
