### PR TITLE
feat: modernize Node and Commander

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -49,24 +49,30 @@ jobs:
         include:
           # Linux — full suite
           - os: ubuntu-latest
-            node-version: 20
+            node-version: 22.12.0
             run-integration: true
-          - os: ubuntu-latest
-            node-version: 22
-            run-integration: true
+            run-packed: true
           - os: ubuntu-latest
             node-version: 24
             run-integration: true
+            run-packed: true
+          - os: ubuntu-latest
+            node-version: 26
+            run-integration: true
+            run-packed: true
           # Windows — unit tests only
           - os: windows-latest
-            node-version: 20
+            node-version: 22.12.0
             run-integration: false
-          - os: windows-latest
-            node-version: 22
-            run-integration: false
+            run-packed: false
           - os: windows-latest
             node-version: 24
             run-integration: false
+            run-packed: false
+          - os: windows-latest
+            node-version: 26
+            run-integration: false
+            run-packed: false
 
     steps:
       - name: Checkout
@@ -107,10 +113,68 @@ jobs:
         if: matrix.run-integration
         run: npm run test:integration
 
+      - name: Packed consumer smoke test
+        if: matrix.run-packed
+        run: npm run test:packed
+
+  below-floor:
+    runs-on: ubuntu-latest
+    needs: [autoformat]
+    if: always() && (needs.autoformat.result == 'success' || needs.autoformat.result == 'skipped')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup build Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Setup below-floor Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.11.0
+
+      - name: Reject packed install below the runtime floor
+        run: npm run test:engine-floor
+
+  sea:
+    runs-on: ubuntu-latest
+    needs: [autoformat]
+    if: always() && (needs.autoformat.result == 'success' || needs.autoformat.result == 'skipped')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and smoke-test Linux SEA
+        run: npm run test:sea
+
   pty:
     # Interactive PTY smoke tests (live table, wizard, browse/pager, Ctrl+C).
     # Runs the real terminal flows against the built CLI on POSIX runners only;
-    # the suite self-skips on Windows. Single Node version (22) keeps the matrix
+    # the suite self-skips on Windows. Single Node version (24) keeps the matrix
     # small — these exercise terminal behaviour, not Node version compatibility.
     runs-on: ${{ matrix.os }}
     needs: [autoformat]
@@ -127,10 +191,10 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
 
   below-floor:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [autoformat]
     if: always() && (needs.autoformat.result == 'success' || needs.autoformat.result == 'skipped')
 
@@ -150,6 +152,8 @@ jobs:
 
   sea:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [autoformat]
     if: always() && (needs.autoformat.result == 'success' || needs.autoformat.result == 'skipped')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
 
@@ -175,7 +175,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -294,6 +294,12 @@ jobs:
       VERSION: ${{ needs.release.outputs.version }}
 
     steps:
+      - name: Setup Node.js for npm smoke test
+        if: matrix.method == 'npm'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Smoke test npm install
         if: matrix.method == 'npm'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking Node and CLI baseline:** Node-based Librarium installs now require
+  Node.js 22.12 or newer and use Commander 15. CLI query, provider, mode,
+  concurrency, timeout, budget, cleanup, usage, completion-shell, and config
+  inputs are validated before command actions run. Invalid completion-shell
+  arguments intentionally exit with status 1. Standalone and Homebrew binaries
+  remain self-contained and do not require a host Node.js installation.
 - SearchAPI now authenticates through `Authorization: Bearer` without placing
   credentials in URLs. The strict `zeroRetention` option sends
   `zero_retention=true` and fails closed with no fallback or privacy downgrade

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://www.npmjs.com/package/librarium"><img src="https://img.shields.io/npm/v/librarium?color=cb3837&label=npm" alt="npm version" /></a>
   <a href="https://github.com/jkudish/librarium/actions/workflows/ci.yml"><img src="https://github.com/jkudish/librarium/actions/workflows/ci.yml/badge.svg" alt="CI status" /></a>
   <a href="https://github.com/jkudish/librarium/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/librarium?color=blue" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/node/v/librarium?color=5fa04e" alt="Node >= 20.12" />
+  <img src="https://img.shields.io/node/v/librarium?color=5fa04e" alt="Node >= 22.12" />
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ The full docs live at **[librarium.agentsy.build](https://librarium.agentsy.buil
 ## Quick Start
 
 ```bash
-# Install (requires Node.js >= 20.12)
+# Install from npm (requires Node.js >= 22.12)
 npm install -g librarium
 
 # Start guided setup if no providers are configured yet
@@ -69,7 +69,7 @@ Plus provider groups, automatic fallbacks, and custom providers from npm or loca
 
 ## Installation
 
-### npm (requires Node.js >= 20.12)
+### npm (requires Node.js >= 22.12)
 
 ```bash
 npm install -g librarium
@@ -99,11 +99,17 @@ brew install jkudish/tap/librarium
 curl -fsSL https://raw.githubusercontent.com/jkudish/librarium/main/scripts/install.sh | sh
 ```
 
+The standalone and Homebrew installations ship a self-contained executable with
+its own Node runtime. They do not require Node.js to be installed on the host.
+
 ### npx (no install)
 
 ```bash
 npx librarium run "your query"
 ```
+
+The npm, pnpm, yarn, and npx methods, including `librarium/core` and
+`librarium/node` library imports, require Node.js 22.12 or newer.
 
 ### Upgrade
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,25 @@ librarium answer <query> [options]
 
 `answer` runs the same fan-out as `run` (defaulting to the `quick` group, overridable with `-g`/`-p`/`-m` and the usual run flags), then makes one LLM synthesis call over the successful providers' content plus the deduped source list. The model is instructed to answer only from the findings, cite with inline `[n]` indices that map to the numbered source list, and state what is uncertain rather than invent. The answer is rendered in the terminal followed by a hyperlinked source list, and written to `answer.md` in the run directory.
 
+| Flag | Description |
+|---|---|
+| `-p, --providers <ids\|names>` | Use specific provider IDs or display names instead of the default `quick` group |
+| `-g, --group <name>` | Use a predefined provider group |
+| `-m, --mode <mode>` | Execution mode: `sync`, `async`, or `mixed` |
+| `-o, --output <dir>` | Output base directory |
+| `--parallel <n>` | Max parallel requests |
+| `--timeout <n>` | Timeout per provider in seconds |
+| `--max-cost <usd>` | Stop launching providers once API-reported cost crosses this budget |
+| `--max-estimated-cost <usd>` | Skip launches once reserved estimated cost crosses this ceiling |
+| `--no-fallback` | Disable configured provider fallbacks for an exact provider matrix |
+| `-y, --yes` | Skip the deep-research pre-flight confirm |
+| `--json` | Output `run.json` to stdout |
+| `--refine` | Rewrite the query into tier-tuned variants before dispatch |
+| `--verify` | Add a bounded evidence-verification pass after synthesis |
+| `--html` | Generate `report.html` in the run directory |
+| `--jsonl` | Generate `results.jsonl` in the run directory |
+| `--open` | Open the output directory (or `report.html` with `--html`) when complete |
+
 ```
 $ librarium answer "what changed in postgres 17 logical replication"
 
@@ -433,7 +452,7 @@ $ librarium answer "what changed in postgres 17 logical replication"
   ▸ ~/research/agents/librarium/1781136000-what-changed-in-postgres-17/
 ```
 
-The synthesis call uses the first available of OpenAI (`gpt-5-mini`), Gemini (`gemini-2.5-flash`), or Perplexity (`sonar`), overridable via an `answer: { provider, model }` config key that falls back to the `refine` config and then to those defaults. Synthesis fails open: if every client fails (quota, auth, timeout), a detailed warning prints and the run summary and output directory still appear, so the research is never lost. The exit code reflects the run, not the synthesis. `answer` accepts the same run flags, including `--max-cost`, `--max-estimated-cost`, `--html`, and `--jsonl`. When the run directory contains `answer.md`, both `report.html` (an Answer section leading the report) and `results.jsonl` (an `"type":"answer"` line) pick it up automatically on generation and regeneration. The interactive wizard also offers grounded synthesis after its refine prompt when an LLM client key is configured.
+The synthesis call uses the first available of OpenAI (`gpt-5-mini`), Gemini (`gemini-2.5-flash`), or Perplexity (`sonar`), overridable via an `answer: { provider, model }` config key that falls back to the `refine` config and then to those defaults. Synthesis fails open: if every client fails (quota, auth, timeout), a detailed warning prints and the run summary and output directory still appear, so the research is never lost. The exit code reflects the run, not the synthesis. `answer` accepts the same run flags, including `--no-fallback`, `--max-cost`, `--max-estimated-cost`, `--html`, and `--jsonl`. When the run directory contains `answer.md`, both `report.html` (an Answer section leading the report) and `results.jsonl` (an `"type":"answer"` line) pick it up automatically on generation and regeneration. The interactive wizard also offers grounded synthesis after its refine prompt when an LLM client key is configured.
 
 Pass `--verify` to add a bounded, opt-in evidence pass after synthesis. Librarium selects up to eight material factual claims, checks the independent source evidence already returned by the fan-out, and only then collects evidence from up to three successful targeted searches for unresolved claims. A query whose provider attempts all fail does not consume that successful-query allowance. Follow-ups start with eligible successful `ai-grounded` and `raw-search` providers from the original run and may traverse their configured eligible fallback chains, including a fallback provider that was not part of the original result set; deep-research providers are never used. Each selected claim gets at most one query with at most three provider attempts, honoring configured fallbacks, eligible alternates, the inherited per-call timeout, and both inherited cost ceilings. If either ceiling is already exhausted by the original fan-out, verification makes no LLM or provider call. Verification fails open: any incomplete evidence, budget exhaustion, provider failure, or LLM failure leaves the original grounded `answer.md` intact.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@clack/prompts": "^1.7.0",
         "@inquirer/prompts": "^7.10.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "marked": "^18.0.9",
         "ora": "^9.4.1",
         "p-limit": "^7.3.0",
@@ -37,7 +37,7 @@
         "wrangler": "^4.113.0"
       },
       "engines": {
-        "node": ">=20.12"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -2766,12 +2766,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/confbox": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:integration": "npm run build && vitest run --config vitest.integration.config.ts",
+    "test:packed": "npm run build && node scripts/verify-packed-consumer.mjs",
+    "test:engine-floor": "node scripts/verify-packed-consumer.mjs --expect-engine-rejection",
+    "test:sea": "npm run build:sea && node scripts/verify-sea.mjs",
     "test:workers": "npm run build && vitest run --config vitest.workers.config.ts",
     "test:pty": "npm run build && vitest run --config vitest.pty.config.ts",
     "test:watch": "vitest",
@@ -43,7 +46,7 @@
     "@clack/prompts": "^1.7.0",
     "@inquirer/prompts": "^7.10.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "marked": "^18.0.9",
     "ora": "^9.4.1",
     "p-limit": "^7.3.0",
@@ -74,7 +77,7 @@
     }
   },
   "engines": {
-    "node": ">=20.12"
+    "node": ">=22.12.0"
   },
   "files": [
     "dist"

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -12,9 +12,15 @@
  */
 
 import { execSync } from 'node:child_process';
-import { copyFileSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import {
+  chmodSync,
+  copyFileSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { arch, platform } from 'node:os';
 import { join } from 'node:path';
-import { platform, arch } from 'node:os';
 
 const DIST = 'dist';
 const SEA_CONFIG = join(DIST, 'sea-config.json');
@@ -45,22 +51,37 @@ console.log(`  Output:  ${outputPath}`);
 
 // Step 1: Bundle with esbuild into CJS (SEA requires CJS)
 console.log('\n1. Bundling with esbuild...');
-run(`npx esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=${CJS_BUNDLE} --define:__VERSION__='"${pkg.version}"' --external:fsevents`);
+run(
+  `npx esbuild src/cli.ts --bundle --platform=node --target=node22.12 --format=cjs --outfile=${CJS_BUNDLE} --define:__VERSION__='"${pkg.version}"' --external:fsevents`,
+);
 
 // Step 2: Generate SEA config and blob
 console.log('\n2. Generating SEA blob...');
-writeFileSync(SEA_CONFIG, JSON.stringify({
-  main: CJS_BUNDLE,
-  output: SEA_BLOB,
-  disableExperimentalSEAWarning: true,
-  useCodeCache: true,
-}, null, 2));
+writeFileSync(
+  SEA_CONFIG,
+  JSON.stringify(
+    {
+      main: CJS_BUNDLE,
+      output: SEA_BLOB,
+      disableExperimentalSEAWarning: true,
+      useCodeCache: true,
+    },
+    null,
+    2,
+  ),
+);
 
 run(`"${process.execPath}" --experimental-sea-config ${SEA_CONFIG}`);
 
 // Step 3: Copy node binary
 console.log('\n3. Copying Node.js binary...');
+rmSync(outputPath, { force: true });
 copyFileSync(process.execPath, outputPath);
+if (!isWindows) {
+  // Homebrew's Node binary can be read-only in the Cellar. postject needs the
+  // copied executable to be writable before it can inject the SEA blob.
+  chmodSync(outputPath, 0o755);
+}
 
 // Step 4: Remove macOS code signature (required before injection)
 if (isMac) {

--- a/scripts/generate-contract-snapshot.mjs
+++ b/scripts/generate-contract-snapshot.mjs
@@ -6,7 +6,7 @@ const result = await build({
   bundle: true,
   format: 'esm',
   platform: 'node',
-  target: 'node20',
+  target: 'node22.12',
   write: false,
 });
 

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const expectEngineRejection = process.argv.includes(
+  '--expect-engine-rejection',
+);
+const root = process.cwd();
+const workspace = mkdtempSync(join(tmpdir(), 'librarium-packed-consumer-'));
+const packDirectory = join(workspace, 'pack');
+const consumerDirectory = join(workspace, 'consumer');
+// The temporary consumer isolates package resolution. Reuse the caller's npm
+// cache so this gate does not redownload the dependency graph after `npm ci`.
+const npmEnvironment = process.env;
+
+function npmCommand() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function runNode(args, cwd = consumerDirectory) {
+  return execFileSync(process.execPath, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function runInstalledCli(args) {
+  const executable = join(
+    consumerDirectory,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'librarium.cmd' : 'librarium',
+  );
+
+  if (process.platform === 'win32') {
+    const command = [
+      '"',
+      executable.replaceAll('"', '""'),
+      '" ',
+      args.join(' '),
+    ].join('');
+    return execFileSync(
+      process.env.ComSpec ?? 'cmd.exe',
+      ['/d', '/s', '/c', command],
+      {
+        cwd: consumerDirectory,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    ).trim();
+  }
+
+  return execFileSync(executable, args, {
+    cwd: consumerDirectory,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+try {
+  mkdirSync(packDirectory);
+  mkdirSync(consumerDirectory);
+
+  execFileSync(npmCommand(), ['pack', '--pack-destination', packDirectory], {
+    cwd: root,
+    encoding: 'utf8',
+    env: npmEnvironment,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  if (pkg.engines?.node !== '>=22.12.0') {
+    throw new Error(
+      `Expected package engines.node to be >=22.12.0, received ${String(pkg.engines?.node)}`,
+    );
+  }
+  const tarball = resolve(
+    packDirectory,
+    `${pkg.name.replace('@', '').replace('/', '-')}-${pkg.version}.tgz`,
+  );
+
+  execFileSync(npmCommand(), ['init', '--yes'], {
+    cwd: consumerDirectory,
+    env: npmEnvironment,
+    stdio: 'ignore',
+  });
+
+  const install = spawnSync(
+    npmCommand(),
+    [
+      'install',
+      '--engine-strict',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--prefer-offline',
+      tarball,
+    ],
+    {
+      cwd: consumerDirectory,
+      encoding: 'utf8',
+      env: { ...npmEnvironment, npm_config_engine_strict: 'true' },
+    },
+  );
+
+  if (expectEngineRejection) {
+    if (install.status === 0) {
+      throw new Error(
+        `Expected Node ${process.version} to reject ${pkg.name} ${pkg.engines.node}`,
+      );
+    }
+
+    const diagnostics = `${install.stdout ?? ''}\n${install.stderr ?? ''}`;
+    if (!/EBADENGINE|Unsupported engine/i.test(diagnostics)) {
+      throw new Error(
+        `Expected an engine-strict rejection, received:\n${diagnostics.trim()}`,
+      );
+    }
+    if (
+      !diagnostics.includes(`${pkg.name}@${pkg.version}`) ||
+      !diagnostics.includes(pkg.engines.node)
+    ) {
+      throw new Error(
+        `Engine rejection did not identify ${pkg.name}@${pkg.version} ${pkg.engines.node}:\n${diagnostics.trim()}`,
+      );
+    }
+
+    console.log(
+      `Verified Node ${process.version} rejects ${pkg.name} ${pkg.engines.node}`,
+    );
+  } else {
+    if (install.status !== 0) {
+      throw new Error(
+        `Packed consumer install failed:\n${install.stdout ?? ''}\n${install.stderr ?? ''}`,
+      );
+    }
+
+    runNode([
+      '--input-type=module',
+      '--eval',
+      "await import('librarium/core'); await import('librarium/node');",
+    ]);
+
+    runInstalledCli(['--help']);
+    const version = runInstalledCli(['--version']);
+    if (version !== pkg.version) {
+      throw new Error(
+        `Expected CLI version ${pkg.version}, received ${version}`,
+      );
+    }
+
+    console.log(
+      `Verified packed ${pkg.name}@${pkg.version} on ${process.version}: install, CLI, core, node`,
+    );
+  }
+} finally {
+  rmSync(workspace, { recursive: true, force: true });
+}

--- a/scripts/verify-sea.mjs
+++ b/scripts/verify-sea.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { accessSync, constants, readFileSync } from 'node:fs';
 import { arch, platform } from 'node:os';
-import { delimiter, dirname, join, resolve } from 'node:path';
+import { delimiter, join, resolve } from 'node:path';
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const os = platform();
@@ -13,16 +13,45 @@ const binary =
     ? `librarium-windows-${cpu}.exe`
     : `librarium-${os === 'darwin' ? 'macos' : 'linux'}-${cpu}`;
 const executable = join(process.cwd(), 'dist', binary);
-const hostNodeDirectory = resolve(dirname(process.execPath));
-const pathWithoutHostNode = (process.env.PATH ?? '')
+const pathEntries = (process.env.PATH ?? '')
   .split(delimiter)
-  .filter((entry) => entry && resolve(entry) !== hostNodeDirectory)
-  .join(delimiter);
+  .filter(Boolean)
+  .map((entry) => resolve(entry));
+
+function containsNodeExecutable(directory) {
+  for (const filename of ['node', 'node.exe']) {
+    try {
+      accessSync(
+        join(directory, filename),
+        os === 'win32' ? constants.F_OK : constants.X_OK,
+      );
+      return true;
+    } catch {
+      // Keep checking the other platform spelling.
+    }
+  }
+  return false;
+}
+
+const nodeDirectories = new Set(pathEntries.filter(containsNodeExecutable));
+if (nodeDirectories.size === 0) {
+  throw new Error(
+    'SEA verification could not identify a Node.js executable on PATH',
+  );
+}
+
+const isolatedPathEntries = pathEntries.filter(
+  (entry) => !nodeDirectories.has(entry),
+);
+if (isolatedPathEntries.some(containsNodeExecutable)) {
+  throw new Error('SEA verification failed to remove Node.js from PATH');
+}
+const pathWithoutNode = isolatedPathEntries.join(delimiter);
 
 function run(args) {
   return execFileSync(executable, args, {
     encoding: 'utf8',
-    env: { ...process.env, PATH: pathWithoutHostNode },
+    env: { ...process.env, PATH: pathWithoutNode },
     stdio: ['ignore', 'pipe', 'pipe'],
   }).trim();
 }

--- a/scripts/verify-sea.mjs
+++ b/scripts/verify-sea.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { arch, platform } from 'node:os';
+import { delimiter, dirname, join, resolve } from 'node:path';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const os = platform();
+const cpu = arch();
+const binary =
+  os === 'win32'
+    ? `librarium-windows-${cpu}.exe`
+    : `librarium-${os === 'darwin' ? 'macos' : 'linux'}-${cpu}`;
+const executable = join(process.cwd(), 'dist', binary);
+const hostNodeDirectory = resolve(dirname(process.execPath));
+const pathWithoutHostNode = (process.env.PATH ?? '')
+  .split(delimiter)
+  .filter((entry) => entry && resolve(entry) !== hostNodeDirectory)
+  .join(delimiter);
+
+function run(args) {
+  return execFileSync(executable, args, {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: pathWithoutHostNode },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+run(['--help']);
+const version = run(['--version']);
+if (version !== pkg.version) {
+  throw new Error(`Expected SEA version ${pkg.version}, received ${version}`);
+}
+
+console.log(`Verified ${binary}: --help and --version (${version})`);

--- a/src/cli-parsers.ts
+++ b/src/cli-parsers.ts
@@ -1,0 +1,164 @@
+import { InvalidArgumentError } from 'commander';
+import {
+  RESEARCH_REQUEST_LIMITS,
+  ResearchQuerySchema,
+} from './core/research-request.js';
+import { type Defaults, LegacyExecutionModeSchema } from './types.js';
+
+const MICRO_USD_PER_USD = 1_000_000n;
+const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
+
+export const CLI_LIMITS = {
+  providers: RESEARCH_REQUEST_LIMITS.profiles,
+  parallel: {
+    min: RESEARCH_REQUEST_LIMITS.minConcurrency,
+    max: RESEARCH_REQUEST_LIMITS.maxConcurrency,
+  },
+  timeoutSeconds: {
+    min: RESEARCH_REQUEST_LIMITS.minDeadlineMs / 1_000,
+    max: RESEARCH_REQUEST_LIMITS.maxDeadlineMs / 1_000,
+  },
+  queryLength: RESEARCH_REQUEST_LIMITS.queryLength,
+} as const;
+
+export type CliMode = Defaults['mode'];
+export type CompletionShell = 'zsh' | 'bash' | 'fish';
+export type ConfigAction = 'menu';
+
+function invalid(message: string): never {
+  throw new InvalidArgumentError(message);
+}
+
+export function parseResearchQuery(value: string): string {
+  const result = ResearchQuerySchema.safeParse(value);
+  if (result.success) return result.data;
+  return invalid(result.error.issues[0]?.message ?? 'is not a valid query.');
+}
+
+export function parseProviders(value: string): string[] {
+  const providers = value.split(',').map((provider) => provider.trim());
+  if (providers.some((provider) => provider.length === 0)) {
+    return invalid('must be a comma-separated list of non-empty provider IDs.');
+  }
+  if (providers.length > CLI_LIMITS.providers) {
+    return invalid(`must contain at most ${CLI_LIMITS.providers} providers.`);
+  }
+  return providers;
+}
+
+export function parseMode(value: string): CliMode {
+  const result = LegacyExecutionModeSchema.safeParse(value);
+  if (result.success) return result.data;
+  return invalid('must be one of: sync, async, mixed.');
+}
+
+export function parseParallel(value: string): number {
+  return parseBoundedInteger(
+    value,
+    CLI_LIMITS.parallel.min,
+    CLI_LIMITS.parallel.max,
+  );
+}
+
+export function parseTimeoutSeconds(value: string): number {
+  return parseBoundedInteger(
+    value,
+    CLI_LIMITS.timeoutSeconds.min,
+    CLI_LIMITS.timeoutSeconds.max,
+  );
+}
+
+export function parsePositiveDays(value: string): number {
+  return parseBoundedInteger(value, 1, Number.MAX_SAFE_INTEGER);
+}
+
+export function parseCompletionShell(value: string): CompletionShell {
+  if (value === 'zsh' || value === 'bash' || value === 'fish') {
+    return value;
+  }
+  return invalid('must be one of: zsh, bash, fish.');
+}
+
+export function parseConfigAction(value: string): ConfigAction {
+  if (value === 'menu') return value;
+  return invalid('must be "menu" when supplied.');
+}
+
+/**
+ * Parse a positive USD budget through an exact micro-USD integer. Decimal and
+ * exponent spellings are normalized; sub-micro precision is never rounded.
+ */
+export function parseUsdBudget(value: string): number {
+  const normalized = value.trim();
+  if (normalized.length > RESEARCH_REQUEST_LIMITS.exactIntegerLength * 2) {
+    return invalid('is too large to represent safely.');
+  }
+  const match = /^\+?(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:[eE]([+-]?\d+))?$/.exec(
+    normalized,
+  );
+  if (!match) {
+    return invalid('must be a positive decimal or exponent-form USD amount.');
+  }
+
+  const fraction = match[2] ?? match[3] ?? '';
+  const coefficientDigits = `${match[1] ?? '0'}${fraction}`;
+  const coefficient = BigInt(coefficientDigits);
+  if (coefficient === 0n) {
+    return invalid('must be at least 0.000001 USD.');
+  }
+
+  const exponent = BigInt(match[4] ?? '0');
+  const microPower = 6n - BigInt(fraction.length) + exponent;
+  let microUsd: bigint;
+  if (microPower >= 0n) {
+    if (microPower > 20n) {
+      return invalid('is too large to represent safely.');
+    }
+    microUsd = coefficient * 10n ** microPower;
+  } else {
+    const divisorPower = -microPower;
+    if (divisorPower > BigInt(coefficientDigits.length)) {
+      return invalid('must not use precision smaller than one micro-USD.');
+    }
+    const divisor = 10n ** divisorPower;
+    if (coefficient % divisor !== 0n) {
+      return invalid('must not use precision smaller than one micro-USD.');
+    }
+    microUsd = coefficient / divisor;
+  }
+
+  if (microUsd <= 0n) {
+    return invalid('must be at least 0.000001 USD.');
+  }
+  if (microUsd > MAX_SAFE_INTEGER) {
+    return invalid('is too large to represent safely.');
+  }
+
+  const parsed = Number(microUsd) / Number(MICRO_USD_PER_USD);
+  if (Math.round(parsed * Number(MICRO_USD_PER_USD)) !== Number(microUsd)) {
+    return invalid('is too large to preserve exact micro-USD precision.');
+  }
+  return parsed;
+}
+
+function parseBoundedInteger(
+  value: string,
+  minimum: number,
+  maximum: number,
+): number {
+  const normalized = value.trim();
+  if (!/^\+?\d+$/.test(normalized)) {
+    return invalid(
+      'must be a base-10 integer without a minus sign or decimals.',
+    );
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed)) {
+    return invalid('must be a safe integer.');
+  }
+  if (parsed < minimum || parsed > maximum) {
+    return invalid(`must be between ${minimum} and ${maximum}.`);
+  }
+  return parsed;
+}

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import { registerAnswerCommand } from './commands/answer.js';
+import { registerBrowseCommand } from './commands/browse.js';
+import { registerCleanupCommand } from './commands/cleanup.js';
+import { registerCompletionsCommand } from './commands/completions.js';
+import { registerConfigCommand } from './commands/config.js';
+import { registerDoctorCommand } from './commands/doctor.js';
+import { registerGroupsCommand } from './commands/groups.js';
+import { registerHtmlCommand } from './commands/html.js';
+import { registerInitCommand } from './commands/init.js';
+import { registerInstallSkillCommand } from './commands/install-skill.js';
+import { registerJsonlCommand } from './commands/jsonl.js';
+import { registerLsCommand } from './commands/ls.js';
+import { registerMcpCommand } from './commands/mcp.js';
+import { registerRefineCommand } from './commands/refine.js';
+import { registerRunCommand } from './commands/run.js';
+import { registerStatusCommand } from './commands/status.js';
+import { registerUpgradeCommand } from './commands/upgrade.js';
+import { registerUsageCommand } from './commands/usage.js';
+import { VERSION } from './constants.js';
+
+/** Build the complete CLI command tree without parsing argv or running actions. */
+export function createCliProgram(): Command {
+  const program = new Command();
+
+  program
+    .name('librarium')
+    .description(
+      'Fan out research queries to multiple search and deep-research APIs in parallel',
+    )
+    .version(VERSION);
+
+  registerRunCommand(program);
+  registerAnswerCommand(program);
+  registerStatusCommand(program);
+  registerUsageCommand(program);
+  registerBrowseCommand(program);
+  registerHtmlCommand(program);
+  registerJsonlCommand(program);
+  registerRefineCommand(program);
+  registerCompletionsCommand(program);
+  registerLsCommand(program);
+  registerGroupsCommand(program);
+  registerInitCommand(program);
+  registerDoctorCommand(program);
+  registerConfigCommand(program);
+  registerCleanupCommand(program);
+  registerUpgradeCommand(program);
+  registerInstallSkillCommand(program);
+  registerMcpCommand(program);
+
+  return program;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,51 +1,6 @@
-import { Command } from 'commander';
-import { registerAnswerCommand } from './commands/answer.js';
-import { registerBrowseCommand } from './commands/browse.js';
-import { registerCleanupCommand } from './commands/cleanup.js';
-import { registerCompletionsCommand } from './commands/completions.js';
-import { registerConfigCommand } from './commands/config.js';
-import { registerDoctorCommand } from './commands/doctor.js';
-import { registerGroupsCommand } from './commands/groups.js';
-import { registerHtmlCommand } from './commands/html.js';
-import { registerInitCommand } from './commands/init.js';
-import { registerInstallSkillCommand } from './commands/install-skill.js';
-import { registerJsonlCommand } from './commands/jsonl.js';
-import { registerLsCommand } from './commands/ls.js';
-import { registerMcpCommand } from './commands/mcp.js';
-import { registerRefineCommand } from './commands/refine.js';
-import { registerRunCommand } from './commands/run.js';
-import { registerStatusCommand } from './commands/status.js';
-import { registerUpgradeCommand } from './commands/upgrade.js';
-import { registerUsageCommand } from './commands/usage.js';
-import { VERSION } from './constants.js';
+import { createCliProgram } from './cli-program.js';
 
-const program = new Command();
-
-program
-  .name('librarium')
-  .description(
-    'Fan out research queries to multiple search and deep-research APIs in parallel',
-  )
-  .version(VERSION);
-
-registerRunCommand(program);
-registerAnswerCommand(program);
-registerStatusCommand(program);
-registerUsageCommand(program);
-registerBrowseCommand(program);
-registerHtmlCommand(program);
-registerJsonlCommand(program);
-registerRefineCommand(program);
-registerCompletionsCommand(program);
-registerLsCommand(program);
-registerGroupsCommand(program);
-registerInitCommand(program);
-registerDoctorCommand(program);
-registerConfigCommand(program);
-registerCleanupCommand(program);
-registerUpgradeCommand(program);
-registerInstallSkillCommand(program);
-registerMcpCommand(program);
+const program = createCliProgram();
 
 // Bare `librarium` in an interactive terminal launches the wizard. Non-TTY
 // bare invocations (pipes, CI) keep printing help so scripts never hang.

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -1,5 +1,12 @@
 import { join } from 'node:path';
 import type { Command } from 'commander';
+import {
+  parseMode,
+  parseParallel,
+  parseProviders,
+  parseResearchQuery,
+  parseTimeoutSeconds,
+} from '../cli-parsers.js';
 import { safeWriteFile } from '../core/fs-utils.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
 import type { Config, ProviderDispatchResult } from '../types.js';
@@ -45,17 +52,25 @@ export function registerAnswerCommand(program: Command): void {
     .description(
       'Fan out a query and synthesize one grounded, cited answer from the results',
     )
-    .argument('<query>', 'The research query')
+    .argument('<query>', 'The research query', parseResearchQuery)
     .option(
       '-p, --providers <ids>',
       'Comma-separated provider IDs',
-      (v: string) => v.split(','),
+      parseProviders,
     )
     .option('-g, --group <name>', 'Use a predefined provider group')
-    .option('-m, --mode <mode>', 'Execution mode: sync, async, or mixed')
+    .option(
+      '-m, --mode <mode>',
+      'Execution mode: sync, async, or mixed',
+      parseMode,
+    )
     .option('-o, --output <dir>', 'Output base directory')
-    .option('--parallel <n>', 'Max parallel requests', Number.parseInt)
-    .option('--timeout <n>', 'Timeout per provider in seconds', Number.parseInt)
+    .option('--parallel <n>', 'Max parallel requests', parseParallel)
+    .option(
+      '--timeout <n>',
+      'Timeout per provider in seconds',
+      parseTimeoutSeconds,
+    )
     .option(
       '--max-cost <usd>',
       'Stop launching providers once API-reported cost crosses this budget (USD)',
@@ -67,6 +82,10 @@ export function registerAnswerCommand(program: Command): void {
       parseMaxCost,
     )
     .option('-y, --yes', 'Skip the deep-research pre-flight confirm')
+    .option(
+      '--no-fallback',
+      'Disable configured provider fallbacks for an exact provider matrix',
+    )
     .option('--json', 'Output run.json to stdout')
     .option(
       '--refine',

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -2,6 +2,7 @@ import { rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import * as p from '@clack/prompts';
 import type { Command } from 'commander';
+import { parsePositiveDays } from '../cli-parsers.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import { formatRunDate } from './browse-data.js';
 import {
@@ -32,7 +33,7 @@ export function registerCleanupCommand(program: Command): void {
     .option(
       '--days <n>',
       'Age threshold in days (default: 30)',
-      Number.parseInt,
+      parsePositiveDays,
       30,
     )
     .option('--all', 'Delete every run directory regardless of age')

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,4 +1,5 @@
-import type { Command } from 'commander';
+import type { Command, Option } from 'commander';
+import { type CompletionShell, parseCompletionShell } from '../cli-parsers.js';
 import { DEFAULT_GROUPS } from '../constants.js';
 
 /**
@@ -10,101 +11,50 @@ interface CommandSpec {
   name: string;
   description: string;
   flags: string[];
+  groupAware: boolean;
 }
-
-/** Commands that accept a -g/--group flag and so get group-name completion. */
-const GROUP_AWARE_COMMANDS = new Set(['run', 'answer']);
-
-const COMMANDS: CommandSpec[] = [
-  {
-    name: 'run',
-    description: 'Run a research query across providers',
-    flags: [
-      '--providers',
-      '--group',
-      '--mode',
-      '--output',
-      '--parallel',
-      '--timeout',
-      '--json',
-      '--html',
-      '--open',
-      '--refine',
-    ],
-  },
-  {
-    name: 'answer',
-    description: 'Synthesize one grounded, cited answer from a fan-out',
-    flags: [
-      '--providers',
-      '--group',
-      '--mode',
-      '--output',
-      '--parallel',
-      '--timeout',
-      '--json',
-      '--refine',
-      '--html',
-      '--jsonl',
-      '--open',
-    ],
-  },
-  {
-    name: 'status',
-    description: 'Check async deep-research tasks',
-    flags: ['--wait', '--retrieve', '--json'],
-  },
-  {
-    name: 'browse',
-    description: 'Browse past runs interactively',
-    flags: ['--output'],
-  },
-  {
-    name: 'html',
-    description: 'Generate report.html for a run',
-    flags: ['--open'],
-  },
-  {
-    name: 'refine',
-    description: 'Rewrite a query into tier-tuned variants',
-    flags: ['--json'],
-  },
-  { name: 'ls', description: 'List providers', flags: ['--json'] },
-  { name: 'groups', description: 'List or manage groups', flags: ['--json'] },
-  { name: 'init', description: 'Set up configuration', flags: ['--auto'] },
-  { name: 'doctor', description: 'Provider health check', flags: ['--json'] },
-  { name: 'config', description: 'Show resolved config', flags: ['--json'] },
-  {
-    name: 'cleanup',
-    description: 'Delete old run directories',
-    flags: ['--days', '--dry-run'],
-  },
-  { name: 'upgrade', description: 'Upgrade librarium', flags: [] },
-  {
-    name: 'install-skill',
-    description: 'Install the agent skill',
-    flags: [],
-  },
-  {
-    name: 'completions',
-    description: 'Print shell completion script',
-    flags: [],
-  },
-];
 
 const GROUP_NAMES = Object.keys(DEFAULT_GROUPS);
 
-export function zshCompletions(): string {
-  const commandLines = COMMANDS.map(
-    (c) => `    '${c.name}:${c.description}'`,
-  ).join('\n');
-  const cases = COMMANDS.filter((c) => c.flags.length > 0)
-    .map((c) => {
-      const flagWords = c.flags.join(' ');
-      const groupCase = GROUP_AWARE_COMMANDS.has(c.name)
+function optionFlags(option: Option): string[] {
+  return [option.short, option.long].filter(
+    (flag): flag is string => typeof flag === 'string',
+  );
+}
+
+/** Read completion metadata from the same Commander tree used at runtime. */
+function commandSpecs(program: Command): CommandSpec[] {
+  return program.commands.map((command) => {
+    const flags = command.options.flatMap(optionFlags);
+    return {
+      name: command.name(),
+      description: command.description(),
+      flags,
+      groupAware: command.options.some((option) => option.long === '--group'),
+    };
+  });
+}
+
+function singleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+export function zshCompletions(program: Command): string {
+  const commands = commandSpecs(program);
+  const commandLines = commands
+    .map(
+      (command) =>
+        `    ${singleQuote(`${command.name}:${command.description}`)}`,
+    )
+    .join('\n');
+  const cases = commands
+    .filter((command) => command.flags.length > 0)
+    .map((command) => {
+      const flagWords = command.flags.join(' ');
+      const groupCase = command.groupAware
         ? `\n      if [[ $words[CURRENT-1] == '-g' || $words[CURRENT-1] == '--group' ]]; then\n        compadd ${GROUP_NAMES.join(' ')}\n        return\n      fi`
         : '';
-      return `    ${c.name})${groupCase}\n      compadd -- ${flagWords}\n      ;;`;
+      return `    ${command.name})${groupCase}\n      compadd -- ${flagWords}\n      ;;`;
     })
     .join('\n');
 
@@ -133,10 +83,18 @@ fi
 `;
 }
 
-export function bashCompletions(): string {
-  const names = COMMANDS.map((c) => c.name).join(' ');
-  const flagCases = COMMANDS.filter((c) => c.flags.length > 0)
-    .map((c) => `    ${c.name}) flags="${c.flags.join(' ')}" ;;`)
+export function bashCompletions(program: Command): string {
+  const commands = commandSpecs(program);
+  const names = commands.map((command) => command.name).join(' ');
+  const groupAwareNames = commands
+    .filter((command) => command.groupAware)
+    .map((command) => command.name)
+    .join(' ');
+  const flagCases = commands
+    .filter((command) => command.flags.length > 0)
+    .map(
+      (command) => `    ${command.name}) flags="${command.flags.join(' ')}" ;;`,
+    )
     .join('\n');
 
   return `# librarium bash completions. Install:
@@ -152,7 +110,7 @@ _librarium_completions() {
     return
   fi
 
-  if [[ "\${prev}" == "-g" || "\${prev}" == "--group" ]]; then
+  if [[ " ${groupAwareNames} " == *" \${cmd} "* && ( "\${prev}" == "-g" || "\${prev}" == "--group" ) ]]; then
     COMPREPLY=( $(compgen -W "${GROUP_NAMES.join(' ')}" -- "\${cur}") )
     return
   fi
@@ -167,20 +125,28 @@ complete -F _librarium_completions librarium
 `;
 }
 
-export function fishCompletions(): string {
-  const commandLines = COMMANDS.map(
-    (c) =>
-      `complete -c librarium -n __fish_use_subcommand -a ${c.name} -d '${c.description}'`,
-  ).join('\n');
-  const flagLines = COMMANDS.flatMap((c) =>
-    c.flags.map(
-      (flag) =>
-        `complete -c librarium -n '__fish_seen_subcommand_from ${c.name}' -l ${flag.replace(/^--/, '')}`,
-    ),
-  ).join('\n');
-  const groupLine = `complete -c librarium -n '__fish_seen_subcommand_from ${[
-    ...GROUP_AWARE_COMMANDS,
-  ].join(' ')}' -s g -l group -a '${GROUP_NAMES.join(' ')}'`;
+export function fishCompletions(program: Command): string {
+  const commands = commandSpecs(program);
+  const commandLines = commands
+    .map(
+      (command) =>
+        `complete -c librarium -n __fish_use_subcommand -a ${command.name} -d ${singleQuote(command.description)}`,
+    )
+    .join('\n');
+  const flagLines = commands
+    .flatMap((command) =>
+      command.flags
+        .filter((flag) => flag !== '-g' && flag !== '--group')
+        .map((flag) => {
+          const kind = flag.startsWith('--') ? '-l' : '-s';
+          return `complete -c librarium -n '__fish_seen_subcommand_from ${command.name}' ${kind} ${flag.replace(/^-+/, '')}`;
+        }),
+    )
+    .join('\n');
+  const groupLine = `complete -c librarium -n '__fish_seen_subcommand_from ${commands
+    .filter((command) => command.groupAware)
+    .map((command) => command.name)
+    .join(' ')}' -s g -l group -a '${GROUP_NAMES.join(' ')}'`;
 
   return `# librarium fish completions. Install:
 #   librarium completions fish > ~/.config/fish/completions/librarium.fish
@@ -192,24 +158,20 @@ ${groupLine}
 
 export function registerCompletionsCommand(program: Command): void {
   program
-    .command('completions <shell>')
+    .command('completions')
     .description('Print a shell completion script (zsh, bash, or fish)')
-    .action((shell: string) => {
+    .argument('<shell>', 'Shell to generate for', parseCompletionShell)
+    .action((shell: CompletionShell) => {
       switch (shell) {
         case 'zsh':
-          process.stdout.write(zshCompletions());
+          process.stdout.write(zshCompletions(program));
           break;
         case 'bash':
-          process.stdout.write(bashCompletions());
+          process.stdout.write(bashCompletions(program));
           break;
         case 'fish':
-          process.stdout.write(fishCompletions());
+          process.stdout.write(fishCompletions(program));
           break;
-        default:
-          console.error(
-            `Unsupported shell "${shell}". Supported: zsh, bash, fish.`,
-          );
-          process.exitCode = 2;
       }
     });
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import type { Command } from 'commander';
+import { parseConfigAction } from '../cli-parsers.js';
 import {
   CONFIG_FILE,
   loadConfig,
@@ -14,7 +15,7 @@ export function registerConfigCommand(program: Command): void {
   program
     .command('config')
     .description('Print or edit librarium configuration')
-    .argument('[action]', 'Use "menu" to edit settings')
+    .argument('[action]', 'Use "menu" to edit settings', parseConfigAction)
     .option('--json', 'Output raw JSON')
     .option('--global', 'Show only global config (ignore project config)')
     .option('--menu', 'Open the interactive config menu')
@@ -23,12 +24,6 @@ export function registerConfigCommand(program: Command): void {
         if (opts.menu || action === 'menu') {
           await runConfigMenu();
           return;
-        }
-
-        if (action) {
-          throw new Error(
-            `Unknown config action "${action}". Use "librarium config menu" to edit settings.`,
-          );
         }
 
         const globalConfig = loadConfig();

--- a/src/commands/refine.ts
+++ b/src/commands/refine.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { parseResearchQuery } from '../cli-parsers.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import type { CredentialContext, EnvRecord } from '../core/credentials.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
@@ -176,10 +177,11 @@ export async function refineQuery(
 
 export function registerRefineCommand(program: Command): void {
   program
-    .command('refine <query>')
+    .command('refine')
     .description(
       'Rewrite a query into tier-tuned variants (no dispatch); suggests a group',
     )
+    .argument('<query>', 'The research query', parseResearchQuery)
     .option('--json', 'Output JSON')
     .action(async (query: string, opts: { json?: boolean }) => {
       try {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,12 +2,20 @@ import { spawn } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import * as p from '@clack/prompts';
-import { type Command, InvalidArgumentError } from 'commander';
+import type { Command } from 'commander';
 import ora from 'ora';
 import {
   getAllProviders,
   initializeProviders,
 } from '../adapters/node-registry.js';
+import {
+  parseMode,
+  parseParallel,
+  parseProviders,
+  parseResearchQuery,
+  parseTimeoutSeconds,
+  parseUsdBudget,
+} from '../cli-parsers.js';
 import {
   BUDGET_SKIP_REASON,
   createBudgetTracker,
@@ -128,28 +136,32 @@ export interface ExecuteRunHooks {
  * circuit breaker. Shared by `run` and `answer` so both validate identically.
  */
 export function parseMaxCost(value: string): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new InvalidArgumentError('must be a positive number of USD.');
-  }
-  return parsed;
+  return parseUsdBudget(value);
 }
 
 export function registerRunCommand(program: Command): void {
   program
     .command('run')
     .description('Run a research query across multiple providers')
-    .argument('<query>', 'The research query')
+    .argument('<query>', 'The research query', parseResearchQuery)
     .option(
       '-p, --providers <ids>',
       'Comma-separated provider IDs',
-      (v: string) => v.split(','),
+      parseProviders,
     )
     .option('-g, --group <name>', 'Use a predefined provider group')
-    .option('-m, --mode <mode>', 'Execution mode: sync, async, or mixed')
+    .option(
+      '-m, --mode <mode>',
+      'Execution mode: sync, async, or mixed',
+      parseMode,
+    )
     .option('-o, --output <dir>', 'Output base directory')
-    .option('--parallel <n>', 'Max parallel requests', Number.parseInt)
-    .option('--timeout <n>', 'Timeout per provider in seconds', Number.parseInt)
+    .option('--parallel <n>', 'Max parallel requests', parseParallel)
+    .option(
+      '--timeout <n>',
+      'Timeout per provider in seconds',
+      parseTimeoutSeconds,
+    )
     .option(
       '--max-cost <usd>',
       'Stop launching providers once API-reported cost crosses this budget (USD)',

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import type { Command } from 'commander';
+import { parsePositiveDays } from '../cli-parsers.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import { formatRunDate } from './browse-data.js';
 import { formatCost, formatTokens } from './run-format.js';
@@ -18,7 +19,7 @@ export function registerUsageCommand(program: Command): void {
     .option(
       '--days <n>',
       'Only include runs from the last N days',
-      Number.parseInt,
+      parsePositiveDays,
     )
     .option('--json', 'Output JSON')
     .option('-o, --output <dir>', 'Output base directory')

--- a/src/core/research-request.ts
+++ b/src/core/research-request.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod/v4';
 import { OpaqueIdSchema } from '../contracts/common.js';
-import { EvidenceRequirementsSchema } from '../contracts/interchange/request.js';
+import {
+  EvidenceRequirementsSchema,
+  ExecutionModeSchema,
+} from '../contracts/interchange/request.js';
 
 export const RESEARCH_REQUEST_LIMITS = {
   queryLength: 100_000,
@@ -14,6 +17,15 @@ export const RESEARCH_REQUEST_LIMITS = {
   minPollIntervalMs: 100,
   maxPollIntervalMs: 5 * 60 * 1_000,
 } as const;
+
+export const ResearchQuerySchema = z
+  .string()
+  .trim()
+  .min(1, 'must not be blank.')
+  .max(
+    RESEARCH_REQUEST_LIMITS.queryLength,
+    `must be at most ${RESEARCH_REQUEST_LIMITS.queryLength.toLocaleString('en-US')} characters.`,
+  );
 
 export const ExactMicrousdSchema = z
   .string()
@@ -143,8 +155,8 @@ export const RefinementIntentSchema = z.discriminatedUnion('kind', [
 ]);
 
 export const CanonicalResearchRequestSchema = z.strictObject({
-  query: z.string().trim().min(1).max(RESEARCH_REQUEST_LIMITS.queryLength),
-  mode: z.enum(['sync', 'async']),
+  query: ResearchQuerySchema,
+  mode: ExecutionModeSchema,
   selector: ResearchSelectorSchema,
   fallback: FallbackIntentSchema,
   limits: ResearchExecutionLimitsSchema,

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,13 +319,15 @@ export const CustomProviderSourceSchema = z.discriminatedUnion('type', [
 export type CustomProviderSource = z.infer<typeof CustomProviderSourceSchema>;
 
 // Defaults config
+export const LegacyExecutionModeSchema = z.enum(['sync', 'async', 'mixed']);
+
 export const DefaultsSchema = z.object({
   outputDir: z.string().default('./agents/librarium'),
   maxParallel: z.number().default(6),
   timeout: z.number().default(30),
   asyncTimeout: z.number().default(1800),
   asyncPollInterval: z.number().default(30),
-  mode: z.enum(['sync', 'async', 'mixed']).default('mixed'),
+  mode: LegacyExecutionModeSchema.default('mixed'),
   llmWebSearch: z.boolean().default(true),
   // Optional runtime spend circuit breaker. Honest budget: only API-reported
   // costs count toward it (see src/core/budget.ts). Unset means no limit.
@@ -374,7 +376,7 @@ export const ProjectConfigSchema = z.object({
       timeout: z.number().optional(),
       asyncTimeout: z.number().optional(),
       asyncPollInterval: z.number().optional(),
-      mode: z.enum(['sync', 'async', 'mixed']).optional(),
+      mode: LegacyExecutionModeSchema.optional(),
       llmWebSearch: z.boolean().optional(),
       maxCostUsd: z.number().optional(),
       maxEstimatedCostUsd: z.number().optional(),

--- a/tests/answer-hardening.test.ts
+++ b/tests/answer-hardening.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { createCliProgram } from '../src/cli-program.js';
 import { citationWarnings, renderSourceLink } from '../src/commands/answer.js';
 import {
   buildSynthesisPrompt,
@@ -112,9 +113,10 @@ describe('citation validation warnings', () => {
 
 describe('answer command completions parity', () => {
   it('includes answer with its flags and group completion in all shells', () => {
-    const zsh = zshCompletions();
-    const bash = bashCompletions();
-    const fish = fishCompletions();
+    const program = createCliProgram();
+    const zsh = zshCompletions(program);
+    const bash = bashCompletions(program);
+    const fish = fishCompletions(program);
     for (const script of [zsh, bash, fish]) {
       expect(script).toContain('answer');
     }

--- a/tests/cli-parsers.test.ts
+++ b/tests/cli-parsers.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CLI_LIMITS,
+  parseCompletionShell,
+  parseConfigAction,
+  parseMode,
+  parseParallel,
+  parsePositiveDays,
+  parseProviders,
+  parseResearchQuery,
+  parseTimeoutSeconds,
+  parseUsdBudget,
+} from '../src/cli-parsers.js';
+
+describe('strict CLI parsers', () => {
+  it('trims valid research queries and rejects blank or overlong input', () => {
+    expect(parseResearchQuery('  useful query  ')).toBe('useful query');
+    expect(parseResearchQuery('x'.repeat(CLI_LIMITS.queryLength))).toHaveLength(
+      CLI_LIMITS.queryLength,
+    );
+    expect(() => parseResearchQuery('   ')).toThrow(/blank/);
+    expect(() =>
+      parseResearchQuery('x'.repeat(CLI_LIMITS.queryLength + 1)),
+    ).toThrow(/at most/);
+  });
+
+  it('normalizes bounded provider lists without accepting empty slots', () => {
+    expect(parseProviders('openai, perplexity')).toEqual([
+      'openai',
+      'perplexity',
+    ]);
+    expect(() => parseProviders('openai,,perplexity')).toThrow(/non-empty/);
+    expect(() =>
+      parseProviders(
+        Array.from(
+          { length: CLI_LIMITS.providers + 1 },
+          (_, index) => `provider-${index}`,
+        ).join(','),
+      ),
+    ).toThrow(/at most/);
+  });
+
+  it('accepts only the three legacy execution modes', () => {
+    expect(parseMode('sync')).toBe('sync');
+    expect(parseMode('async')).toBe('async');
+    expect(parseMode('mixed')).toBe('mixed');
+    expect(() => parseMode('background')).toThrow(/sync, async, mixed/);
+  });
+
+  it('parses bounded decimal integers without truncation or unsafe values', () => {
+    expect(parseParallel('1')).toBe(1);
+    expect(parseParallel('64')).toBe(64);
+    expect(parseParallel('01')).toBe(1);
+    expect(parseParallel('+01')).toBe(1);
+    expect(parseTimeoutSeconds('604800')).toBe(604_800);
+    expect(parsePositiveDays('365')).toBe(365);
+
+    for (const invalid of ['1.5', '1day', '-1', '0']) {
+      expect(() => parseParallel(invalid)).toThrow();
+    }
+    expect(() => parseParallel('65')).toThrow(/between 1 and 64/);
+    expect(() => parseTimeoutSeconds('604801')).toThrow(/between/);
+    expect(() => parsePositiveDays('9007199254740992')).toThrow(/safe integer/);
+  });
+
+  it('converts positive USD decimals without sub-micro rounding', () => {
+    expect(parseUsdBudget('2.50')).toBe(2.5);
+    expect(parseUsdBudget('.000001')).toBe(0.000001);
+    expect(parseUsdBudget('1.234567')).toBe(1.234567);
+    expect(parseUsdBudget('01')).toBe(1);
+    expect(parseUsdBudget('+01.50')).toBe(1.5);
+    expect(parseUsdBudget('1e3')).toBe(1_000);
+    expect(parseUsdBudget('1e-6')).toBe(0.000001);
+    expect(parseUsdBudget('10e-7')).toBe(0.000001);
+    expect(parseUsdBudget('9007199254.740990')).toBe(9007199254.74099);
+
+    for (const invalid of [
+      '0',
+      '-1',
+      '1.2345678',
+      '1e-7',
+      '11e-7',
+      'NaN',
+      'Infinity',
+      '9007199254.740991',
+    ]) {
+      expect(() => parseUsdBudget(invalid)).toThrow();
+    }
+  });
+
+  it('keeps closed shell and config-action vocabularies explicit', () => {
+    for (const shell of ['zsh', 'bash', 'fish'] as const) {
+      expect(parseCompletionShell(shell)).toBe(shell);
+    }
+    expect(() => parseCompletionShell('pwsh')).toThrow(/zsh, bash, fish/);
+    expect(parseConfigAction('menu')).toBe('menu');
+    expect(() => parseConfigAction('edit')).toThrow(/menu/);
+  });
+});

--- a/tests/cli-parsers.test.ts
+++ b/tests/cli-parsers.test.ts
@@ -30,6 +30,14 @@ describe('strict CLI parsers', () => {
       'perplexity',
     ]);
     expect(() => parseProviders('openai,,perplexity')).toThrow(/non-empty/);
+    expect(
+      parseProviders(
+        Array.from(
+          { length: CLI_LIMITS.providers },
+          (_, index) => `provider-${index}`,
+        ).join(','),
+      ),
+    ).toHaveLength(CLI_LIMITS.providers);
     expect(() =>
       parseProviders(
         Array.from(
@@ -52,8 +60,10 @@ describe('strict CLI parsers', () => {
     expect(parseParallel('64')).toBe(64);
     expect(parseParallel('01')).toBe(1);
     expect(parseParallel('+01')).toBe(1);
+    expect(parseTimeoutSeconds('1')).toBe(1);
     expect(parseTimeoutSeconds('604800')).toBe(604_800);
     expect(parsePositiveDays('365')).toBe(365);
+    expect(() => parsePositiveDays('0')).toThrow(/between 1/);
 
     for (const invalid of ['1.5', '1day', '-1', '0']) {
       expect(() => parseParallel(invalid)).toThrow();

--- a/tests/cli-program.test.ts
+++ b/tests/cli-program.test.ts
@@ -1,0 +1,104 @@
+import type { Command } from 'commander';
+import { describe, expect, it, vi } from 'vitest';
+import { createCliProgram } from '../src/cli-program.js';
+
+function command(program: Command, name: string): Command {
+  const found = program.commands.find((candidate) => candidate.name() === name);
+  if (!found) throw new Error(`Missing command: ${name}`);
+  return found;
+}
+
+async function expectRejectedBeforeAction(
+  args: string[],
+  commandName: string,
+): Promise<void> {
+  const program = createCliProgram();
+  program.exitOverride();
+  const output = { writeErr: () => {}, writeOut: () => {} };
+  program.configureOutput(output);
+  const action = vi.fn();
+  command(program, commandName).configureOutput(output).action(action);
+
+  await expect(
+    program.parseAsync(['node', 'librarium', ...args]),
+  ).rejects.toThrow();
+  expect(action).not.toHaveBeenCalled();
+}
+
+describe('CLI program factory', () => {
+  it('builds independent complete command trees without parsing argv', () => {
+    const first = createCliProgram();
+    const second = createCliProgram();
+    expect(first).not.toBe(second);
+    expect(first.commands.map((item) => item.name())).toEqual(
+      second.commands.map((item) => item.name()),
+    );
+    expect(first.commands.map((item) => item.name())).toContain('mcp');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('rejects invalid run values before invoking the action', async () => {
+    await expectRejectedBeforeAction(['run', '   '], 'run');
+    await expectRejectedBeforeAction(
+      ['run', 'query', '--parallel', '2workers'],
+      'run',
+    );
+    await expectRejectedBeforeAction(
+      ['run', 'query', '--mode', 'background'],
+      'run',
+    );
+    await expectRejectedBeforeAction(
+      ['run', 'query', '--providers', 'openai,'],
+      'run',
+    );
+    await expectRejectedBeforeAction(
+      ['run', 'query', '--max-cost', '0.0000001'],
+      'run',
+    );
+  });
+
+  it('rejects invalid answer and refine values before invoking actions', async () => {
+    await expectRejectedBeforeAction(
+      ['answer', 'query', '--timeout', '0'],
+      'answer',
+    );
+    await expectRejectedBeforeAction(['refine', 'x'.repeat(100_001)], 'refine');
+  });
+
+  it('rejects closed command arguments before invoking their actions', async () => {
+    await expectRejectedBeforeAction(['completions', 'pwsh'], 'completions');
+    await expectRejectedBeforeAction(['config', 'edit'], 'config');
+    await expectRejectedBeforeAction(['cleanup', '--days', '-1'], 'cleanup');
+    await expectRejectedBeforeAction(['usage', '--days', '1.5'], 'usage');
+  });
+
+  it('keeps Commander lone-negation fallback semantics aligned', async () => {
+    for (const commandName of ['run', 'answer']) {
+      for (const expectation of [
+        { flags: [] as string[], fallback: true },
+        { flags: ['--no-fallback'], fallback: false },
+      ]) {
+        const program = createCliProgram();
+        program.exitOverride();
+        const output = { writeErr: () => {}, writeOut: () => {} };
+        program.configureOutput(output);
+        const selected = command(program, commandName);
+        selected.configureOutput(output);
+        const action = vi.fn();
+        selected.action(action);
+
+        await program.parseAsync([
+          'node',
+          'librarium',
+          commandName,
+          '  query  ',
+          ...expectation.flags,
+        ]);
+
+        expect(action).toHaveBeenCalledOnce();
+        expect(action.mock.calls[0]?.[0]).toBe('query');
+        expect(selected.opts().fallback).toBe(expectation.fallback);
+      }
+    }
+  });
+});

--- a/tests/cli-program.test.ts
+++ b/tests/cli-program.test.ts
@@ -17,7 +17,10 @@ async function expectRejectedBeforeAction(
   const output = { writeErr: () => {}, writeOut: () => {} };
   program.configureOutput(output);
   const action = vi.fn();
-  command(program, commandName).configureOutput(output).action(action);
+  command(program, commandName)
+    .exitOverride()
+    .configureOutput(output)
+    .action(action);
 
   await expect(
     program.parseAsync(['node', 'librarium', ...args]),
@@ -70,6 +73,21 @@ describe('CLI program factory', () => {
     await expectRejectedBeforeAction(['config', 'edit'], 'config');
     await expectRejectedBeforeAction(['cleanup', '--days', '-1'], 'cleanup');
     await expectRejectedBeforeAction(['usage', '--days', '1.5'], 'usage');
+  });
+
+  it('uses exit code 1 for an invalid completion shell in v2', async () => {
+    const program = createCliProgram();
+    program.exitOverride();
+    const output = { writeErr: () => {}, writeOut: () => {} };
+    program.configureOutput(output);
+    command(program, 'completions').exitOverride().configureOutput(output);
+
+    await expect(
+      program.parseAsync(['node', 'librarium', 'completions', 'pwsh']),
+    ).rejects.toMatchObject({
+      code: 'commander.invalidArgument',
+      exitCode: 1,
+    });
   });
 
   it('keeps Commander lone-negation fallback semantics aligned', async () => {

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -1,4 +1,6 @@
+import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
+import { createCliProgram } from '../src/cli-program.js';
 import {
   bashCompletions,
   fishCompletions,
@@ -16,27 +18,44 @@ const GROUPS = [
   'all',
 ];
 const COMMANDS = ['run', 'status', 'browse', 'html', 'refine', 'completions'];
+const program = createCliProgram();
+const bashAvailable = spawnSync('bash', ['--version']).status === 0;
 
 describe('shell completions', () => {
   it('zsh script covers commands, flags, and group names', () => {
-    const script = zshCompletions();
+    const script = zshCompletions(program);
     expect(script).toContain('#compdef librarium');
     for (const command of COMMANDS) expect(script).toContain(command);
     expect(script).toContain('--providers');
     expect(script).toContain('--refine');
     for (const group of GROUPS) expect(script).toContain(group);
+    for (const command of program.commands) {
+      for (const option of command.options) {
+        if (option.short) expect(script).toContain(option.short);
+        if (option.long) expect(script).toContain(option.long);
+      }
+    }
   });
 
   it('bash script covers commands, flags, and group names', () => {
-    const script = bashCompletions();
+    const script = bashCompletions(program);
     expect(script).toContain('complete -F _librarium_completions librarium');
     for (const command of COMMANDS) expect(script).toContain(command);
     expect(script).toContain('--html');
     expect(script).toContain(GROUPS.join(' '));
   });
 
+  it.skipIf(!bashAvailable)('emits Bash with valid syntax', () => {
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-n'], {
+      input: bashCompletions(program),
+      encoding: 'utf8',
+    });
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+
   it('fish script covers commands, flags, and group names', () => {
-    const script = fishCompletions();
+    const script = fishCompletions(program);
     expect(script).toContain('__fish_use_subcommand');
     for (const command of COMMANDS) expect(script).toContain(command);
     expect(script).toContain(
@@ -46,9 +65,9 @@ describe('shell completions', () => {
 
   it('contains no em-dashes', () => {
     for (const script of [
-      zshCompletions(),
-      bashCompletions(),
-      fishCompletions(),
+      zshCompletions(program),
+      bashCompletions(program),
+      fishCompletions(program),
     ]) {
       expect(script).not.toContain('—');
     }

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -20,6 +20,7 @@ const GROUPS = [
 const COMMANDS = ['run', 'status', 'browse', 'html', 'refine', 'completions'];
 const program = createCliProgram();
 const bashAvailable = spawnSync('bash', ['--version']).status === 0;
+const zshAvailable = spawnSync('zsh', ['--version']).status === 0;
 
 describe('shell completions', () => {
   it('zsh script covers commands, flags, and group names', () => {
@@ -28,6 +29,9 @@ describe('shell completions', () => {
     for (const command of COMMANDS) expect(script).toContain(command);
     expect(script).toContain('--providers');
     expect(script).toContain('--refine');
+    expect(script).toContain(
+      "'run:Run a research query across multiple providers'",
+    );
     for (const group of GROUPS) expect(script).toContain(group);
     for (const command of program.commands) {
       for (const option of command.options) {
@@ -43,11 +47,33 @@ describe('shell completions', () => {
     for (const command of COMMANDS) expect(script).toContain(command);
     expect(script).toContain('--html');
     expect(script).toContain(GROUPS.join(' '));
+    expect(script).toContain(
+      'if [[ " run answer " == *" ${cmd} "* && ( "${prev}" == "-g" || "${prev}" == "--group" ) ]]; then',
+    );
   });
 
   it.skipIf(!bashAvailable)('emits Bash with valid syntax', () => {
     const result = spawnSync('bash', ['--noprofile', '--norc', '-n'], {
       input: bashCompletions(program),
+      encoding: 'utf8',
+    });
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+
+  it('emits valid zsh syntax when zsh is available', () => {
+    const script = zshCompletions(program);
+    if (!zshAvailable) {
+      // Windows runners may not provide zsh; pin its complete function shape
+      // there instead of silently skipping every assertion.
+      expect(script).toContain('_librarium() {');
+      expect(script).toContain('case $words[2] in');
+      expect(script).toContain('compdef _librarium librarium');
+      return;
+    }
+
+    const result = spawnSync('zsh', ['-n'], {
+      input: script,
       encoding: 'utf8',
     });
     expect(result.stderr).toBe('');

--- a/tests/readme-drift.test.ts
+++ b/tests/readme-drift.test.ts
@@ -26,6 +26,15 @@ const README = readFileSync(
 
 const program = createCliProgram();
 
+function commandSection(commandName: string): string {
+  const heading = `### \`${commandName}\``;
+  const start = README.indexOf(heading);
+  if (start === -1) return '';
+  const rest = README.slice(start + heading.length);
+  const nextHeading = rest.search(/^### /m);
+  return nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+}
+
 describe('README drift: commands', () => {
   const commandNames = program.commands.map((c) => c.name());
 
@@ -70,7 +79,11 @@ describe('README drift: command flags', () => {
         .map((opt) => opt.long)
         .filter((long): long is string => Boolean(long) && long !== '--help');
 
-      const missing = longFlags.filter((flag) => !README.includes(flag));
+      // Answer mirrors most of run's options, so scope its assertion to the
+      // answer section; a run-table mention must not mask answer-doc drift.
+      const documentation =
+        commandName === 'answer' ? commandSection(commandName) : README;
+      const missing = longFlags.filter((flag) => !documentation.includes(flag));
       expect(
         missing,
         `README.md (\`${commandName}\` section) is missing flag(s): ${missing.join(', ')}.`,

--- a/tests/readme-drift.test.ts
+++ b/tests/readme-drift.test.ts
@@ -1,25 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { Command } from 'commander';
 import { describe, expect, it } from 'vitest';
-import { registerAnswerCommand } from '../src/commands/answer.js';
-import { registerBrowseCommand } from '../src/commands/browse.js';
-import { registerCleanupCommand } from '../src/commands/cleanup.js';
-import { registerCompletionsCommand } from '../src/commands/completions.js';
-import { registerConfigCommand } from '../src/commands/config.js';
-import { registerDoctorCommand } from '../src/commands/doctor.js';
-import { registerGroupsCommand } from '../src/commands/groups.js';
-import { registerHtmlCommand } from '../src/commands/html.js';
-import { registerInitCommand } from '../src/commands/init.js';
-import { registerInstallSkillCommand } from '../src/commands/install-skill.js';
-import { registerJsonlCommand } from '../src/commands/jsonl.js';
-import { registerLsCommand } from '../src/commands/ls.js';
-import { registerMcpCommand } from '../src/commands/mcp.js';
-import { registerRefineCommand } from '../src/commands/refine.js';
-import { registerRunCommand } from '../src/commands/run.js';
-import { registerStatusCommand } from '../src/commands/status.js';
-import { registerUpgradeCommand } from '../src/commands/upgrade.js';
-import { registerUsageCommand } from '../src/commands/usage.js';
+import { createCliProgram } from '../src/cli-program.js';
 import { DEFAULT_GROUPS, PROVIDER_ENV_VARS } from '../src/constants.js';
 
 /**
@@ -42,32 +24,7 @@ const README = readFileSync(
   'utf-8',
 );
 
-/** Build the real program exactly as src/cli.ts does. */
-function buildProgram(): Command {
-  const program = new Command();
-  program.name('librarium');
-  registerRunCommand(program);
-  registerAnswerCommand(program);
-  registerStatusCommand(program);
-  registerUsageCommand(program);
-  registerBrowseCommand(program);
-  registerHtmlCommand(program);
-  registerJsonlCommand(program);
-  registerRefineCommand(program);
-  registerCompletionsCommand(program);
-  registerLsCommand(program);
-  registerGroupsCommand(program);
-  registerInitCommand(program);
-  registerDoctorCommand(program);
-  registerConfigCommand(program);
-  registerCleanupCommand(program);
-  registerUpgradeCommand(program);
-  registerInstallSkillCommand(program);
-  registerMcpCommand(program);
-  return program;
-}
-
-const program = buildProgram();
+const program = createCliProgram();
 
 describe('README drift: commands', () => {
   const commandNames = program.commands.map((c) => c.name());

--- a/tests/run-manifest.test.ts
+++ b/tests/run-manifest.test.ts
@@ -88,7 +88,7 @@ describe('run manifest v2 store', () => {
       bundle: true,
       platform: 'node',
       format: 'esm',
-      target: 'node20',
+      target: 'node22.12',
     });
     await Promise.all(
       Array.from(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "Node16",
     "moduleResolution": "Node16",
     "strict": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 const shared: Options = {
   format: ['esm'],
-  target: 'node20',
+  target: 'node22.12',
   outDir: 'dist',
   splitting: false,
   sourcemap: true,
@@ -40,7 +40,7 @@ export default defineConfig([
   // Platform is `neutral`: core's reachable graph is edge-safe, and the
   // Node-only code reachable only from `node-entry` (custom.ts -> child_process
   // etc.) stays isolated in the node-specific chunk. Node built-ins resolve
-  // fine under the esm/node20 target. The shared chunk reachable from core must
+  // fine under the esm/node22.12 target. The shared chunk reachable from core must
   // remain free of Node-only APIs -- the workers test guards this.
   {
     ...shared,


### PR DESCRIPTION
## Summary

Modernizes Librarium's Node and CLI foundation for v2 by requiring Node 22.12+, adopting Commander 15, and enforcing strict CLI input validation before command actions run. It also adds packed-consumer and standalone-binary verification so package and release compatibility claims are exercised directly.

## Changes

- Require Node `>=22.12.0`, target Node 22.12 in emitted code, and test supported Node 22.12, 24, and 26 releases.
- Upgrade to Commander 15 and centralize command registration in an internal side-effect-free program factory.
- Validate queries, modes, integer bounds, provider lists, exact micro-USD budgets, cleanup/usage days, completion shells, and config actions at the CLI boundary.
- Add `answer --no-fallback` parity and generate completions/documentation checks from the real Commander command tree.
- Verify packed tarball installation through the actual npm bin shim and installed `core`/`node` entrypoints.
- Add an exact below-floor engine rejection gate plus official Node 24 SEA build and self-contained binary smoke coverage.
- Document the breaking runtime floor and intentional invalid-argument behavior in the changelog and README.

## Compatibility notes

- Node-based npm and library consumers now require Node 22.12 or newer.
- Standalone and Homebrew binaries remain self-contained and do not require a host Node installation.
- Invalid completion shells now use Commander's standard exit code `1`.
- Nested group completion and final v2 workflow migration remain outside this change.

## Testing

- [x] Added / updated unit tests (`npm test`)
- [ ] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

Additional verification:

- 1,395 unit tests
- 24 Worker compatibility tests
- 14 integration tests
- TypeScript typecheck and Biome lint
- Production build and packed tarball consumer smoke
- Bash and Zsh completion syntax checks
- Built CLI validation and help smoke
- Independent multi-reviewer security, architecture, and regression review

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] New providers include an adapter, a built-in descriptor, explicit group membership, and a core export (not applicable; no providers added)
- [x] Config changes are reflected in `src/core/config.ts` and `src/types.ts` (not applicable; no config-file schema changes)
