### PR TITLE
Redesign package exports for Librarium v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking v2 package boundary:** `librarium` is now a side-effect-free,
+  Worker-safe schema and catalog entry; `librarium/core` explicitly exposes
+  injected catalog, planning, transport, coordination, and execution ports
+  without concrete adapters or global registries; and `librarium/node` adds a
+  load-only trusted custom-provider service and Node credential context. The
+  CLI remains available only through the `librarium` executable. Legacy
+  dispatcher, registry, adapter-constructor, file-runner, and raw keychain
+  exports are no longer public.
 - **Breaking Node and CLI baseline:** Node-based Librarium installs now require
   Node.js 22.12 or newer and use Commander 15. CLI query, provider, mode,
   concurrency, timeout, budget, cleanup, usage, completion-shell, and config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatcher, registry, adapter-constructor, file-runner, and raw keychain
   exports are no longer public.
 - **Breaking Node and CLI baseline:** Node-based Librarium installs now require
-  Node.js 22.12 or newer and use Commander 15. CLI query, provider, mode,
-  concurrency, timeout, budget, cleanup, usage, completion-shell, and config
-  inputs are validated before command actions run. Invalid completion-shell
-  arguments intentionally exit with status 1. Standalone and Homebrew binaries
-  remain self-contained and do not require a host Node.js installation.
+  Node.js 22.12 or newer and use Commander 15. CLI query shape, provider-list
+  shape/count, mode, concurrency, timeout, budget, cleanup/usage day,
+  completion-shell, and config-action inputs are validated before command
+  actions run. Invalid completion-shell arguments intentionally exit with
+  status 1. Standalone and Homebrew binaries remain self-contained and do not
+  require a host Node.js installation.
 - SearchAPI now authenticates through `Authorization: Bearer` without placing
   credentials in URLs. The strict `zeroRetention` option sends
   `zero_retention=true` and fails closed with no fallback or privacy downgrade

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://librarium.agentsy.build"><strong>Website</strong></a> &nbsp;·&nbsp;
   <a href="#quick-start">Quick start</a> &nbsp;·&nbsp;
   <a href="#commands">Commands</a> &nbsp;·&nbsp;
-  <a href="#library-usage-librariumcore">Library</a> &nbsp;·&nbsp;
+  <a href="#library-usage">Library</a> &nbsp;·&nbsp;
   <a href="#using-with-ai-agents">Agents</a>
 </p>
 
@@ -31,7 +31,13 @@ Ask once. Librarium fans your query out to search engines, AI-grounded answers, 
 
 Inspired by Aaron Francis' [counselors](https://github.com/aarondfrancis/counselors), librarium applies the same fan-out pattern to search. Where counselors fans out prompts to multiple LLM CLIs, librarium fans out research queries to search engines, AI-grounded search, and deep-research APIs -- collecting, normalizing, and deduplicating results into structured output.
 
-Librarium is both a **CLI** and an **embeddable library**: `import { dispatch } from 'librarium/core'` gives you the same provider adapters and fan-out dispatcher with in-memory structured results, no filesystem or Node-only dependencies -- it runs in Cloudflare Workers and other edge runtimes. See [Library Usage](#library-usage-librariumcore).
+Librarium is both a **CLI** and a set of **embeddable foundations**. The
+side-effect-free `librarium` root validates canonical requests and terminal
+results; `librarium/core` adds Worker-safe catalog, planning, transport, and
+execution ports; `librarium/node` adds deliberate Node-only services. The v2
+package boundary does not yet expose a high-level library runner -- use the
+`librarium` executable for complete research runs. See
+[Library Usage](#library-usage).
 
 The full docs live at **[librarium.agentsy.build](https://librarium.agentsy.build)**.
 
@@ -63,7 +69,7 @@ On first run, `librarium` opens a guided onboarding wizard: pick providers, choo
 - **Reports for humans and machines** -- a tabbed [HTML report](#html) for reading, [`results.jsonl`](#jsonl) with full content for pipelines, and a [browsable run directory](#browse) for everything else.
 - **Tier-tuned queries** -- [`--refine`](#refine) rewrites your query three ways with one LLM call: a brief for deep research, a question for AI answers, keywords for raw search.
 - **Async deep research** -- submit long-running jobs and walk away. [`status --wait --retrieve`](#status) collects the reports when they land.
-- **Built for agents** -- an [agent skill](#option-1-claude-code-skill-recommended), an [MCP server](#option-2-mcp-server), and an [embeddable edge-safe core](#library-usage-librariumcore). Your agents fan out, browse, and cite without screen-scraping a terminal.
+- **Built for agents** -- an [agent skill](#option-1-claude-code-skill-recommended), an [MCP server](#option-2-mcp-server), and [embeddable edge-safe foundations](#library-usage). Your agents fan out, browse, and cite without screen-scraping a terminal.
 
 Plus provider groups, automatic fallbacks, and custom providers from npm or local scripts.
 
@@ -297,21 +303,26 @@ adapter factory with its tier, display/catalog metadata, credential environment
 variable, metering declaration, option schema, aliases, default model, and a
 discriminated inline/background capability contract. Registry initialization,
 the onboarding catalog, provider names, credential lookup, aliases, and
-metering are derived from that inventory. Default groups remain explicit
-policy, with automatic validation against the inventory so a new provider
-cannot silently drift out of `all` or `llm`.
+metering are derived from that inventory. The v2 provider-profile catalog owns
+workflow facts: `quick` and `visibility` use curated profile rosters, while
+`deep` and `all` are derived from profile capabilities. Automatic validation
+rejects missing bindings, invalid workflow declarations, and stale curated
+memberships.
 
-Library consumers can inspect the same inventory:
+Library consumers can inspect the public capability catalog without importing
+adapter constructors or initializing a global registry:
 
 ```ts
-import { BUILTIN_PROVIDER_DESCRIPTORS } from 'librarium/core';
+import { BUILTIN_PROVIDER_CATALOG } from 'librarium';
 
-for (const descriptor of BUILTIN_PROVIDER_DESCRIPTORS) {
+for (const provider of BUILTIN_PROVIDER_CATALOG) {
   console.log({
-    id: descriptor.id,
-    model: descriptor.defaultModel,
-    execution: descriptor.capabilities.execution,
-    options: descriptor.optionsSchema,
+    id: provider.provider_id,
+    profiles: provider.profiles.map(({ profile_id, invocation, target }) => ({
+      profile_id,
+      invocation,
+      target,
+    })),
   });
 }
 ```
@@ -1412,213 +1423,171 @@ The `usage` and `metering` fields are optional. `usage` is reported-only: its `i
 | `1` | Partial success (some providers failed) |
 | `2` | Total failure (all providers failed, or configuration error) |
 
-## Library Usage (`librarium/core`)
+## Library Usage
 
-Everything the CLI does with providers is importable. The `librarium/core` entry exposes the adapters, registry, dispatcher, normalizer, and types, and returns results **in memory**. The core entry has zero Node-only dependencies: no `node:fs`, no `process.env` access, fetch-based HTTP only. It is tested in workerd (Cloudflare's runtime) on every CI run. Node applications that want Librarium's complete durable file-writing lifecycle can use `executeResearchRun()` from `librarium/node`.
+Install the package when you need Librarium's schemas, catalog, or execution
+ports in application code:
 
 ```bash
 npm install librarium
 ```
 
-```ts
-import { dispatch, initializeProviders, type Config } from 'librarium/core';
+The v2 package boundary is deliberately lower-level than the CLI. There is no
+public `createLibrarium().research()`, global provider registry, adapter
+constructor inventory, or headless file-writing runner yet. Use the
+`librarium` executable for complete configured research runs while the
+canonical runner is integrated.
 
-// Credentials are injected -- core never reads process.env itself.
-// Pass an env map (Workers: pass your `env` binding) or a resolveCredential fn.
-const credentials = { env: { GEMINI_API_KEY: '...', OPENROUTER_API_KEY: '...' } };
+### Root API (`librarium`)
 
-await initializeProviders({ credentials });
-
-const config: Config = {
-  version: 1,
-  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'sync', llmWebSearch: true },
-  providers: {
-    'gemini-grounded': { enabled: true },
-    'openrouter-online': { enabled: true },
-  },
-  customProviders: {},
-  trustedProviderIds: [],
-  groups: {},
-};
-
-const { results, asyncTasks } = await dispatch({
-  config,
-  providerIds: ['gemini-grounded', 'openrouter-online'],
-  query: 'What is the best wholesale produce supplier in London?',
-  mode: 'sync',
-  credentials,
-});
-
-for (const r of results) {
-  // { provider, tier, status, text, sourceUrls, citations, durationMs,
-  //   model, tokenUsage, error, fallbackFor }
-  console.log(r.provider, r.status, r.sourceUrls);
-}
-```
-
-Notes:
-
-- **Credential injection.** `CredentialContext` is `{ env?: Record<string, string | undefined>, resolveCredential?: (value: string) => string | undefined }`. `$ENV_VAR` references in provider config resolve against the injected `env`; literal keys pass through. In the CLI, this is backed by `process.env` -- in a Worker, pass your env binding.
-- **Custom providers from the library.** Hand-written providers work anywhere via `registerProvider()` (edge included). npm- and script-based custom providers need Node (module resolution, child processes), so they load through the dedicated `librarium/node` entry -- the same loader the CLI uses. See [Custom providers](#custom-providers-librariumnode).
-- **Async deep-research from the library.** `dispatch` with `mode: 'async'`/`'mixed'` returns `asyncTasks` handles; polling/retrieval is the caller's responsibility. See [Async deep-research](#async-deep-research-from-the-library).
-- **Bring your own persistence.** Core returns data; where it goes (D1, R2, files, nowhere) is up to you.
-
-### Headless durable runs (`librarium/node`)
-
-`executeResearchRun(request, overrides?)` is the shared application service behind the CLI and MCP server. It has no spinner, prompt, stdout, or stderr behavior. The caller supplies an initialized config, selected provider IDs, and an output directory; the service creates and reconciles `run.json`, dispatches providers, writes provider results, deduplicates citations, and writes `prompt.md`, `sources.json`, and `summary.md`.
-
-```ts
-import { initializeProviders } from 'librarium/core';
-import { executeResearchRun } from 'librarium/node';
-
-const credentials = { env: process.env };
-await initializeProviders({ ...config, credentials });
-
-const run = await executeResearchRun({
-  query: 'Compare current deep-research APIs',
-  config,
-  providerIds: ['openai-research'],
-  outputDir: '/absolute/path/to/run',
-  slug: 'compare-current-deep-research-apis',
-  credentials,
-  onEvent(event) {
-    if (event.type === 'dispatch-progress') {
-      renderProgress(event.progress);
-    }
-  },
-});
-
-console.log(run.manifest.status, run.sources.length);
-```
-
-Production defaults are used when `overrides` is omitted. Embedders and tests may independently replace `providerRegistry`, `taskStore`, `httpClient`, or `dispatch`. The HTTP override creates run-local copies of built-in and other `ProviderBase` adapters; a registry containing plain-object providers can implement `withHttpClient()` to supply its own run-local projection. `onEvent` receives a typed event union and is observational: an event handler failure cannot interrupt dispatch or corrupt persistence. A `postDispatch` callback can add `answer` or `verification` metadata before the manifest reaches its final lifecycle state; callback failures are reported as `post-dispatch-warning` events and do not discard the run.
-
-### Custom providers (`librarium/node`)
-
-Three flavors of custom provider:
-
-1. **Hand-written** -- implement the `Provider` interface (fetch-based) and call `registerProvider(provider)` from `librarium/core`. This is edge-safe and works in Workers.
-2. **npm modules** -- a published/local package exporting a provider (or a factory). Requires Node module resolution.
-3. **scripts** -- an external executable that speaks librarium's JSON-over-stdio protocol. Requires child processes.
-
-The last two are Node-only, so they live behind the `librarium/node` entry point (one implementation, shared with the CLI). It exposes:
-
-- `loadCustomProviders(config, options?) -> { providers, loadedIds, skippedIds, warnings }` -- loads (but does not register) the npm/script providers declared in `config.customProviders`, applying the same `trustedProviderIds` gating and reserved-ID protection the CLI uses.
-- `registerCustomProviders(config, options?)` -- convenience that loads and registers them into the core registry. Built-in IDs are reserved directly from the descriptor inventory, even before initialization or when a built-in has invalid options. Same return shape.
-
-```ts
-import { dispatch, initializeProviders, getProvider } from 'librarium/core';
-import { registerCustomProviders } from 'librarium/node';
-
-const credentials = { env: process.env };
-await initializeProviders({ credentials });
-
-const config = {
-  version: 1 as const,
-  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'sync' as const, llmWebSearch: true },
-  providers: { 'my-search': { enabled: true } },
-  // npm: { type: 'npm', module: 'my-search-provider', export: 'default' }
-  // script: { type: 'script', command: './providers/my-search.mjs' }
-  customProviders: { 'my-search': { type: 'npm' as const, module: 'my-search-provider' } },
-  trustedProviderIds: ['my-search'], // untrusted IDs are skipped with a warning
-  groups: {},
-};
-
-const { warnings, loadedIds } = await registerCustomProviders(config);
-if (warnings.length) console.warn(warnings.join('\n'));
-
-// Now registered alongside the built-ins -- dispatch sees it.
-console.log(getProvider('my-search')?.source); // 'npm'
-const { results } = await dispatch({
-  config,
-  providerIds: loadedIds,
-  query: 'best wholesale produce supplier in London',
-  mode: 'sync',
-  credentials,
-});
-```
-
-`librarium/core` stays Node-free: edge users never import `librarium/node` and keep using fetch-based `registerProvider()` providers.
-
-### Async deep-research from the library
-
-Deep-research providers can run asynchronously. In `mode: 'mixed'` (or `'async'`), `dispatch` submits each deep-research task and returns an `AsyncTaskHandle` in `asyncTasks` instead of blocking; sync-tier providers still return their results inline. The caller persists the handles, then later polls and retrieves through the registry -- there is no background worker in core.
+The package root is side-effect-free and Worker-safe. It exposes the canonical
+request and terminal-response schemas/types, the built-in provider capability
+catalog, and `VERSION`.
 
 ```ts
 import {
-  dispatch,
-  initializeProviders,
-  getProvider,
-  type AsyncTaskHandle,
-  type Config,
-} from 'librarium/core';
+  BUILTIN_PROVIDER_CATALOG,
+  ResearchRequestSchema,
+  ResearchResponseSchema,
+  type ResearchRequest,
+} from 'librarium';
 
-const credentials = { env: process.env };
-await initializeProviders({ credentials });
-
-const config: Config = {
-  version: 1,
-  defaults: { outputDir: '', maxParallel: 4, timeout: 60, asyncTimeout: 600, asyncPollInterval: 5, mode: 'mixed', llmWebSearch: true },
-  providers: {
-    'openai-research': { enabled: true },    // deep-research -> async
-    'gemini-grounded': { enabled: true },    // ai-grounded -> sync, inline
+const request: ResearchRequest = ResearchRequestSchema.parse({
+  query: 'Compare current deep-research APIs',
+  mode: 'sync',
+  selector: { kind: 'group', group_id: 'deep' },
+  fallback: { kind: 'configured' },
+  limits: {
+    max_concurrency: 4,
+    request_deadline_ms: 600_000,
+    inline_attempt_deadline_ms: 60_000,
+    background_attempt_deadline_ms: 600_000,
+    poll_interval_ms: 5_000,
   },
-  customProviders: {},
-  trustedProviderIds: [],
-  groups: {},
-};
-
-// 1. Dispatch. Sync results are inline; deep-research tasks come back as handles.
-const { results, asyncTasks } = await dispatch({
-  config,
-  providerIds: ['openai-research', 'gemini-grounded'],
-  query: 'State of solid-state battery commercialization in 2026',
-  mode: 'mixed',
-  credentials,
 });
 
-for (const r of results) {
-  // r.status is one of: 'success' | 'error' | 'timeout' | 'skipped' | 'async-pending'
-  // Deep-research providers submitted async show up here as 'async-pending'
-  // (empty text); their real payload arrives via retrieve() below.
-  if (r.status === 'success') console.log(r.provider, r.sourceUrls);
-}
+console.log(BUILTIN_PROVIDER_CATALOG.length, request.query);
 
-// 2. Persist the handles wherever you want (DB, KV, file, queue). They're plain
-//    JSON: { provider, taskId, query, submittedAt, status, ... }.
-await saveHandles(asyncTasks); // your storage
+// Validate a terminal payload produced by Librarium or another conforming
+// implementation. This does not execute the request.
+const response = ResearchResponseSchema.parse(receivedPayload);
+console.log(response.status, response.results.length);
+```
 
-// ...later, in a separate invocation, reload the handles and resolve them:
-const handles: AsyncTaskHandle[] = await loadHandles();
+Importing the root does not parse CLI arguments, write files, initialize
+providers, install signal handlers, or read credentials.
 
-for (const handle of handles) {
-  const provider = getProvider(handle.provider);
-  if (provider?.execution !== 'background') continue;
+### Advanced Worker-safe API (`librarium/core`)
 
-  // 3. Poll for status. AsyncPollResult.status is the AsyncTaskStatus enum:
-  //    'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
-  const poll = await provider.poll(handle);
-  if (poll.status === 'pending' || poll.status === 'running') {
-    continue; // still cooking -- check again next time
-  }
-  if (poll.status !== 'completed') {
-    console.warn(`${handle.provider} ${poll.status}: ${poll.message ?? ''}`);
-    continue;
-  }
+`librarium/core` re-exports the root and adds explicit catalog, planning,
+HTTP/stream transport, coordination-store, and attempt-execution ports. These
+APIs are dependency-injected and contain no concrete provider adapters or
+global registry.
 
-  // 4. Retrieve the finished result. retrieve() returns a ProviderResult:
-  //    { provider, tier, content, citations, durationMs, model?, tokenUsage?, usage?, error? }
-  const result = await provider.retrieve(handle);
-  if (result.error) {
-    console.warn(`${handle.provider} retrieve error: ${result.error}`);
-    continue;
-  }
-  console.log(result.provider, result.content);
-  for (const c of result.citations) console.log(' -', c.title ?? c.url, c.url);
+```ts
+import { ResearchRequestSchema } from 'librarium';
+import {
+  buildProviderCatalog,
+  prepareResearchExecution,
+  type PreparationDependencies,
+} from 'librarium/core';
+
+const catalog = buildProviderCatalog({
+  providerConfigs: {
+    'brave-search': { enabled: true },
+  },
+  credentials: {
+    env: { BRAVE_API_KEY: workerEnv.BRAVE_API_KEY },
+  },
+});
+
+const dependencies: PreparationDependencies = {
+  clock: { now: () => Date.now() },
+  ids: {
+    next(scope) {
+      return crypto.randomUUID() + '-' + scope;
+    },
+  },
+};
+
+const prepared = prepareResearchExecution(
+  ResearchRequestSchema.parse({
+    query: 'Independent web evidence',
+    mode: 'sync',
+    selector: {
+      kind: 'targets',
+      targets: [{ provider_id: 'brave-search', profile_id: 'search' }],
+    },
+    fallback: { kind: 'disabled' },
+    limits: {
+      max_concurrency: 1,
+      request_deadline_ms: 30_000,
+      inline_attempt_deadline_ms: 30_000,
+      background_attempt_deadline_ms: 30_000,
+      poll_interval_ms: 1_000,
+    },
+  }),
+  catalog,
+  dependencies,
+);
+
+if (!prepared.ok) {
+  console.error(prepared.issues);
 }
 ```
 
-> **Workers note.** A single request can't block for minutes, so split the lifecycle: dispatch on the first request and persist `asyncTasks` (KV, D1, R2, or a Durable Object), then resolve them on a later request, a Cron Trigger, or a Durable Object alarm. `getProvider(handle.provider).poll/retrieve` is pure fetch, so it runs in the same Worker -- just reload the handle from storage between invocations.
+Preparation is network-free. `runPreparedExecution` is an advanced
+coordination primitive that requires an injected `AttemptExecutionPort` and
+`CoordinationStateStore`; it is not a preconfigured research client.
+
+### Node-only API (`librarium/node`)
+
+`librarium/node` re-exports the Worker-safe API and adds two deliberate
+Node services:
+
+- `createNodeCredentialContext()` resolves environment and supported OS
+  keychain references without exposing raw keychain CRUD.
+- `loadCustomProviders(config, options?)` trust-checks and loads npm/script
+  providers, returning provider instances and diagnostics without registering
+  global state.
+
+```ts
+import {
+  loadCustomProviders,
+  type CustomProviderLoadConfig,
+} from 'librarium/node';
+
+const config: CustomProviderLoadConfig = {
+  providers: {
+    'my-search': { enabled: true },
+  },
+  customProviders: {
+    'my-search': {
+      type: 'npm',
+      module: 'librarium-provider-myteam',
+      export: 'createProvider',
+    },
+  },
+  trustedProviderIds: ['my-search'],
+};
+
+const { providers, loadedIds, skippedIds, warnings } =
+  await loadCustomProviders(config);
+
+console.log({ loadedIds, skippedIds, warnings });
+const result = await providers[0]?.execute('Research question', {
+  timeout: 30,
+});
+```
+
+> **Security:** trusted npm modules and script declarations execute arbitrary
+> code with the current process's permissions and inherited environment.
+> `trustedProviderIds` is an execution allowlist, not a sandbox. Load only
+> code you explicitly trust.
+
+The Node entry does not expose `executeResearchRun`, writable configuration
+migration, run-manifest mutation, or a registration convenience. Those service
+shapes remain private until their v2 contracts are finalized.
 
 ## Using with AI Agents
 

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -39,12 +39,30 @@ Load rules:
 - Built-in IDs are reserved and cannot be overridden
 - Project and global configs merge; project `customProviders` override same IDs from global
 
-## Core vs CLI Boundary (v0.2.0+)
+## Package and CLI Boundary
 
-Librarium is consumable as a library via the `librarium/core` package export (see README "Library Usage"). The boundary matters for provider development:
+Librarium exposes three deliberate package entries (see README "Library
+Usage"). The boundary matters for provider development:
 
-- **Built-in adapters** live in core: they must stay runtime-portable -- fetch-based HTTP only, no `node:*` imports, no direct `process.env` access. API keys resolve through the injected `CredentialContext` (`BaseProvider.getApiKey(apiKeyRef, credentials)`); a workerd CI suite enforces this.
-- **Custom npm and script providers** are CLI-only: they depend on Node module resolution and child processes and are loaded by the CLI's `node-registry`, never by core. Library consumers who need a custom provider implement the `Provider` interface directly and call `registerProvider()` at runtime.
+- **Built-in adapters** are internal runtime modules. They must remain portable:
+  fetch-based HTTP only, no `node:*` imports, and no direct `process.env`
+  access. API keys resolve through the injected `CredentialContext`; a workerd
+  CI suite imports these modules directly even though their constructors are
+  not public package exports.
+- **`librarium`** exposes canonical request/terminal-result schemas and the
+  static provider capability catalog. It never initializes adapters.
+- **`librarium/core`** exposes Worker-safe provider interfaces and injected
+  catalog/planning/transport/execution ports. It has no concrete adapter
+  classes, dispatcher convenience, or global provider registry.
+- **`librarium/node`** exposes `loadCustomProviders()` for explicitly trusted
+  npm modules and scripts. It returns provider instances without registering
+  them. Complete configured runs still go through the `librarium` CLI while
+  the v2 high-level library runner is finalized.
+
+> **Security:** an allowed npm module or script executes arbitrary code with
+> the Librarium process's permissions and inherited environment.
+> `trustedProviderIds` is an execution allowlist, not a sandbox. Load only code
+> you explicitly trust.
 
 ## Provider Interface Contract
 
@@ -96,9 +114,11 @@ You can export either:
 Factory function receives:
 
 ```ts
+import type { CustomProviderRuntimeConfig } from 'librarium/node';
+
 {
   id: string;
-  config?: ProviderConfig;
+  config?: CustomProviderRuntimeConfig;
   sourceOptions: Record<string, unknown>;
 }
 ```
@@ -229,20 +249,27 @@ A built-in adapter declares its pricing model in its provider descriptor. The me
 
 ## Adding a Built-in Adapter
 
-Built-in adapters live in core and must stay runtime-portable (fetch-only HTTP, no `node:*`, no direct `process.env`; a workerd CI suite enforces this). Each built-in has one typed runtime descriptor composed from:
+Built-in adapters live in the internal Worker-safe adapter layer and must stay runtime-portable (fetch-only HTTP, no `node:*`, no direct `process.env`; a workerd CI suite enforces this). Each built-in has one typed runtime descriptor composed from:
 
 - `src/core/provider-descriptor.ts`: portable metadata, aliases, credential name, tier, display/catalog copy, default model, metering, option schema, and discriminated execution capabilities
 - `src/adapters/provider-descriptors.ts`: the adapter factory for each metadata definition
 
-Runtime registration, constants, aliases, onboarding catalog, and metering are derived from these descriptors. Default groups remain explicit product policy in `src/constants.ts`, but startup validation rejects unknown IDs, duplicates, tier mistakes, or a stale `all`/`llm` roster.
+Runtime registration, constants, aliases, onboarding catalog, and metering are derived from these descriptors. Legacy CLI grouping remains internal until the configuration and runtime cutover work lands. The v2 workflow source of truth is provider profiles plus curated `quick`/`visibility` policy and capability-derived `deep`/`all` membership.
 
 To add one:
 
 1. **Adapter** -- `src/adapters/<id>.ts`, extending `BaseProvider` for inline execution or `BackgroundBaseProvider` for a complete remote-task lifecycle. Implement `execute` in both cases; background adapters also implement `submit`/`poll`/`retrieve`. Return `usage` when the API reports cost/tokens.
 2. **Descriptor definition** -- add the portable metadata entry in `src/core/provider-descriptor.ts`, including its metering declaration and an appropriate Zod schema for the supported `options`.
-3. **Factory** -- add the constructor mapping in `src/adapters/provider-descriptors.ts`. `initializeProviders()` validates configured options, constructs adapters from this descriptor list, and checks the runtime adapter matches its declared ID, tier, execution mode, display name, and credential. Invalid options warn but do not unregister the adapter: Librarium blocks new `execute`, `submit`, and `test` work before HTTP while retaining `poll`/`retrieve` for existing background tasks and preserving reserved built-in IDs.
-4. **Group policy** -- place the canonical ID in the intended explicit groups in `src/constants.ts`. Every non-LLM built-in must appear in `all`; every LLM built-in must appear in `llm`.
-5. **Core export** -- `export * from './adapters/<id>.js'` in `src/core-entry.ts`.
+3. **Factory** -- add the constructor mapping in `src/adapters/provider-descriptors.ts`. The internal Node registry validates configured options, constructs adapters from this descriptor list, and checks that runtime adapters match their declared ID, tier, execution mode, display name, and credential. Invalid options warn but do not remove the adapter: Librarium blocks new `execute`, `submit`, and `test` work before HTTP while retaining `poll`/`retrieve` for existing background tasks and preserving reserved built-in IDs.
+4. **Workflow policy** -- declare eligible curated workflow membership on the
+   profile in `src/core/provider-profiles.ts` and update
+   `src/core/builtin-workflows.ts` only when the profile belongs in the curated
+   `quick` or `visibility` roster. `deep` and `all` are derived from profile
+   capabilities and must not be manually enumerated.
+5. **Capability catalog** -- add or update the corresponding audited profile in
+   `src/core/provider-profiles.ts` and its binding in
+   `src/core/profile-bindings.ts`. Do not add the concrete adapter constructor
+   to a public package entry.
 6. **README** -- bump the "N built-in provider adapters" count; the README-drift test (`tests/readme-drift.test.ts`) tripwires on the provider count, tiers, and group names.
 
 Run `npm run test` (it includes the metering lockstep and README-drift guards) and `npm run test:workers` (the runtime-portability suite) before opening a PR.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.4.1",
   "description": "Fan out research queries to multiple search and deep-research APIs in parallel",
   "type": "module",
-  "main": "./dist/cli.js",
-  "types": "./dist/cli.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/cli.d.ts",
-      "import": "./dist/cli.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./core": {
       "types": "./dist/core.d.ts",
@@ -22,14 +22,17 @@
   "bin": {
     "librarium": "dist/cli.js"
   },
+  "sideEffects": [
+    "./dist/cli.js"
+  ],
   "scripts": {
-    "build": "tsup",
+    "build": "node scripts/clean-dist.mjs && tsup",
     "build:sea": "node scripts/build-sea.mjs",
     "contracts:generate": "node scripts/generate-contract-snapshot.mjs",
     "benchmark": "node benchmark/cli.mjs",
     "benchmark:validate": "node benchmark/validate.mjs",
     "benchmark:ci": "node benchmark/ci.mjs",
-    "dev": "tsup --watch",
+    "dev": "node scripts/clean-dist.mjs && tsup --watch",
     "test": "vitest run",
     "test:integration": "npm run build && vitest run --config vitest.integration.config.ts",
     "test:packed": "npm run build && node scripts/verify-packed-consumer.mjs",

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,27 @@
+import { realpathSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Exact repository build output, independent of the caller's cwd. */
+export const DIST_DIRECTORY = fileURLToPath(
+  new URL('../dist/', import.meta.url),
+);
+
+export function cleanDist() {
+  rmSync(DIST_DIRECTORY, { recursive: true, force: true });
+}
+
+export function isMainModule(path = process.argv[1]) {
+  if (!path) return false;
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(path))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  cleanDist();
+}

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -1,9 +1,19 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { builtinModules } from 'node:module';
+import { build as esbuild } from 'esbuild';
 
 const expectEngineRejection = process.argv.includes(
   '--expect-engine-rejection',
@@ -12,18 +22,63 @@ const root = process.cwd();
 const workspace = mkdtempSync(join(tmpdir(), 'librarium-packed-consumer-'));
 const packDirectory = join(workspace, 'pack');
 const consumerDirectory = join(workspace, 'consumer');
-// The temporary consumer isolates package resolution. Reuse the caller's npm
-// cache so this gate does not redownload the dependency graph after `npm ci`.
 const npmEnvironment = process.env;
+const NODE_BUILTINS = new Set(
+  builtinModules.flatMap((specifier) => [
+    specifier,
+    specifier.startsWith('node:') ? specifier.slice(5) : `node:${specifier}`,
+  ]),
+);
+
+const ROOT_EXPORTS = [
+  'BUILTIN_PROVIDER_CATALOG',
+  'CitationSchema',
+  'ResearchErrorSchema',
+  'ResearchRequestSchema',
+  'ResearchResponseSchema',
+  'ResearchResultSchema',
+  'ResultProvenanceSchema',
+  'SourceSchema',
+  'UsageSchema',
+  'VERSION',
+].sort();
+
+const CORE_EXPORTS = [
+  ...ROOT_EXPORTS,
+  'HttpRequestAbortedError',
+  'HttpRequestTimeoutError',
+  'HttpResponseTooLargeError',
+  'InMemoryCoordinationStateStore',
+  'ProviderCatalogError',
+  'admitResearchExecution',
+  'buildPrompt',
+  'buildProviderCatalog',
+  'createProviderAttemptBridge',
+  'generateSlug',
+  'httpRequest',
+  'httpStreamRequest',
+  'materializeResearchExecution',
+  'prepareResearchExecution',
+  'resolveOutputDir',
+  'runPreparedExecution',
+  'updateCoordinationState',
+].sort();
+
+const NODE_EXPORTS = [
+  ...CORE_EXPORTS,
+  'createNodeCredentialContext',
+  'loadCustomProviders',
+].sort();
 
 function npmCommand() {
   return process.platform === 'win32' ? 'npm.cmd' : 'npm';
 }
 
-function runNode(args, cwd = consumerDirectory) {
+function runNode(args, cwd = consumerDirectory, environment = process.env) {
   return execFileSync(process.execPath, args, {
     cwd,
     encoding: 'utf8',
+    env: environment,
     stdio: ['ignore', 'pipe', 'pipe'],
   }).trim();
 }
@@ -61,16 +116,413 @@ function runInstalledCli(args) {
   }).trim();
 }
 
+function listFiles(directory, base = directory) {
+  const files = [];
+  for (const name of readdirSync(directory)) {
+    const path = join(directory, name);
+    if (statSync(path).isDirectory()) files.push(...listFiles(path, base));
+    else files.push(relative(base, path).split(sep).join('/'));
+  }
+  return files.sort();
+}
+
+function assertEqual(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${label} mismatch:\nexpected ${JSON.stringify(expected)}\nreceived ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function verifyTarballInventory(packResult) {
+  const actual = packResult.files.map(({ path }) => path).sort();
+  const expected = [
+    'LICENSE',
+    'README.md',
+    'package.json',
+    ...listFiles(join(root, 'dist')).map((path) => `dist/${path}`),
+  ].sort();
+  assertEqual(actual, expected, 'Packed tarball inventory');
+
+  for (const forbidden of [
+    'dist/cli.d.ts',
+    'dist/cli.d.ts.map',
+    'contracts/v1',
+  ]) {
+    if (actual.some((path) => path === forbidden || path.startsWith(`${forbidden}/`))) {
+      throw new Error(`Forbidden packed artifact: ${forbidden}`);
+    }
+  }
+}
+
+function verifyExports() {
+  const source = `
+    const checks = ${JSON.stringify({
+      librarium: ROOT_EXPORTS,
+      'librarium/core': CORE_EXPORTS,
+      'librarium/node': NODE_EXPORTS,
+    })};
+    for (const [specifier, expected] of Object.entries(checks)) {
+      const actual = Object.keys(await import(specifier)).sort();
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(specifier + ' exports ' + JSON.stringify(actual));
+      }
+    }
+    for (const specifier of [
+      'librarium/cli',
+      'librarium/contracts/v1',
+      'librarium/package.json',
+      'librarium/adapters',
+      'librarium/internal',
+    ]) {
+      try {
+        await import(specifier);
+        throw new Error('Unexpected public subpath: ' + specifier);
+      } catch (error) {
+        if (error?.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error;
+      }
+    }
+  `;
+  runNode(['--input-type=module', '--eval', source]);
+}
+
+function verifyImportSideEffects() {
+  const home = join(workspace, 'poisoned-home');
+  // Keep the poisoned cwd below the consumer so bare package resolution still
+  // reaches the installed tarball while filesystem effects remain isolated.
+  const cwd = join(consumerDirectory, 'poisoned-cwd');
+  mkdirSync(home);
+  mkdirSync(cwd);
+  const source = `
+    import { readdirSync } from 'node:fs';
+    const before = JSON.stringify(readdirSync('.').sort());
+    const exitCodeBefore = process.exitCode;
+    process.argv = [process.execPath, 'librarium', 'config', 'init'];
+    process.exit = (code) => { throw new Error('process.exit:' + code); };
+    process.stdout.write = () => { throw new Error('stdout write'); };
+    process.stderr.write = () => { throw new Error('stderr write'); };
+    for (const method of ['on', 'once', 'addListener', 'prependListener']) {
+      const original = process[method].bind(process);
+      process[method] = (event, ...args) => {
+        if (String(event).startsWith('SIG')) throw new Error('signal listener:' + event);
+        return original(event, ...args);
+      };
+    }
+    await import('librarium');
+    await import('librarium/core');
+    await import('librarium/node');
+    if (process.exitCode !== exitCodeBefore) {
+      throw new Error('import changed process.exitCode');
+    }
+    const after = JSON.stringify(readdirSync('.').sort());
+    if (before !== after) throw new Error('import wrote files');
+  `;
+  runNode(['--input-type=module', '--eval', source], cwd, {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+  });
+  if (readdirSync(home).length !== 0 || readdirSync(cwd).length !== 0) {
+    throw new Error('Root/core/node import changed the filesystem');
+  }
+}
+
+function verifyDeclarations() {
+  const workerSourcePath = join(consumerDirectory, 'worker-consumer.ts');
+  const workerConfigPath = join(consumerDirectory, 'worker-tsconfig.json');
+  writeFileSync(
+    workerSourcePath,
+    `
+      import {
+        BUILTIN_PROVIDER_CATALOG,
+        type BuiltinWorkflowId,
+        type DeclarableWorkflowId,
+        type ExecutionProfile,
+        type ProfileTarget,
+        type ProviderIdentity,
+        ResearchRequestSchema,
+        type ResearchRequest,
+      } from 'librarium';
+      import {
+        type AsyncPollResult,
+        type AsyncTaskHandle,
+        type AttemptLaunch,
+        buildProviderCatalog,
+        type CatalogProviderConfig,
+        type CoordinatorDependencies,
+        type CoordinatorState,
+        type DurableHandle,
+        type InterchangeRequest,
+        type LegacyProviderTier,
+        type PreparationNotice,
+        type ProviderCitation,
+        type StructuredError,
+        type AttemptExecutionPort,
+        type HttpClient,
+      } from 'librarium/core';
+      declare const launch: AttemptLaunch;
+      declare const error: StructuredError;
+      declare const handle: DurableHandle;
+      declare const coordinator: CoordinatorDependencies;
+      declare const state: CoordinatorState;
+      declare const preparedRequest: InterchangeRequest;
+      declare const notice: PreparationNotice;
+      declare const task: AsyncTaskHandle;
+      declare const poll: AsyncPollResult;
+      declare const tier: LegacyProviderTier;
+      declare const providerCitation: ProviderCitation;
+      declare const identity: ProviderIdentity;
+      declare const target: ProfileTarget;
+      declare const workflow: BuiltinWorkflowId;
+      declare const declaredWorkflow: DeclarableWorkflowId;
+      const catalogConfig: CatalogProviderConfig = {
+        enabled: true,
+        model: 'fixture-model',
+      };
+      const request: ResearchRequest = ResearchRequestSchema.parse({
+        query: 'packed declaration consumer',
+        mode: 'sync',
+        selector: { kind: 'default' },
+        fallback: { kind: 'disabled' },
+        limits: {
+          max_concurrency: 1,
+          request_deadline_ms: 1000,
+          inline_attempt_deadline_ms: 1000,
+          background_attempt_deadline_ms: 1000,
+          poll_interval_ms: 100,
+        },
+      });
+      const client: HttpClient = async <T>() => ({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        data: {} as T,
+        durationMs: 1,
+      });
+      const port: AttemptExecutionPort = {
+        async execute(received, context) {
+          const typedLaunch: AttemptLaunch = received;
+          const profile: ExecutionProfile = typedLaunch.profile;
+          await context.submissionAccepted(handle);
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error,
+              durable_handle: handle,
+            },
+          };
+        },
+      };
+      void [
+        BUILTIN_PROVIDER_CATALOG,
+        buildProviderCatalog,
+        request,
+        client,
+        port,
+        launch,
+        coordinator,
+        state,
+        preparedRequest,
+        notice,
+        task,
+        poll,
+        tier,
+        providerCitation,
+        identity,
+        target,
+        workflow,
+        declaredWorkflow,
+        catalogConfig,
+      ];
+    `,
+  );
+  writeFileSync(
+    workerConfigPath,
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2023',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        strict: true,
+        noEmit: true,
+        skipLibCheck: false,
+        types: [],
+        lib: ['ES2023', 'DOM', 'DOM.Iterable'],
+      },
+      files: ['./worker-consumer.ts'],
+    }),
+  );
+  execFileSync(
+    process.execPath,
+    [
+      resolve(root, 'node_modules/typescript/bin/tsc'),
+      '-p',
+      workerConfigPath,
+    ],
+    { cwd: consumerDirectory, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+
+  const nodeSourcePath = join(consumerDirectory, 'node-consumer.ts');
+  const nodeConfigPath = join(consumerDirectory, 'node-tsconfig.json');
+  writeFileSync(
+    nodeSourcePath,
+    `
+      import {
+        type CustomProviderExecutionProfileConfig,
+        type CustomProviderLoadConfig,
+        type CustomProviderLoadResult,
+        type CustomProviderRuntimeConfig,
+        type ExecutionProfile,
+        type LoadCustomProvidersOptions,
+        type NpmCustomProviderSource,
+        type ScriptCustomProviderSource,
+        createNodeCredentialContext,
+        loadCustomProviders,
+      } from 'librarium/node';
+      declare const profile: ExecutionProfile;
+      const credentials = createNodeCredentialContext({ TEST_KEY: 'value' });
+      const executionProfile: CustomProviderExecutionProfileConfig = {
+        bindingId: 'fixture.binding',
+        profile,
+      };
+      const npmSource: NpmCustomProviderSource = {
+        type: 'npm',
+        module: 'fixture-provider',
+        executionProfile,
+      };
+      const scriptSource: ScriptCustomProviderSource = {
+        type: 'script',
+        command: 'fixture-provider',
+      };
+      const provider: CustomProviderRuntimeConfig = { enabled: true };
+      const config: CustomProviderLoadConfig = {
+        customProviders: { npmSource, scriptSource },
+        trustedProviderIds: ['npmSource', 'scriptSource'],
+        providers: { npmSource: provider, scriptSource: provider },
+      };
+      const options: LoadCustomProvidersOptions = { reservedProviderIds: [] };
+      const loaded: Promise<CustomProviderLoadResult> = loadCustomProviders(
+        config,
+        options,
+      );
+      void credentials;
+      void loaded;
+    `,
+  );
+  writeFileSync(
+    nodeConfigPath,
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2023',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        strict: true,
+        noEmit: true,
+        skipLibCheck: false,
+        types: ['node'],
+        typeRoots: [resolve(root, 'node_modules/@types')],
+        lib: ['ES2023', 'DOM', 'DOM.Iterable'],
+      },
+      files: ['./node-consumer.ts'],
+    }),
+  );
+  execFileSync(
+    process.execPath,
+    [resolve(root, 'node_modules/typescript/bin/tsc'), '-p', nodeConfigPath],
+    { cwd: consumerDirectory, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+
+  const nodeDeclaration = readFileSync(join(root, 'dist/node.d.ts'), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  if (/\bConfig\b/.test(nodeDeclaration)) {
+    throw new Error('The public Node declaration leaks the legacy Config type');
+  }
+}
+
+async function verifyWorkerSafeGraph() {
+  const scan = await esbuild({
+    entryPoints: [
+      join(root, 'src/index.ts'),
+      join(root, 'src/core-entry.ts'),
+    ],
+    outdir: join(workspace, 'worker-scan'),
+    bundle: true,
+    splitting: true,
+    format: 'esm',
+    platform: 'neutral',
+    target: 'es2023',
+    packages: 'external',
+    write: false,
+    metafile: true,
+    define: { __VERSION__: JSON.stringify('packed-verifier') },
+  });
+  const inputs = Object.keys(scan.metafile.inputs).map((path) =>
+    path.split(sep).join('/'),
+  );
+  const forbiddenSources = [
+    'src/adapters/custom.ts',
+    'src/commands/',
+    'src/mcp/',
+    'src/node-',
+    'src/cli',
+    'src/core/config.ts',
+    'src/core/install-method.ts',
+  ];
+  for (const input of inputs) {
+    if (forbiddenSources.some((fragment) => input.includes(fragment))) {
+      throw new Error(`Worker-safe graph reached ${input}`);
+    }
+  }
+  for (const [output, metadata] of Object.entries(scan.metafile.outputs)) {
+    for (const imported of metadata.imports) {
+      if (imported.external && NODE_BUILTINS.has(imported.path)) {
+        throw new Error(`${output} imports Node builtin ${imported.path}`);
+      }
+    }
+  }
+
+  const distEntries = [join(root, 'dist/index.js'), join(root, 'dist/core.js')];
+  const visited = new Set();
+  const visit = (path) => {
+    if (visited.has(path)) return;
+    visited.add(path);
+    const source = readFileSync(path, 'utf8');
+    const specifiers = [
+      ...source.matchAll(/(?:from\s*|import\s*)["']([^"']+)["']/g),
+      ...source.matchAll(/(?:import|require)\s*\(\s*["']([^"']+)["']/g),
+    ].map((match) => match[1]);
+    for (const specifier of specifiers) {
+      if (NODE_BUILTINS.has(specifier)) {
+        throw new Error(
+          `Worker-safe output imports Node builtin ${specifier}: ${path}`,
+        );
+      }
+      if (specifier.startsWith('./')) {
+        visit(resolve(dirname(path), specifier));
+      }
+    }
+  };
+  for (const entry of distEntries) visit(entry);
+}
+
 try {
   mkdirSync(packDirectory);
   mkdirSync(consumerDirectory);
 
-  execFileSync(npmCommand(), ['pack', '--pack-destination', packDirectory], {
-    cwd: root,
-    encoding: 'utf8',
-    env: npmEnvironment,
-    stdio: ['ignore', 'pipe', 'inherit'],
-  });
+  const packOutput = execFileSync(
+    npmCommand(),
+    ['pack', '--json', '--pack-destination', packDirectory],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: npmEnvironment,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    },
+  );
+  const [packResult] = JSON.parse(packOutput);
+  if (!packResult) throw new Error('npm pack did not return a package result');
 
   const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
   if (pkg.engines?.node !== '>=22.12.0') {
@@ -78,10 +530,8 @@ try {
       `Expected package engines.node to be >=22.12.0, received ${String(pkg.engines?.node)}`,
     );
   }
-  const tarball = resolve(
-    packDirectory,
-    `${pkg.name.replace('@', '').replace('/', '-')}-${pkg.version}.tgz`,
-  );
+  verifyTarballInventory(packResult);
+  const tarball = resolve(packDirectory, packResult.filename);
 
   execFileSync(npmCommand(), ['init', '--yes'], {
     cwd: consumerDirectory,
@@ -139,10 +589,14 @@ try {
       );
     }
 
+    await verifyWorkerSafeGraph();
+    verifyExports();
+    verifyImportSideEffects();
+    verifyDeclarations();
     runNode([
       '--input-type=module',
       '--eval',
-      "await import('librarium/core'); await import('librarium/node');",
+      "await import('librarium'); await import('librarium/core'); await import('librarium/node');",
     ]);
 
     runInstalledCli(['--help']);
@@ -154,7 +608,7 @@ try {
     }
 
     console.log(
-      `Verified packed ${pkg.name}@${pkg.version} on ${process.version}: install, CLI, core, node`,
+      `Verified packed ${pkg.name}@${pkg.version} on ${process.version}: inventory, exports, declarations, Worker-safe graph, side effects, CLI`,
     );
   }
 } finally {

--- a/src/adapters/node-registry.ts
+++ b/src/adapters/node-registry.ts
@@ -1,4 +1,4 @@
-import { registerCustomProviders } from '../node-entry.js';
+import { loadCustomProviders } from '../node-entry.js';
 import {
   getAllProviders,
   getExactProvider,
@@ -30,14 +30,14 @@ export async function initializeProviders(
     return builtinResult;
   }
 
-  // Reuse the same load-and-register path the library `librarium/node` entry
-  // exposes -- one implementation, two callers. Reserved IDs default to the
-  // built-ins just registered above.
-  const customResult = await registerCustomProviders({
+  // Reuse the public trust-filtered loader, then keep the legacy global
+  // registration step private to the CLI compatibility path.
+  const customResult = await loadCustomProviders({
     customProviders,
     trustedProviderIds: config.trustedProviderIds ?? [],
     providers: config.providers ?? {},
   });
+  for (const provider of customResult.providers) registerProvider(provider);
 
   return {
     warnings: [...builtinResult.warnings, ...customResult.warnings],

--- a/src/core-entry.ts
+++ b/src/core-entry.ts
@@ -1,51 +1,169 @@
-export * from './adapters/base.js';
-export * from './adapters/brave-answers.js';
-export * from './adapters/brave-search.js';
-export * from './adapters/claude.js';
-export * from './adapters/exa.js';
-export * from './adapters/firecrawl-search.js';
-export * from './adapters/gemini-chat.js';
-export * from './adapters/gemini-deep.js';
-export * from './adapters/gemini-grounded.js';
-export * from './adapters/grok.js';
-export * from './adapters/index.js';
-export * from './adapters/jina-search.js';
-export * from './adapters/kagi-fastgpt.js';
-export * from './adapters/openai-chat.js';
-export * from './adapters/openai-deep.js';
-export * from './adapters/openai-deep-base.js';
-export * from './adapters/openai-deep-o3.js';
-export * from './adapters/openai-research.js';
-export * from './adapters/openrouter-chat.js';
-export * from './adapters/openrouter-online.js';
-export * from './adapters/perplexity-advanced-deep.js';
-export * from './adapters/perplexity-agent-base.js';
-export * from './adapters/perplexity-deep-research.js';
-export * from './adapters/perplexity-pro-search.js';
-export * from './adapters/perplexity-search.js';
-export * from './adapters/perplexity-search-options.js';
-export * from './adapters/perplexity-sonar-deep.js';
-export * from './adapters/perplexity-sonar-pro.js';
-export * from './adapters/provider-descriptors.js';
-export * from './adapters/searchapi.js';
-export * from './adapters/searchapi-bing-copilot.js';
-export * from './adapters/searchapi-chatgpt.js';
-export * from './adapters/searchapi-gemini.js';
-export * from './adapters/searchapi-google-ai-mode.js';
-export * from './adapters/searchapi-google-ai-overview.js';
-export * from './adapters/searchapi-perplexity.js';
-export * from './adapters/serpapi.js';
-export * from './adapters/tavily.js';
-export * from './adapters/you-research.js';
-export * from './constants.js';
-export * from './core/budget.js';
-export * from './core/credentials.js';
-export * from './core/dispatcher.js';
-export * from './core/http-client.js';
-export * from './core/metering.js';
-export * from './core/normalizer.js';
-export * from './core/prompt-builder.js';
-export * from './core/provider-catalog.js';
-export * from './core/provider-descriptor.js';
-export * from './core/provider-selection.js';
-export * from './types.js';
+/** Advanced, Worker-safe planning and execution ports. */
+
+export type { BaseProviderOptions } from './adapters/base.js';
+export type {
+  DurableHandle,
+  StructuredError,
+} from './contracts/domain/index.js';
+export type { LifecycleEvent } from './contracts/interchange/internal.js';
+export type {
+  EvidenceRequirements,
+  InterchangeRequest,
+  RequestSlot,
+} from './contracts/interchange/request.js';
+export type {
+  AttemptFinishedInput,
+  AttemptLaunch,
+  CoordinatorAttemptState,
+  CoordinatorAttemptStatus,
+  CoordinatorBudgetState,
+  CoordinatorCancellation,
+  CoordinatorClock,
+  CoordinatorDependencies,
+  CoordinatorIdGenerator,
+  CoordinatorReserveCandidate,
+  CoordinatorSlotState,
+  CoordinatorSlotStatus,
+  CoordinatorState,
+  CoordinatorStatus,
+  CoordinatorTerminalOutcome,
+  PendingFallbackLaunch,
+  UnresolvedAcceptance,
+} from './core/coordinator.js';
+export type {
+  CoordinationCompareAndSwapResult,
+  CoordinationStateStore,
+  VersionedCoordinationState,
+} from './core/coordinator-store.js';
+export {
+  InMemoryCoordinationStateStore,
+  updateCoordinationState,
+} from './core/coordinator-store.js';
+export type { CredentialContext } from './core/credentials.js';
+export type {
+  AdapterBindingIdentity,
+  AdmittedSelectedProfile,
+  CanonicalResearchAdmissionResult,
+  FrozenPlanningCatalog,
+  NetworkFreeEstimate,
+  PlanningProfile,
+  PreparationClock,
+  PreparationDependencies,
+  PreparationIdGenerator,
+  PreparationResult,
+  PreparedProfilePlan,
+  PreparedResearchExecution,
+  PrivateExecutionPolicy,
+  ResearchAdmissionResult,
+  ResearchExecutionAdmission,
+} from './core/execution-plan.js';
+export {
+  admitResearchExecution,
+  materializeResearchExecution,
+  prepareResearchExecution,
+} from './core/execution-plan.js';
+export type {
+  AttemptExecutionContext,
+  AttemptExecutionPort,
+  AttemptExecutionResult,
+  ExecutionRuntimeDependencies,
+  ExecutionRuntimeResult,
+} from './core/execution-runtime.js';
+export { runPreparedExecution } from './core/execution-runtime.js';
+export type {
+  HttpClient,
+  HttpRequestOptions,
+  HttpResponse,
+  HttpRetryPolicy,
+  HttpStreamClient,
+  HttpStreamRequestOptions,
+  HttpStreamResponse,
+} from './core/http-client.js';
+export {
+  HttpRequestAbortedError,
+  HttpRequestTimeoutError,
+  HttpResponseTooLargeError,
+  httpRequest,
+  httpStreamRequest,
+} from './core/http-client.js';
+export type {
+  AvailabilityReason,
+  CatalogProfileBinding,
+  CatalogProfileTarget,
+  CatalogProviderConfig,
+  CustomCatalogProfile,
+  ProviderCatalog,
+  ProviderCatalogOptions,
+  ResolvedCatalogProfile,
+  WorkflowOmission,
+  WorkflowResolutionResult,
+} from './core/profile-catalog.js';
+export {
+  buildProviderCatalog,
+  ProviderCatalogError,
+} from './core/profile-catalog.js';
+export {
+  buildPrompt,
+  generateSlug,
+  resolveOutputDir,
+} from './core/prompt-builder.js';
+export type { ProviderAttemptBridgeDependencies } from './core/provider-attempt-bridge.js';
+export { createProviderAttemptBridge } from './core/provider-attempt-bridge.js';
+export type {
+  PreparationDiagnostic,
+  PreparationIssue,
+  PreparationNotice,
+  PreparationPhase,
+} from './core/research-request.js';
+export type {
+  BuiltinWorkflowId,
+  CatalogProfileRef,
+  Citation,
+  DeclarableWorkflowId,
+  ExecutableProfileDeclaration,
+  ExecutionProfile,
+  ProfileFeatures,
+  ProfileTarget,
+  ProviderCatalogEntry,
+  ProviderIdentity,
+  ResearchError,
+  ResearchRequest,
+  ResearchResponse,
+  ResearchResult,
+  ResultProvenance,
+  Source,
+  Usage,
+} from './index.js';
+export {
+  BUILTIN_PROVIDER_CATALOG,
+  CitationSchema,
+  ResearchErrorSchema,
+  ResearchRequestSchema,
+  ResearchResponseSchema,
+  ResearchResultSchema,
+  ResultProvenanceSchema,
+  SourceSchema,
+  UsageSchema,
+  VERSION,
+} from './index.js';
+export type {
+  ActualCostSource,
+  AsyncPollResult,
+  AsyncTaskHandle,
+  AsyncTaskStatus,
+  BackgroundProvider,
+  Citation as ProviderCitation,
+  CostConfidence,
+  InlineProvider,
+  MeteringActual,
+  MeteringEstimate,
+  MeteringKind,
+  Provider,
+  ProviderCommon,
+  ProviderMetering,
+  ProviderOptions,
+  ProviderResult,
+  ProviderSource,
+  ProviderTier as LegacyProviderTier,
+  ProviderUsage,
+} from './types.js';

--- a/src/core/profile-catalog.ts
+++ b/src/core/profile-catalog.ts
@@ -3,7 +3,6 @@ import type {
   ExecutionProfile,
   ProviderIdentity,
 } from '../contracts/domain/index.js';
-import type { ProviderConfig } from '../types.js';
 import {
   BUILTIN_WORKFLOW_IDS,
   type BuiltinWorkflowId,
@@ -90,10 +89,18 @@ export interface CatalogProfileTarget {
   readonly profile_id: string;
 }
 
+/** Minimal v1-compatible inputs needed to resolve an executable profile. */
+export interface CatalogProviderConfig {
+  readonly apiKey?: string;
+  readonly enabled?: boolean;
+  readonly model?: string;
+  readonly options?: Readonly<Record<string, unknown>>;
+}
+
 export interface ProviderCatalogOptions {
   readonly catalog?: readonly ProviderCatalogEntry[];
   /** v1 provider configuration, keyed by adapter id. */
-  readonly providerConfigs?: Readonly<Record<string, ProviderConfig>>;
+  readonly providerConfigs?: Readonly<Record<string, CatalogProviderConfig>>;
   readonly credentials?: CredentialContext;
   /** User-defined groups; reserved names are migrated to `custom:<name>`. */
   readonly groups?: Readonly<Record<string, readonly string[]>>;
@@ -165,7 +172,7 @@ function profileKeyOf(profile: ResolvedCatalogProfile): string {
 function bindingConfig(
   options: ProviderCatalogOptions,
   adapterId: string,
-): ProviderConfig | undefined {
+): CatalogProviderConfig | undefined {
   return options.providerConfigs?.[adapterId];
 }
 

--- a/src/core/prompt-builder.ts
+++ b/src/core/prompt-builder.ts
@@ -1,4 +1,3 @@
-import { mkdirSync } from 'node:fs';
 import { MAX_SLUG_LENGTH } from '../constants.js';
 
 /**
@@ -24,72 +23,6 @@ export function resolveOutputDir(baseDir: string, slug: string): string {
   const dirName = `${timestamp}-${slug}`;
   const separator = baseDir.endsWith('/') || baseDir.endsWith('\\') ? '' : '/';
   return `${baseDir}${separator}${dirName}`;
-}
-
-/** Injectable deps for {@link createRunDir} so collisions are testable. */
-export interface CreateRunDirDeps {
-  /** Current time in ms. Defaults to Date.now. */
-  now?: () => number;
-  /** Short random suffix generator. Defaults to a base36 fragment. */
-  randomSuffix?: () => string;
-  /** Exclusive directory creator. Defaults to mkdirSync. */
-  mkdir?: (dir: string) => void;
-}
-
-/** Default short random suffix: a few base36 characters. */
-function defaultRandomSuffix(): string {
-  return Math.random().toString(36).slice(2, 8);
-}
-
-/**
- * Create a unique run directory and return its absolute path. The directory
- * name embeds a millisecond timestamp plus a short random suffix so that
- * concurrent runs of the same query in the same second never share a
- * directory. Creation uses exclusive mkdir ({ recursive: false }) and retries
- * with a fresh suffix on collision (EEXIST), so the returned directory is the
- * one this call actually created. Callers should record this exact path in the
- * manifest.
- *
- * The leading second-granularity timestamp prefix is preserved so existing
- * sort/discovery by directory name keeps working; uniqueness comes from the
- * millisecond + random tail.
- */
-export function createRunDir(
-  baseDir: string,
-  slug: string,
-  deps: CreateRunDirDeps = {},
-): string {
-  const now = deps.now ?? Date.now;
-  const randomSuffix = deps.randomSuffix ?? defaultRandomSuffix;
-  const mkdir =
-    deps.mkdir ?? ((dir: string) => mkdirSync(dir, { recursive: false }));
-  const separator = baseDir.endsWith('/') || baseDir.endsWith('\\') ? '' : '/';
-
-  // Ensure the base directory exists (recursive is fine here; it is shared).
-  mkdirSync(baseDir, { recursive: true });
-
-  const MAX_ATTEMPTS = 50;
-  let lastError: unknown;
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    const ms = now();
-    const seconds = Math.floor(ms / 1000);
-    const millis = ms % 1000;
-    const dirName = `${seconds}-${slug}-${String(millis).padStart(3, '0')}${randomSuffix()}`;
-    const dir = `${baseDir}${separator}${dirName}`;
-    try {
-      mkdir(dir);
-      return dir;
-    } catch (e) {
-      const code = (e as NodeJS.ErrnoException)?.code;
-      if (code !== 'EEXIST') throw e;
-      lastError = e;
-    }
-  }
-  throw new Error(
-    `Failed to create a unique run directory under ${baseDir} after ${MAX_ATTEMPTS} attempts${
-      lastError instanceof Error ? `: ${lastError.message}` : ''
-    }`,
-  );
 }
 
 /**

--- a/src/core/provider-attempt-bridge.ts
+++ b/src/core/provider-attempt-bridge.ts
@@ -2,23 +2,23 @@ import type {
   DurableHandle,
   ExecutionProfile,
   StructuredError,
-} from './contracts/domain/index.js';
+} from '../contracts/domain/index.js';
 import {
   ExecutionProfileSchema,
   executionProfilesEqual,
-} from './contracts/domain/index.js';
-import type { AttemptLaunch } from './core/coordinator.js';
-import type { AdapterBindingIdentity } from './core/execution-plan.js';
+} from '../contracts/domain/index.js';
+import type { AsyncTaskHandle, Provider, ProviderResult } from '../types.js';
+import type { AttemptLaunch } from './coordinator.js';
+import type { AdapterBindingIdentity } from './execution-plan.js';
 import type {
   AttemptExecutionContext,
   AttemptExecutionPort,
   AttemptExecutionResult,
-} from './core/execution-runtime.js';
-import type { AsyncTaskHandle, Provider, ProviderResult } from './types.js';
+} from './execution-runtime.js';
 
 type BackgroundProvider = Extract<Provider, { execution: 'background' }>;
 
-export interface NodeExecutionBridgeDependencies {
+export interface ProviderAttemptBridgeDependencies {
   /** Exact binding lookup only: aliases and selector policy are absent. */
   resolveExactBinding(binding: AdapterBindingIdentity):
     | {
@@ -211,11 +211,11 @@ async function retrieveCompletedTask(
 }
 
 /**
- * Node-only compatibility bridge. A launch is already frozen to one binding;
+ * Provider compatibility bridge. A launch is already frozen to one binding;
  * this bridge only resolves that exact adapter id and invokes its lifecycle.
  */
-export function createNodeAttemptBridge(
-  dependencies: NodeExecutionBridgeDependencies,
+export function createProviderAttemptBridge(
+  dependencies: ProviderAttemptBridgeDependencies,
 ): AttemptExecutionPort {
   const now = dependencies.now ?? Date.now;
   const wait = dependencies.wait ?? defaultWait;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Side-effect-free, Worker-safe public API.
+ *
+ * Keep this entry deliberately small: importing `librarium` must never start
+ * the CLI, inspect the host, touch files, initialize adapters, or install
+ * process handlers.
+ */
+export { VERSION } from './constants.js';
+export type {
+  ExecutionProfile,
+  ProfileTarget,
+  ProviderIdentity,
+} from './contracts/domain/index.js';
+export type {
+  ResearchError,
+  ResearchResponse,
+} from './contracts/interchange/research-response.js';
+export {
+  ResearchErrorSchema,
+  ResearchResponseSchema,
+} from './contracts/interchange/research-response.js';
+export type {
+  Citation,
+  ResearchResult,
+  ResultProvenance,
+  Source,
+  Usage,
+} from './contracts/interchange/research-result.js';
+export {
+  CitationSchema,
+  ResearchResultSchema,
+  ResultProvenanceSchema,
+  SourceSchema,
+  UsageSchema,
+} from './contracts/interchange/research-result.js';
+export type {
+  BuiltinWorkflowId,
+  DeclarableWorkflowId,
+} from './core/builtin-workflows.js';
+export type {
+  CatalogProfileRef,
+  ExecutableProfileDeclaration,
+  ProfileFeatures,
+  ProviderCatalogEntry,
+} from './core/provider-profiles.js';
+export { BUILTIN_PROVIDER_CATALOG } from './core/provider-profiles.js';
+export type { CanonicalResearchRequest as ResearchRequest } from './core/research-request.js';
+export { CanonicalResearchRequestSchema as ResearchRequestSchema } from './core/research-request.js';

--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -6,11 +6,7 @@ import {
 import { type RefinedQueries, refineQuery } from '../commands/refine.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import type { CredentialContext } from '../core/credentials.js';
-import {
-  type CreateRunDirDeps,
-  createRunDir,
-  generateSlug,
-} from '../core/prompt-builder.js';
+import { generateSlug } from '../core/prompt-builder.js';
 import {
   ProviderSelectionError,
   resolveProviderSelection as resolveProviderSelectionCore,
@@ -20,6 +16,7 @@ import {
   executeResearchRun,
 } from '../core/research-run.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
+import { type CreateRunDirDeps, createRunDir } from '../node-run-directory.js';
 import { emitProductionShadowDiagnostic } from '../node-shadow-diagnostics.js';
 import type { Config, Defaults } from '../types.js';
 

--- a/src/node-credentials.ts
+++ b/src/node-credentials.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { platform } from 'node:os';
 import {
   type CredentialContext,
+  type EnvRecord,
   keychainCredentialName,
 } from './core/credentials.js';
 
@@ -67,7 +68,7 @@ export function deleteKeychainCredential(name: string): void {
 }
 
 export function createNodeCredentialContext(
-  env: NodeJS.ProcessEnv = process.env,
+  env: EnvRecord = process.env,
 ): CredentialContext {
   return {
     env,

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -1,74 +1,233 @@
 /**
- * librarium/node -- the Node-only bridge for the library.
+ * Deliberate Node-only services layered on the Worker-safe core API.
  *
- * `librarium/core` is edge-safe (no Node APIs) and exposes the built-in
- * provider adapters plus `registerProvider()` for hand-written providers.
- * Custom providers configured as npm modules or external scripts, however,
- * require Node (module resolution + child processes). This entry point is the
- * single, documented place those are loaded from -- it shares the exact
- * loading/trust logic the CLI uses (one implementation, two callers).
- *
- * Edge/Workers users should keep importing from `librarium/core`.
+ * Filesystem configuration, durable artifacts, and writable migration
+ * services remain private until their v2 service shapes land.
  */
-
 import {
   type CustomProviderLoadResult,
   loadCustomProviders as loadCustomProvidersInternal,
 } from './adapters/custom.js';
-import { getAllProviders, registerProvider } from './adapters/index.js';
+import type { ExecutionProfile } from './contracts/domain/index.js';
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './core/reserved-provider-ids.js';
-import type { Config } from './types.js';
 
 export type { CustomProviderLoadResult } from './adapters/custom.js';
-export * from './core/research-run.js';
-export * from './node-credentials.js';
+export type {
+  ActualCostSource,
+  AdapterBindingIdentity,
+  AdmittedSelectedProfile,
+  AsyncPollResult,
+  AsyncTaskHandle,
+  AsyncTaskStatus,
+  AttemptExecutionContext,
+  AttemptExecutionPort,
+  AttemptExecutionResult,
+  AttemptFinishedInput,
+  AttemptLaunch,
+  AvailabilityReason,
+  BackgroundProvider,
+  BaseProviderOptions,
+  BuiltinWorkflowId,
+  CanonicalResearchAdmissionResult,
+  CatalogProfileBinding,
+  CatalogProfileRef,
+  CatalogProfileTarget,
+  CatalogProviderConfig,
+  Citation,
+  CoordinationCompareAndSwapResult,
+  CoordinationStateStore,
+  CoordinatorAttemptState,
+  CoordinatorAttemptStatus,
+  CoordinatorBudgetState,
+  CoordinatorCancellation,
+  CoordinatorClock,
+  CoordinatorDependencies,
+  CoordinatorIdGenerator,
+  CoordinatorReserveCandidate,
+  CoordinatorSlotState,
+  CoordinatorSlotStatus,
+  CoordinatorState,
+  CoordinatorStatus,
+  CoordinatorTerminalOutcome,
+  CostConfidence,
+  CredentialContext,
+  CustomCatalogProfile,
+  DeclarableWorkflowId,
+  DurableHandle,
+  EvidenceRequirements,
+  ExecutableProfileDeclaration,
+  ExecutionProfile,
+  ExecutionRuntimeDependencies,
+  ExecutionRuntimeResult,
+  FrozenPlanningCatalog,
+  HttpClient,
+  HttpRequestOptions,
+  HttpResponse,
+  HttpRetryPolicy,
+  HttpStreamClient,
+  HttpStreamRequestOptions,
+  HttpStreamResponse,
+  InlineProvider,
+  InterchangeRequest,
+  LegacyProviderTier,
+  LifecycleEvent,
+  MeteringActual,
+  MeteringEstimate,
+  MeteringKind,
+  NetworkFreeEstimate,
+  PendingFallbackLaunch,
+  PlanningProfile,
+  PreparationClock,
+  PreparationDependencies,
+  PreparationDiagnostic,
+  PreparationIdGenerator,
+  PreparationIssue,
+  PreparationNotice,
+  PreparationPhase,
+  PreparationResult,
+  PreparedProfilePlan,
+  PreparedResearchExecution,
+  PrivateExecutionPolicy,
+  ProfileFeatures,
+  ProfileTarget,
+  Provider,
+  ProviderAttemptBridgeDependencies,
+  ProviderCatalog,
+  ProviderCatalogEntry,
+  ProviderCatalogOptions,
+  ProviderCitation,
+  ProviderCommon,
+  ProviderIdentity,
+  ProviderMetering,
+  ProviderOptions,
+  ProviderResult,
+  ProviderSource,
+  ProviderUsage,
+  RequestSlot,
+  ResearchAdmissionResult,
+  ResearchError,
+  ResearchExecutionAdmission,
+  ResearchRequest,
+  ResearchResponse,
+  ResearchResult,
+  ResolvedCatalogProfile,
+  ResultProvenance,
+  Source,
+  StructuredError,
+  UnresolvedAcceptance,
+  Usage,
+  VersionedCoordinationState,
+  WorkflowOmission,
+  WorkflowResolutionResult,
+} from './core-entry.js';
+export {
+  admitResearchExecution,
+  BUILTIN_PROVIDER_CATALOG,
+  buildPrompt,
+  buildProviderCatalog,
+  CitationSchema,
+  createProviderAttemptBridge,
+  generateSlug,
+  HttpRequestAbortedError,
+  HttpRequestTimeoutError,
+  HttpResponseTooLargeError,
+  httpRequest,
+  httpStreamRequest,
+  InMemoryCoordinationStateStore,
+  materializeResearchExecution,
+  ProviderCatalogError,
+  prepareResearchExecution,
+  ResearchErrorSchema,
+  ResearchRequestSchema,
+  ResearchResponseSchema,
+  ResearchResultSchema,
+  ResultProvenanceSchema,
+  resolveOutputDir,
+  runPreparedExecution,
+  SourceSchema,
+  UsageSchema,
+  updateCoordinationState,
+  VERSION,
+} from './core-entry.js';
+export { createNodeCredentialContext } from './node-credentials.js';
 
 export interface LoadCustomProvidersOptions {
-  /**
-   * Additional provider IDs that may not be claimed by a custom provider.
-   * Built-in canonical IDs and aliases are always reserved.
-   */
+  /** Additional IDs which custom providers may not claim. */
   reservedProviderIds?: Iterable<string>;
 }
 
+export interface CustomProviderExecutionProfileConfig {
+  bindingId: string;
+  profile: ExecutionProfile;
+  credential?: { envVar: string };
+}
+
+export interface NpmCustomProviderSource {
+  type: 'npm';
+  module: string;
+  export?: string;
+  options?: Record<string, unknown>;
+  executionProfile?: CustomProviderExecutionProfileConfig;
+}
+
+export interface ScriptCustomProviderSource {
+  type: 'script';
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  options?: Record<string, unknown>;
+  executionProfile?: CustomProviderExecutionProfileConfig;
+}
+
+export type CustomProviderSource =
+  | NpmCustomProviderSource
+  | ScriptCustomProviderSource;
+
+export interface CustomProviderRuntimeConfig {
+  apiKey?: string;
+  enabled?: boolean;
+  model?: string;
+  options?: Record<string, unknown>;
+  fallback?: string;
+}
+
+/** Minimal trusted-provider input; deliberately independent of v1 Config. */
+export interface CustomProviderLoadConfig {
+  readonly customProviders?: Readonly<Record<string, CustomProviderSource>>;
+  readonly trustedProviderIds?: readonly string[];
+  readonly providers?: Readonly<Record<string, CustomProviderRuntimeConfig>>;
+}
+
 /**
- * Load custom providers (npm modules + scripts) declared in a librarium
- * `Config`, applying the same trust gating (`trustedProviderIds`) and
- * reserved-ID protection the CLI uses. Returns the loaded providers plus
- * diagnostics; it does NOT register them. Use `registerCustomProviders` for
- * the load-and-register convenience.
+ * Load trusted custom providers without mutating a global registry.
+ *
+ * The caller owns the returned provider instances and decides how to bind
+ * them into its client-scoped execution runtime.
+ *
+ * SECURITY: trusted npm modules and script declarations execute arbitrary
+ * code with this process's permissions and inherited environment. Load only
+ * code you explicitly trust; `trustedProviderIds` is an execution allowlist,
+ * not a sandbox.
  */
 export async function loadCustomProviders(
-  config: Pick<Config, 'customProviders' | 'trustedProviderIds' | 'providers'>,
+  config: CustomProviderLoadConfig,
   options: LoadCustomProvidersOptions = {},
 ): Promise<CustomProviderLoadResult> {
   const reservedProviderIds = new Set([
     ...RESERVED_BUILTIN_PROVIDER_IDS,
-    ...getAllProviders().map((provider) => provider.id),
     ...(options.reservedProviderIds ?? []),
   ]);
 
   return loadCustomProvidersInternal({
-    customProviders: config.customProviders ?? {},
-    trustedProviderIds: config.trustedProviderIds ?? [],
-    providerConfigs: config.providers ?? {},
+    customProviders: { ...(config.customProviders ?? {}) },
+    trustedProviderIds: [...(config.trustedProviderIds ?? [])],
+    providerConfigs: Object.fromEntries(
+      Object.entries(config.providers ?? {}).map(([id, provider]) => [
+        id,
+        { ...provider, enabled: provider.enabled ?? true },
+      ]),
+    ),
     reservedProviderIds,
   });
-}
-
-/**
- * Load custom providers from a `Config` and register the successfully loaded
- * ones into the core registry (so `getProvider`/`dispatch` see them). Returns
- * the same diagnostics as `loadCustomProviders`. Call after
- * `initializeProviders()` so reserved-ID detection sees the built-ins.
- */
-export async function registerCustomProviders(
-  config: Pick<Config, 'customProviders' | 'trustedProviderIds' | 'providers'>,
-  options: LoadCustomProvidersOptions = {},
-): Promise<CustomProviderLoadResult> {
-  const result = await loadCustomProviders(config, options);
-  for (const provider of result.providers) {
-    registerProvider(provider);
-  }
-  return result;
 }

--- a/src/node-run-directory.ts
+++ b/src/node-run-directory.ts
@@ -1,0 +1,59 @@
+import { mkdirSync } from 'node:fs';
+
+/** Injectable dependencies for unique run-directory creation. */
+export interface CreateRunDirDeps {
+  /** Current time in milliseconds. Defaults to Date.now. */
+  now?: () => number;
+  /** Short random suffix generator. Defaults to a base36 fragment. */
+  randomSuffix?: () => string;
+  /** Exclusive directory creator. Defaults to mkdirSync. */
+  mkdir?: (dir: string) => void;
+}
+
+function defaultRandomSuffix(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+/**
+ * Create a unique run directory and return its absolute path.
+ *
+ * This filesystem service intentionally lives outside `librarium/core`; the
+ * pure prompt and output-path helpers remain usable in Workers.
+ */
+export function createRunDir(
+  baseDir: string,
+  slug: string,
+  deps: CreateRunDirDeps = {},
+): string {
+  const now = deps.now ?? Date.now;
+  const randomSuffix = deps.randomSuffix ?? defaultRandomSuffix;
+  const mkdir =
+    deps.mkdir ?? ((dir: string) => mkdirSync(dir, { recursive: false }));
+  const separator = baseDir.endsWith('/') || baseDir.endsWith('\\') ? '' : '/';
+
+  mkdirSync(baseDir, { recursive: true });
+
+  const maxAttempts = 50;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const milliseconds = now();
+    const seconds = Math.floor(milliseconds / 1_000);
+    const millis = milliseconds % 1_000;
+    const dirName = `${seconds}-${slug}-${String(millis).padStart(3, '0')}${randomSuffix()}`;
+    const dir = `${baseDir}${separator}${dirName}`;
+    try {
+      mkdir(dir);
+      return dir;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== 'EEXIST') throw error;
+      lastError = error;
+    }
+  }
+
+  throw new Error(
+    `Failed to create a unique run directory under ${baseDir} after ${maxAttempts} attempts${
+      lastError instanceof Error ? `: ${lastError.message}` : ''
+    }`,
+  );
+}

--- a/tests/clean-dist.test.ts
+++ b/tests/clean-dist.test.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { DIST_DIRECTORY, isMainModule } from '../scripts/clean-dist.mjs';
+
+describe('dist cleanup target', () => {
+  it('is anchored to the repository rather than process.cwd()', () => {
+    const repositoryDist = fileURLToPath(new URL('../dist/', import.meta.url));
+    expect(DIST_DIRECTORY).toBe(repositoryDist);
+    expect(DIST_DIRECTORY).not.toBe(resolve(tmpdir(), 'dist'));
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'recognizes a symlinked script entrypoint',
+    () => {
+      const directory = mkdtempSync(join(tmpdir(), 'librarium-clean-dist-'));
+      const link = join(directory, 'clean-dist.mjs');
+      try {
+        symlinkSync(
+          fileURLToPath(new URL('../scripts/clean-dist.mjs', import.meta.url)),
+          link,
+        );
+        expect(isMainModule(link)).toBe(true);
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -13,7 +13,7 @@ import {
   type AttemptExecutionPort,
   runPreparedExecution,
 } from '../src/core/execution-runtime.js';
-import { createNodeAttemptBridge } from '../src/node-execution-bridge.js';
+import { createProviderAttemptBridge } from '../src/core/provider-attempt-bridge.js';
 import type { Provider, ProviderResult } from '../src/types.js';
 
 const start = Date.parse('2026-08-09T12:00:00.000Z');
@@ -316,7 +316,7 @@ describe('private prepared execution runtime', () => {
     const result = await runPreparedExecution(plan, {
       store,
       coordinator: coordinatorDependencies(),
-      attempts: createNodeAttemptBridge({
+      attempts: createProviderAttemptBridge({
         resolveExactBinding,
         now: () => start,
       }),
@@ -369,7 +369,7 @@ describe('private prepared execution runtime', () => {
       {
         store,
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: (binding) =>
             binding.adapter_id === 'adapter-durable'
               ? resolvedBinding('durable', durable)
@@ -416,7 +416,7 @@ describe('private prepared execution runtime', () => {
       {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: (binding) =>
             binding.adapter_id === 'adapter-durable'
               ? resolvedBinding('durable', durable)
@@ -580,7 +580,7 @@ describe('private prepared execution runtime', () => {
     const result = await runPreparedExecution(prepared([profile('primary')]), {
       store: new InMemoryCoordinationStateStore(),
       coordinator: coordinatorDependencies(),
-      attempts: createNodeAttemptBridge({
+      attempts: createProviderAttemptBridge({
         resolveExactBinding: () => ({
           binding: {
             adapter_id: 'adapter-primary',
@@ -633,7 +633,7 @@ describe('private prepared execution runtime', () => {
         {
           store: new InMemoryCoordinationStateStore(),
           coordinator: coordinatorDependencies(),
-          attempts: createNodeAttemptBridge({
+          attempts: createProviderAttemptBridge({
             resolveExactBinding: () =>
               resolvedBinding(
                 'primary',
@@ -678,7 +678,7 @@ describe('private prepared execution runtime', () => {
     const result = await runPreparedExecution(prepared([plannedProfile]), {
       store: new InMemoryCoordinationStateStore(),
       coordinator: coordinatorDependencies(),
-      attempts: createNodeAttemptBridge({
+      attempts: createProviderAttemptBridge({
         resolveExactBinding: () =>
           resolvedBinding('primary', provider, resolvedProfile),
         now: () => start,
@@ -734,7 +734,7 @@ describe('private prepared execution runtime', () => {
       {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: (binding) =>
             binding.adapter_id === 'adapter-durable'
               ? resolvedBinding('durable', durable)
@@ -784,7 +784,7 @@ describe('private prepared execution runtime', () => {
       {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: () => resolvedBinding('durable', durable),
           now: () => start,
         }),
@@ -825,7 +825,7 @@ describe('private prepared execution runtime', () => {
       {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: () => resolvedBinding('durable', durable),
           now: () => start,
         }),
@@ -886,7 +886,7 @@ describe('private prepared execution runtime', () => {
         {
           store: new InMemoryCoordinationStateStore(),
           coordinator: coordinatorDependencies(),
-          attempts: createNodeAttemptBridge({
+          attempts: createProviderAttemptBridge({
             resolveExactBinding: () => resolvedBinding('durable', durable),
             now: () => start,
           }),
@@ -983,7 +983,7 @@ describe('private prepared execution runtime', () => {
         {
           store: new InMemoryCoordinationStateStore(),
           coordinator: systemCoordinatorDependencies(),
-          attempts: createNodeAttemptBridge({
+          attempts: createProviderAttemptBridge({
             resolveExactBinding: (binding) =>
               binding.adapter_id === 'adapter-primary'
                 ? resolvedBinding('primary', primary)
@@ -1041,7 +1041,7 @@ describe('private prepared execution runtime', () => {
         {
           store: new InMemoryCoordinationStateStore(),
           coordinator: systemCoordinatorDependencies(),
-          attempts: createNodeAttemptBridge({
+          attempts: createProviderAttemptBridge({
             resolveExactBinding: (binding) =>
               binding.adapter_id === 'adapter-durable'
                 ? resolvedBinding('durable', durable)
@@ -1103,7 +1103,7 @@ describe('private prepared execution runtime', () => {
         {
           store: new InMemoryCoordinationStateStore(),
           coordinator: systemCoordinatorDependencies(),
-          attempts: createNodeAttemptBridge({
+          attempts: createProviderAttemptBridge({
             resolveExactBinding: (binding) =>
               binding.adapter_id === 'adapter-durable'
                 ? resolvedBinding('durable', durable)
@@ -1167,7 +1167,7 @@ describe('private prepared execution runtime', () => {
       {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: (binding) =>
             binding.adapter_id === 'adapter-durable'
               ? resolvedBinding('durable', durable)
@@ -1223,7 +1223,7 @@ describe('private prepared execution runtime', () => {
       {
         store: new InMemoryCoordinationStateStore(),
         coordinator: coordinatorDependencies(),
-        attempts: createNodeAttemptBridge({
+        attempts: createProviderAttemptBridge({
           resolveExactBinding: (binding) =>
             binding.adapter_id === 'adapter-durable'
               ? resolvedBinding('durable', durable)
@@ -1362,7 +1362,7 @@ describe('private prepared execution runtime', () => {
     const result = await runPreparedExecution(prepared([profile('primary')]), {
       store: new InMemoryCoordinationStateStore(),
       coordinator: coordinatorDependencies(),
-      attempts: createNodeAttemptBridge({
+      attempts: createProviderAttemptBridge({
         resolveExactBinding: () => resolvedBinding('primary', provider),
         now: () => start,
       }),

--- a/tests/integration/dist-registry.test.ts
+++ b/tests/integration/dist-registry.test.ts
@@ -4,26 +4,10 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type {
-  HttpClient,
-  HttpRequestOptions,
-} from '../../src/core/http-client.js';
 
-// Dist-level integration test for the shared provider registry.
-//
-// This is the regression test for the bug where each tsup entry
-// (dist/core.js, dist/node.js, dist/cli.js) bundled its OWN inlined copy of
-// the provider registry module. In that state, `registerCustomProviders()`
-// from `librarium/node` registered into the node bundle's private registry
-// while `getProvider()`/`dispatch()` from `librarium/core` read the core
-// bundle's separate registry -- so the documented flow (import core for
-// dispatch + node for custom providers) silently did nothing.
-//
-// Source-level tests miss this because they import `src/` modules directly,
-// giving a single shared module instance. We MUST import the BUILT dist files.
-//
-// Run `npm run build` before executing these tests.
-
+const DIST_ROOT = pathToFileURL(
+  resolve(import.meta.dirname, '../../dist/index.js'),
+).href;
 const DIST_CORE = pathToFileURL(
   resolve(import.meta.dirname, '../../dist/core.js'),
 ).href;
@@ -31,18 +15,12 @@ const DIST_NODE = pathToFileURL(
   resolve(import.meta.dirname, '../../dist/node.js'),
 ).href;
 
-type CoreModule = typeof import('../../src/core-entry.js');
-type NodeModule = typeof import('../../src/node-entry.js');
-
-describe('dist registry sharing (core + node)', () => {
+describe('built package boundaries', () => {
   let tmpDir: string;
   let originalCwd: string;
 
   beforeEach(() => {
-    tmpDir = join(
-      tmpdir(),
-      `librarium-dist-registry-${randomUUID().slice(0, 8)}`,
-    );
+    tmpDir = join(tmpdir(), `librarium-dist-entry-${randomUUID().slice(0, 8)}`);
     mkdirSync(tmpDir, { recursive: true });
     originalCwd = process.cwd();
     process.chdir(tmpDir);
@@ -54,28 +32,27 @@ describe('dist registry sharing (core + node)', () => {
   });
 
   function writeNpmProvider(id: string): void {
-    const pkgDir = join(tmpDir, 'node_modules', id);
-    mkdirSync(pkgDir, { recursive: true });
+    const packageDirectory = join(tmpDir, 'node_modules', id);
+    mkdirSync(packageDirectory, { recursive: true });
     writeFileSync(
       join(tmpDir, 'package.json'),
-      JSON.stringify({ name: 'tmp-project', private: true }, null, 2),
-      'utf-8',
+      JSON.stringify({ name: 'tmp-project', private: true }),
     );
     writeFileSync(
-      join(pkgDir, 'package.json'),
-      JSON.stringify(
-        { name: id, version: '1.0.0', type: 'module', exports: './index.mjs' },
-        null,
-        2,
-      ),
-      'utf-8',
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: id,
+        version: '1.0.0',
+        type: 'module',
+        exports: './index.mjs',
+      }),
     );
     writeFileSync(
-      join(pkgDir, 'index.mjs'),
+      join(packageDirectory, 'index.mjs'),
       [
         'export default {',
         `  id: '${id}',`,
-        "  displayName: 'Dist Lib Provider',",
+        "  displayName: 'Dist Provider',",
         "  tier: 'ai-grounded',",
         "  execution: 'inline',",
         "  envVar: '',",
@@ -84,180 +61,44 @@ describe('dist registry sharing (core + node)', () => {
         '    return {',
         `      provider: '${id}',`,
         "      tier: 'ai-grounded',",
-        '      content: `dist-lib:${query}`,',
+        '      content: `dist:${query}`,',
         '      citations: [],',
         '      durationMs: 1,',
         '    };',
         '  },',
         '};',
-        '',
       ].join('\n'),
-      'utf-8',
     );
   }
 
-  it('exports the built-in descriptor inventory from the packaged core', async () => {
-    const core = (await import(DIST_CORE)) as CoreModule;
+  it('keeps root and core free of concrete adapters and global registries', async () => {
+    const root = await import(DIST_ROOT);
+    const core = await import(DIST_CORE);
 
-    expect(core.BUILTIN_PROVIDER_DESCRIPTORS).toHaveLength(31);
-    expect(
-      core.BUILTIN_PROVIDER_DESCRIPTORS.find(
-        (descriptor) => descriptor.id === 'openai-research',
-      ),
-    ).toMatchObject({
-      defaultModel: 'gpt-5.6-sol',
-      capabilities: { execution: 'background', taskPersistence: 'remote' },
-      credential: {
-        envVar: 'OPENAI_API_KEY',
-        required: true,
-        autoEnable: true,
-      },
-      metering: { kind: 'native_tokens' },
-    });
-    expect(core.SearchApiChatGptProvider).toBeTypeOf('function');
-    expect(core.SearchApiGeminiProvider).toBeTypeOf('function');
-    expect(core.SearchApiPerplexityProvider).toBeTypeOf('function');
-    expect(core.SearchApiGoogleAiModeProvider).toBeTypeOf('function');
-    expect(core.SearchApiBingCopilotProvider).toBeTypeOf('function');
-    expect(core.SearchApiGoogleAiOverviewProvider).toBeTypeOf('function');
-    expect(core.PerplexityProSearchProvider).toBeTypeOf('function');
+    expect(root.ResearchRequestSchema).toBeDefined();
+    expect(core.buildProviderCatalog).toBeTypeOf('function');
+    expect(core).not.toHaveProperty('initializeProviders');
+    expect(core).not.toHaveProperty('registerProvider');
+    expect(core).not.toHaveProperty('SearchApiProvider');
+    expect(core).not.toHaveProperty('dispatch');
   });
 
-  it('keeps SearchAPI credentials out of built execute and health-check URLs', async () => {
-    const core = (await import(DIST_CORE)) as CoreModule;
-    const apiKey = 'dist-searchapi-synthetic-key';
-    const calls: Array<{ url: string; options?: HttpRequestOptions }> = [];
-    const httpClient: HttpClient = async <T>(url, options) => {
-      calls.push({ url, options });
-      return {
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        data: { organic_results: [] } as T,
-        durationMs: 1,
-      };
-    };
-    const provider = new core.SearchApiProvider({
-      apiKey,
-      httpClient,
-      zeroRetention: true,
-    });
+  it('loads a trusted custom provider through the Node entry without globals', async () => {
+    const node = await import(DIST_NODE);
+    writeNpmProvider('dist-provider');
 
-    await provider.execute('dist transport', { timeout: 4 });
-    await provider.test();
-
-    expect(calls).toHaveLength(2);
-    for (const call of calls) {
-      const url = new URL(call.url);
-      expect(url.searchParams.has('api_key')).toBe(false);
-      expect(url.searchParams.get('zero_retention')).toBe('true');
-      expect(call.url).not.toContain(apiKey);
-      expect(call.options?.headers).toEqual({
-        Authorization: `Bearer ${apiKey}`,
-      });
-    }
-  });
-
-  it('registerCustomProviders (node) is visible to getProvider/dispatch (core)', async () => {
-    const core = (await import(DIST_CORE)) as CoreModule;
-    const node = (await import(DIST_NODE)) as NodeModule;
-
-    writeNpmProvider('dist-lib-provider');
-
-    // Initialize the built-in registry via the CORE entry, then register a
-    // custom provider via the NODE entry. If the registries are separate
-    // bundled copies, getProvider() from core will NOT see it -> test fails.
-    await core.initializeProviders();
-
-    const result = await node.registerCustomProviders({
-      providers: { 'dist-lib-provider': { enabled: true } },
+    const result = await node.loadCustomProviders({
+      providers: { 'dist-provider': { enabled: true } },
       customProviders: {
-        'dist-lib-provider': { type: 'npm', module: 'dist-lib-provider' },
+        'dist-provider': { type: 'npm', module: 'dist-provider' },
       },
-      trustedProviderIds: ['dist-lib-provider'],
+      trustedProviderIds: ['dist-provider'],
     });
 
-    expect(result.warnings).toEqual([]);
-    expect(result.loadedIds).toContain('dist-lib-provider');
-
-    // THE CRITICAL ASSERTION: core's getProvider must see what node registered.
-    const fromCore = core.getProvider('dist-lib-provider');
-    expect(fromCore).toBeDefined();
-    expect(fromCore?.source).toBe('npm');
-
-    // And a dispatch via core must actually run the custom provider.
-    const dispatched = await core.dispatch({
-      config: {
-        version: 1,
-        defaults: {
-          outputDir: './agents/librarium',
-          maxParallel: 2,
-          timeout: 10,
-          asyncTimeout: 60,
-          asyncPollInterval: 1,
-          mode: 'sync',
-          llmWebSearch: true,
-        },
-        providers: { 'dist-lib-provider': { enabled: true } },
-        customProviders: {},
-        trustedProviderIds: [],
-        groups: {},
-      },
-      providerIds: ['dist-lib-provider'],
-      query: 'hello',
-      mode: 'sync',
-      credentials: { env: {} },
-    });
-
-    expect(dispatched.results).toHaveLength(1);
-    expect(dispatched.results[0]?.status).toBe('success');
-    expect(dispatched.results[0]?.text).toBe('dist-lib:hello');
-  });
-
-  it('reserved built-in IDs (registered via core) are rejected by node', async () => {
-    const core = (await import(DIST_CORE)) as CoreModule;
-    const node = (await import(DIST_NODE)) as NodeModule;
-
-    // Built-ins registered via core. node's default reserved-ID set is derived
-    // from getAllProviders() -- which reads the registry. If registries are
-    // separate, node sees an EMPTY built-in set and would wrongly allow `exa`.
-    writeNpmProvider('exa');
-    await core.initializeProviders();
-
-    const result = await node.registerCustomProviders({
-      providers: { exa: { enabled: true } },
-      customProviders: { exa: { type: 'npm', module: 'exa' } },
-      trustedProviderIds: ['exa'],
-    });
-
-    expect(result.loadedIds).not.toContain('exa');
-    expect(result.skippedIds).toContain('exa');
-    expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
-
-    // The built-in exa provider (registered via core) is still the one core sees.
-    expect(core.getProvider('exa')?.source).toBe('builtin');
-  });
-
-  it('reserves descriptor IDs even when current options are invalid', async () => {
-    const core = (await import(DIST_CORE)) as CoreModule;
-    const node = (await import(DIST_NODE)) as NodeModule;
-
-    writeNpmProvider('claude');
-    const initialized = await core.initializeProviders({
-      providers: { claude: { options: { thinking: 'turbo' } } },
-    });
-    expect(initialized.warnings.join(' ')).toContain(
-      'Invalid options for claude',
-    );
-
-    const result = await node.registerCustomProviders({
-      providers: { claude: { enabled: true } },
-      customProviders: { claude: { type: 'npm', module: 'claude' } },
-      trustedProviderIds: ['claude'],
-    });
-
-    expect(result.loadedIds).not.toContain('claude');
-    expect(result.skippedIds).toContain('claude');
-    expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
+    expect(result.loadedIds).toEqual(['dist-provider']);
+    await expect(
+      result.providers[0]?.execute('hello', { timeout: 5 }),
+    ).resolves.toMatchObject({ content: 'dist:hello' });
+    expect(node).not.toHaveProperty('registerCustomProviders');
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -13,7 +13,6 @@ import {
   vi,
 } from 'vitest';
 import { initializeProviders } from '../src/adapters/node-registry.js';
-import { createRunDir } from '../src/core/prompt-builder.js';
 import {
   ResearchInputError,
   resolveProviderSelection,
@@ -33,6 +32,7 @@ import {
   truncateProviderContent,
   UNTRUSTED_CONTENT_WARNING,
 } from '../src/mcp/shaping.js';
+import { createRunDir } from '../src/node-run-directory.js';
 import type {
   Config,
   DeduplicatedSource,

--- a/tests/node-entry.test.ts
+++ b/tests/node-entry.test.ts
@@ -4,39 +4,23 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BUILTIN_PROVIDER_CATALOG } from '../src/core/provider-profiles.js';
+import { RESERVED_BUILTIN_PROVIDER_IDS } from '../src/core/reserved-provider-ids.js';
 
-const PLANNED_PROVIDER_IDS = BUILTIN_PROVIDER_CATALOG.filter((entry) =>
-  entry.profiles.some((profile) => profile.status === 'planned'),
-).map((entry) => entry.provider_id);
-
-// The `librarium/node` entry point is the documented Node-only bridge that lets
-// library consumers (not just the CLI) load npm/script custom providers and
-// register them into the core registry.
+const BUILTIN_IDS = BUILTIN_PROVIDER_CATALOG.map(
+  ({ provider_id }) => provider_id,
+);
+const RESERVED_IDS = [...RESERVED_BUILTIN_PROVIDER_IDS].sort();
 
 describe('librarium/node entry', () => {
   let tmpDir: string;
   let originalCwd: string;
-  let loadCustomProviders: typeof import('../src/node-entry.js').loadCustomProviders;
-  let registerCustomProviders: typeof import('../src/node-entry.js').registerCustomProviders;
-  let executeResearchRun: typeof import('../src/node-entry.js').executeResearchRun;
-  let getProvider: typeof import('../src/adapters/index.js').getProvider;
-  let getAllProviders: typeof import('../src/adapters/index.js').getAllProviders;
-  let initializeProviders: typeof import('../src/adapters/index.js').initializeProviders;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tmpDir = join(tmpdir(), `librarium-node-entry-${randomUUID().slice(0, 8)}`);
     mkdirSync(tmpDir, { recursive: true });
     originalCwd = process.cwd();
     process.chdir(tmpDir);
     vi.resetModules();
-    const nodeEntry = await import('../src/node-entry.js');
-    loadCustomProviders = nodeEntry.loadCustomProviders;
-    registerCustomProviders = nodeEntry.registerCustomProviders;
-    executeResearchRun = nodeEntry.executeResearchRun;
-    const registry = await import('../src/adapters/index.js');
-    getProvider = registry.getProvider;
-    getAllProviders = registry.getAllProviders;
-    initializeProviders = registry.initializeProviders;
   });
 
   afterEach(() => {
@@ -45,31 +29,24 @@ describe('librarium/node entry', () => {
     vi.restoreAllMocks();
   });
 
-  it('exposes the documented load/register API', () => {
-    expect(typeof loadCustomProviders).toBe('function');
-    expect(typeof registerCustomProviders).toBe('function');
-    expect(typeof executeResearchRun).toBe('function');
-  });
-
   function writeNpmProvider(id: string, topLevelEffectPath?: string): void {
-    const pkgDir = join(tmpDir, 'node_modules', id);
-    mkdirSync(pkgDir, { recursive: true });
+    const packageDirectory = join(tmpDir, 'node_modules', id);
+    mkdirSync(packageDirectory, { recursive: true });
     writeFileSync(
       join(tmpDir, 'package.json'),
       JSON.stringify({ name: 'tmp-project', private: true }, null, 2),
-      'utf-8',
     );
     writeFileSync(
-      join(pkgDir, 'package.json'),
-      JSON.stringify(
-        { name: id, version: '1.0.0', type: 'module', exports: './index.mjs' },
-        null,
-        2,
-      ),
-      'utf-8',
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: id,
+        version: '1.0.0',
+        type: 'module',
+        exports: './index.mjs',
+      }),
     );
     writeFileSync(
-      join(pkgDir, 'index.mjs'),
+      join(packageDirectory, 'index.mjs'),
       [
         ...(topLevelEffectPath
           ? [
@@ -79,7 +56,7 @@ describe('librarium/node entry', () => {
           : []),
         'export default {',
         `  id: '${id}',`,
-        "  displayName: 'Lib Provider',",
+        "  displayName: 'Library Provider',",
         "  tier: 'ai-grounded',",
         "  execution: 'inline',",
         "  envVar: '',",
@@ -88,63 +65,74 @@ describe('librarium/node entry', () => {
         '    return {',
         `      provider: '${id}',`,
         "      tier: 'ai-grounded',",
-        '      content: `lib:${query}`,',
+        '      content: `library:${query}`,',
         '      citations: [],',
         '      durationMs: 1,',
         '    };',
         '  },',
         '};',
-        '',
       ].join('\n'),
-      'utf-8',
     );
   }
 
-  it('loadCustomProviders loads a trusted provider without registering it', async () => {
-    writeNpmProvider('lib-provider');
+  function writeScriptProbe(id: string, markerPath: string): string {
+    const scriptPath = join(tmpDir, `${id.replaceAll('/', '-')}-provider.mjs`);
+    writeFileSync(
+      scriptPath,
+      [
+        "import { writeFileSync } from 'node:fs';",
+        `writeFileSync(${JSON.stringify(markerPath)}, 'described');`,
+      ].join('\n'),
+    );
+    return scriptPath;
+  }
 
-    const result = await loadCustomProviders({
-      providers: { 'lib-provider': { enabled: true } },
+  it('loads trusted custom providers without mutating a public registry', async () => {
+    writeNpmProvider('library-provider');
+    const node = await import('../src/node-entry.js');
+
+    const result = await node.loadCustomProviders({
+      providers: { 'library-provider': { enabled: true } },
       customProviders: {
-        'lib-provider': { type: 'npm', module: 'lib-provider' },
+        'library-provider': { type: 'npm', module: 'library-provider' },
       },
-      trustedProviderIds: ['lib-provider'],
+      trustedProviderIds: ['library-provider'],
     });
 
     expect(result.warnings).toEqual([]);
-    expect(result.loadedIds).toContain('lib-provider');
-    expect(result.providers).toHaveLength(1);
-    expect(result.providers[0].source).toBe('npm');
-    // load-only: registry untouched
-    expect(getProvider('lib-provider')).toBeUndefined();
+    expect(result.loadedIds).toEqual(['library-provider']);
+    await expect(
+      result.providers[0]?.execute('hello', { timeout: 5 }),
+    ).resolves.toMatchObject({ content: 'library:hello' });
+    expect(node).not.toHaveProperty('registerCustomProviders');
+    expect(node).not.toHaveProperty('executeResearchRun');
   });
 
-  it('registerCustomProviders registers loaded providers into the core registry', async () => {
-    writeNpmProvider('lib-provider');
-    await initializeProviders();
-    const builtinCount = getAllProviders().length;
+  it.each(RESERVED_IDS)(
+    'rejects reserved built-in id %s before importing custom code',
+    async (providerId) => {
+      const markerPath = join(tmpDir, `${providerId}-loaded`);
+      writeNpmProvider(providerId, markerPath);
+      const { loadCustomProviders } = await import('../src/node-entry.js');
 
-    const result = await registerCustomProviders({
-      providers: { 'lib-provider': { enabled: true } },
-      customProviders: {
-        'lib-provider': { type: 'npm', module: 'lib-provider' },
-      },
-      trustedProviderIds: ['lib-provider'],
-    });
+      const result = await loadCustomProviders({
+        providers: { [providerId]: { enabled: true } },
+        customProviders: {
+          [providerId]: { type: 'npm', module: providerId },
+        },
+        trustedProviderIds: [providerId],
+      });
 
-    expect(result.loadedIds).toContain('lib-provider');
-    const registered = getProvider('lib-provider');
-    expect(registered).toBeDefined();
-    expect(registered?.source).toBe('npm');
-    expect(getAllProviders()).toHaveLength(builtinCount + 1);
+      expect(result.skippedIds).toContain(providerId);
+      expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
+      expect(existsSync(markerPath)).toBe(false);
+    },
+  );
 
-    const executed = await registered!.execute('hi', { timeout: 5 });
-    expect(executed.content).toBe('lib:hi');
-  });
-
-  it('rejects canonical built-in IDs before importing npm code', async () => {
-    const markerPath = join(tmpDir, 'npm-provider-loaded');
+  it('cannot bypass built-in protection with an empty additional reserve', async () => {
+    const markerPath = join(tmpDir, 'exa-loaded');
     writeNpmProvider('exa', markerPath);
+    const { loadCustomProviders } = await import('../src/node-entry.js');
 
     const result = await loadCustomProviders(
       {
@@ -152,28 +140,17 @@ describe('librarium/node entry', () => {
         customProviders: { exa: { type: 'npm', module: 'exa' } },
         trustedProviderIds: ['exa'],
       },
-      {
-        reservedProviderIds: [],
-      },
+      { reservedProviderIds: [] },
     );
 
-    expect(result.loadedIds).not.toContain('exa');
     expect(result.skippedIds).toContain('exa');
-    expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
     expect(existsSync(markerPath)).toBe(false);
   });
 
-  it('rejects built-in aliases before spawning script describe code', async () => {
-    const markerPath = join(tmpDir, 'script-provider-described');
-    const scriptPath = join(tmpDir, 'reserved-provider-script.mjs');
-    writeFileSync(
-      scriptPath,
-      [
-        "import { writeFileSync } from 'node:fs';",
-        `writeFileSync(${JSON.stringify(markerPath)}, 'described');`,
-      ].join('\n'),
-      'utf-8',
-    );
+  it('rejects a built-in alias before spawning script describe code', async () => {
+    const markerPath = join(tmpDir, 'alias-described');
+    const scriptPath = writeScriptProbe('openai-deep', markerPath);
+    const { loadCustomProviders } = await import('../src/node-entry.js');
 
     const result = await loadCustomProviders(
       {
@@ -190,44 +167,18 @@ describe('librarium/node entry', () => {
       { reservedProviderIds: [] },
     );
 
-    expect(result.loadedIds).not.toContain('openai-deep');
     expect(result.skippedIds).toContain('openai-deep');
-    expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
     expect(existsSync(markerPath)).toBe(false);
   });
 
-  it.each(PLANNED_PROVIDER_IDS)(
-    'rejects planned built-in id %s before importing npm code',
+  it.each(RESERVED_IDS)(
+    'rejects reserved script id %s before describe/spawn',
     async (providerId) => {
-      const markerPath = join(tmpDir, `${providerId}-npm-loaded`);
-      writeNpmProvider(providerId, markerPath);
-      const result = await loadCustomProviders({
-        providers: { [providerId]: { enabled: true } },
-        customProviders: {
-          [providerId]: { type: 'npm', module: providerId },
-        },
-        trustedProviderIds: [providerId],
-      });
-      expect(result.loadedIds).not.toContain(providerId);
-      expect(result.skippedIds).toContain(providerId);
-      expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
-      expect(existsSync(markerPath)).toBe(false);
-    },
-  );
+      const safeId = providerId.replaceAll('/', '-');
+      const markerPath = join(tmpDir, `${safeId}-described`);
+      const scriptPath = writeScriptProbe(providerId, markerPath);
+      const { loadCustomProviders } = await import('../src/node-entry.js');
 
-  it.each(PLANNED_PROVIDER_IDS)(
-    'rejects planned built-in id %s before spawning script describe code',
-    async (providerId) => {
-      const markerPath = join(tmpDir, `${providerId}-script-described`);
-      const scriptPath = join(tmpDir, `${providerId}-provider-script.mjs`);
-      writeFileSync(
-        scriptPath,
-        [
-          "import { writeFileSync } from 'node:fs';",
-          `writeFileSync(${JSON.stringify(markerPath)}, 'described');`,
-        ].join('\n'),
-        'utf-8',
-      );
       const result = await loadCustomProviders({
         providers: { [providerId]: { enabled: true } },
         customProviders: {
@@ -239,10 +190,16 @@ describe('librarium/node entry', () => {
         },
         trustedProviderIds: [providerId],
       });
-      expect(result.loadedIds).not.toContain(providerId);
+
       expect(result.skippedIds).toContain(providerId);
       expect(result.warnings.join(' ')).toMatch(/conflicts with a built-in/);
       expect(existsSync(markerPath)).toBe(false);
     },
   );
+
+  it('covers every current and planned catalog identity in the reserved set', () => {
+    expect(
+      BUILTIN_IDS.every((id) => RESERVED_BUILTIN_PROVIDER_IDS.has(id)),
+    ).toBe(true);
+  });
 });

--- a/tests/run-shadow-diagnostics.test.ts
+++ b/tests/run-shadow-diagnostics.test.ts
@@ -105,6 +105,9 @@ vi.mock('../src/core/provider-selection.js', () => {
 vi.mock('../src/core/prompt-builder.js', () => ({
   generateSlug: () => 'fixture-slug',
   resolveOutputDir: () => '/tmp/unused-cli-output',
+}));
+
+vi.mock('../src/node-run-directory.js', () => ({
   createRunDir: () => '/tmp/unused-mcp-output',
 }));
 

--- a/tests/workers/adapters.test.ts
+++ b/tests/workers/adapters.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { GeminiGroundedProvider } from '../../src/adapters/gemini-grounded.js';
+import {
+  getProvider,
+  initializeProviders,
+  registerProvider,
+} from '../../src/adapters/index.js';
+import { PerplexityProSearchProvider } from '../../src/adapters/perplexity-pro-search.js';
+import { PerplexitySearchProvider } from '../../src/adapters/perplexity-search.js';
+import { SearchApiProvider } from '../../src/adapters/searchapi.js';
+import { dispatch } from '../../src/core/dispatcher.js';
+import type {
+  HttpClient,
+  HttpStreamClient,
+} from '../../src/core/http-client.js';
+import type {
+  Config,
+  Provider,
+  ProviderOptions,
+  ProviderResult,
+} from '../../src/types.js';
+import {
+  PRO_SEARCH_CONTENT,
+  splitEveryByte,
+  streamResponse,
+} from '../fixtures/perplexity-pro-search.js';
+
+function makeConfig(): Config {
+  return {
+    version: 1,
+    defaults: {
+      outputDir: './agents/librarium',
+      maxParallel: 2,
+      timeout: 10,
+      asyncTimeout: 60,
+      asyncPollInterval: 1,
+      mode: 'sync',
+      llmWebSearch: true,
+    },
+    providers: { 'worker-mock': { enabled: true } },
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {},
+  };
+}
+
+describe('internal adapters in workerd', () => {
+  it('initializes built-ins and dispatches an in-memory provider', async () => {
+    await initializeProviders({
+      credentials: { env: { GEMINI_API_KEY: 'test-key' } },
+    });
+    const gemini = new GeminiGroundedProvider({
+      credentials: { env: { GEMINI_API_KEY: 'test-key' } },
+    });
+    expect(gemini.id).toBe('gemini-grounded');
+    expect(getProvider('gemini-grounded')?.id).toBe('gemini-grounded');
+
+    const mockProvider: Provider = {
+      id: 'worker-mock',
+      displayName: 'Worker Mock',
+      tier: 'ai-grounded',
+      execution: 'inline',
+      envVar: '',
+      requiresApiKey: false,
+      execute: async (
+        query: string,
+        _options: ProviderOptions,
+      ): Promise<ProviderResult> => ({
+        provider: 'worker-mock',
+        tier: 'ai-grounded',
+        content: `workerd:${query}`,
+        citations: [
+          {
+            url: 'https://example.com/source',
+            title: 'Example Source',
+            provider: 'worker-mock',
+          },
+        ],
+        durationMs: 5,
+        model: 'mock-model',
+      }),
+    };
+    registerProvider(mockProvider);
+
+    const result = await dispatch({
+      config: makeConfig(),
+      providerIds: ['worker-mock'],
+      query: 'hello',
+      mode: 'sync',
+      credentials: { env: {} },
+    });
+
+    expect(result.asyncTasks).toEqual([]);
+    expect(result.reports).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      provider: 'worker-mock',
+      status: 'success',
+      text: 'workerd:hello',
+      sourceUrls: ['https://example.com/source'],
+    });
+  });
+
+  it('runs Perplexity Search through an injected transport', async () => {
+    const requests: unknown[] = [];
+    const provider = new PerplexitySearchProvider({
+      credentials: { env: { PERPLEXITY_API_KEY: 'test-key' } },
+      additionalQueries: ['worker perspective'],
+      httpClient: async (_url, options) => {
+        requests.push(options?.body);
+        return {
+          status: 200,
+          statusText: 'OK',
+          data: { id: 'worker-search', results: [] },
+          headers: {},
+          durationMs: 1,
+        };
+      },
+    });
+
+    await expect(
+      provider.execute('worker query', { timeout: 10 }),
+    ).resolves.toMatchObject({ content: 'No results found.', citations: [] });
+    expect(requests).toEqual([
+      { query: ['worker query', 'worker perspective'], max_results: 10 },
+    ]);
+  });
+
+  it('keeps SearchAPI credentials out of bearer/ZDR request URLs', async () => {
+    const calls: Array<{ url: string; options: Record<string, unknown> }> = [];
+    const httpClient: HttpClient = async <T>(url, options = {}) => {
+      calls.push({ url, options });
+      return {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        data: { organic_results: [] } as T,
+        durationMs: 1,
+      };
+    };
+    const provider = new SearchApiProvider({
+      apiKey: 'worker-searchapi-synthetic-key',
+      httpClient,
+      zeroRetention: true,
+    });
+
+    await provider.execute('worker transport', { timeout: 5 });
+    expect(calls).toHaveLength(1);
+    const request = calls[0];
+    if (!request) throw new Error('SearchAPI request was not recorded');
+    const url = new URL(request.url);
+    expect(url.searchParams.has('api_key')).toBe(false);
+    expect(url.searchParams.get('zero_retention')).toBe('true');
+    expect(request.options.headers).toEqual({
+      Authorization: 'Bearer worker-searchapi-synthetic-key',
+    });
+  });
+
+  it('streams Perplexity Pro Search through an injected transport', async () => {
+    const calls: Array<{ url: string; options: Record<string, unknown> }> = [];
+    const httpStreamClient: HttpStreamClient = async (url, options = {}) => {
+      calls.push({ url, options });
+      return streamResponse(splitEveryByte());
+    };
+    const provider = new PerplexityProSearchProvider({
+      apiKey: 'worker-perplexity-synthetic-key',
+      httpStreamClient,
+    });
+
+    await expect(
+      provider.execute('worker Pro Search', { timeout: 5 }),
+    ).resolves.toMatchObject({
+      provider: 'perplexity-pro-search',
+      content: PRO_SEARCH_CONTENT,
+      model: 'sonar-pro',
+      usage: { costUsd: 0.014138 },
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'https://api.perplexity.ai/v1/sonar',
+      options: {
+        body: {
+          model: 'sonar-pro',
+          stream: true,
+          stream_mode: 'concise',
+          web_search_options: { search_type: 'pro' },
+        },
+        retry: { mode: 'never' },
+      },
+    });
+  });
+});

--- a/tests/workers/core.test.ts
+++ b/tests/workers/core.test.ts
@@ -1,240 +1,81 @@
 import {
-  BUILTIN_PROVIDER_DESCRIPTORS,
-  type Config,
-  dispatch,
-  GeminiGroundedProvider,
-  getProvider,
+  BUILTIN_PROVIDER_CATALOG,
+  type ResearchRequest,
+  ResearchRequestSchema,
+  VERSION,
+} from 'librarium';
+import {
+  buildPrompt,
+  buildProviderCatalog,
+  createProviderAttemptBridge,
   type HttpClient,
-  type HttpStreamClient,
   httpStreamRequest,
-  initializeProviders,
-  PerplexityProSearchProvider,
-  PerplexitySearchProvider,
-  type Provider,
-  type ProviderOptions,
-  type ProviderResult,
-  registerProvider,
-  SearchApiBingCopilotProvider,
-  SearchApiChatGptProvider,
-  SearchApiGeminiProvider,
-  SearchApiGoogleAiModeProvider,
-  SearchApiGoogleAiOverviewProvider,
-  SearchApiPerplexityProvider,
-  SearchApiProvider,
+  InMemoryCoordinationStateStore,
+  prepareResearchExecution,
 } from 'librarium/core';
 import { describe, expect, it } from 'vitest';
-import {
-  PRO_SEARCH_CONTENT,
-  splitEveryByte,
-  streamResponse,
-} from '../fixtures/perplexity-pro-search.js';
 
-function makeConfig(): Config {
-  return {
-    version: 1,
-    defaults: {
-      outputDir: './agents/librarium',
-      maxParallel: 2,
-      timeout: 10,
-      asyncTimeout: 60,
-      asyncPollInterval: 1,
-      mode: 'sync',
-      llmWebSearch: true,
+function request(): ResearchRequest {
+  return ResearchRequestSchema.parse({
+    query: 'Worker-safe package boundary',
+    mode: 'sync',
+    selector: {
+      kind: 'targets',
+      targets: [{ provider_id: 'brave-search', profile_id: 'search' }],
     },
-    providers: {
-      'worker-mock': {
-        enabled: true,
-      },
+    fallback: { kind: 'disabled' },
+    limits: {
+      max_concurrency: 1,
+      request_deadline_ms: 30_000,
+      inline_attempt_deadline_ms: 30_000,
+      background_attempt_deadline_ms: 30_000,
+      poll_interval_ms: 1_000,
     },
-    customProviders: {},
-    trustedProviderIds: [],
-    groups: {},
-  };
+  });
 }
 
-describe('librarium/core in workerd', () => {
-  it('imports the core export, initializes adapters, and dispatches in memory', async () => {
-    expect(BUILTIN_PROVIDER_DESCRIPTORS).toHaveLength(31);
-    await initializeProviders({
-      credentials: { env: { GEMINI_API_KEY: 'test-key' } },
+describe('public Librarium entries in workerd', () => {
+  it('validates, plans, and exposes only Worker-safe root/core primitives', () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+    expect(BUILTIN_PROVIDER_CATALOG.length).toBeGreaterThan(20);
+    expect(request().query).toBe('Worker-safe package boundary');
+
+    const catalog = buildProviderCatalog({
+      providerConfigs: { 'brave-search': { enabled: true } },
+      credentials: { env: { BRAVE_API_KEY: 'worker-synthetic-key' } },
     });
-
-    const gemini = new GeminiGroundedProvider({
-      credentials: { env: { GEMINI_API_KEY: 'test-key' } },
-    });
-    expect(gemini.id).toBe('gemini-grounded');
-    expect(getProvider('gemini-grounded')?.id).toBe('gemini-grounded');
-
-    const mockProvider: Provider = {
-      id: 'worker-mock',
-      displayName: 'Worker Mock',
-      tier: 'ai-grounded',
-      execution: 'inline',
-      envVar: '',
-      requiresApiKey: false,
-      execute: async (
-        query: string,
-        _options: ProviderOptions,
-      ): Promise<ProviderResult> => ({
-        provider: 'worker-mock',
-        tier: 'ai-grounded',
-        content: `workerd:${query}`,
-        citations: [
-          {
-            url: 'https://example.com/source',
-            title: 'Example Source',
-            provider: 'worker-mock',
-          },
-        ],
-        durationMs: 5,
-        model: 'mock-model',
-      }),
-    };
-    registerProvider(mockProvider);
-
-    const result = await dispatch({
-      config: makeConfig(),
-      providerIds: ['worker-mock'],
-      query: 'hello',
-      mode: 'sync',
-      credentials: { env: {} },
-    });
-
-    expect(result.asyncTasks).toEqual([]);
-    expect(result.reports).toHaveLength(1);
-    expect(result.results).toEqual([
-      {
-        provider: 'worker-mock',
-        tier: 'ai-grounded',
-        status: 'success',
-        text: 'workerd:hello',
-        sourceUrls: ['https://example.com/source'],
-        citations: [
-          {
-            url: 'https://example.com/source',
-            title: 'Example Source',
-            provider: 'worker-mock',
-          },
-        ],
-        durationMs: 5,
-        model: 'mock-model',
-        tokenUsage: undefined,
-        metering: { kind: 'manual_unmetered' },
-        error: undefined,
-        fallbackFor: undefined,
+    const prepared = prepareResearchExecution(request(), catalog, {
+      clock: { now: () => Date.parse('2026-08-10T00:00:00.000Z') },
+      ids: {
+        next: (scope) => `${scope}-worker`,
       },
-    ]);
-  });
+    });
 
-  it('exports every new adapter from the Worker-safe core entry', () => {
-    for (const ProviderConstructor of [
-      SearchApiChatGptProvider,
-      SearchApiGeminiProvider,
-      SearchApiPerplexityProvider,
-      SearchApiGoogleAiModeProvider,
-      SearchApiBingCopilotProvider,
-      SearchApiGoogleAiOverviewProvider,
-      PerplexityProSearchProvider,
-    ]) {
-      expect(ProviderConstructor).toBeTypeOf('function');
+    expect(catalog.get('brave-search', 'search')?.availability.selectable).toBe(
+      true,
+    );
+    expect(prepared.ok).toBe(true);
+    if (prepared.ok) {
+      expect(prepared.prepared.request.slots).toHaveLength(1);
+      expect(
+        prepared.prepared.request.slots[0]?.primary.identity,
+      ).toMatchObject({
+        provider_id: 'brave-search',
+        profile_id: 'search',
+      });
     }
-  });
-
-  it('runs Perplexity Search through an injected Worker-safe transport', async () => {
-    const requests: unknown[] = [];
-    const provider = new PerplexitySearchProvider({
-      credentials: { env: { PERPLEXITY_API_KEY: 'test-key' } },
-      additionalQueries: ['worker perspective'],
-      httpClient: async (_url, options) => {
-        requests.push(options?.body);
-        return {
-          status: 200,
-          statusText: 'OK',
-          data: { id: 'worker-search', results: [] },
-          headers: {},
-          durationMs: 1,
-        };
-      },
+    const client: HttpClient = async <T>() => ({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: {} as T,
+      durationMs: 1,
     });
 
-    await expect(
-      provider.execute('worker query', { timeout: 10 }),
-    ).resolves.toMatchObject({
-      content: 'No results found.',
-      citations: [],
-    });
-    expect(requests).toEqual([
-      { query: ['worker query', 'worker perspective'], max_results: 10 },
-    ]);
-  });
-
-  it('constructs SearchAPI requests with fetch-only Worker globals', async () => {
-    const calls: Array<{ url: string; options: Record<string, unknown> }> = [];
-    const httpClient: HttpClient = async <T>(url, options = {}) => {
-      calls.push({ url, options });
-      return {
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        data: { organic_results: [] } as T,
-        durationMs: 1,
-      };
-    };
-    const provider = new SearchApiProvider({
-      apiKey: 'worker-searchapi-synthetic-key',
-      httpClient,
-      zeroRetention: true,
-    });
-
-    await expect(
-      provider.execute('worker transport', { timeout: 5 }),
-    ).resolves.toMatchObject({
-      provider: 'searchapi',
-      content: 'No results found.',
-    });
-    expect(calls).toHaveLength(1);
-    const request = calls[0];
-    if (!request) throw new Error('SearchAPI request was not recorded');
-    const url = new URL(request.url);
-    expect(url.searchParams.has('api_key')).toBe(false);
-    expect(url.searchParams.get('zero_retention')).toBe('true');
-    expect(request.options.headers).toEqual({
-      Authorization: 'Bearer worker-searchapi-synthetic-key',
-    });
-  });
-
-  it('imports the streaming core transport and runs Pro Search in workerd', async () => {
+    expect(typeof client).toBe('function');
     expect(typeof httpStreamRequest).toBe('function');
-    const calls: Array<{ url: string; options: Record<string, unknown> }> = [];
-    const httpStreamClient: HttpStreamClient = async (url, options = {}) => {
-      calls.push({ url, options });
-      return streamResponse(splitEveryByte());
-    };
-    const provider = new PerplexityProSearchProvider({
-      apiKey: 'worker-perplexity-synthetic-key',
-      httpStreamClient,
-    });
-
-    await expect(
-      provider.execute('worker Pro Search', { timeout: 5 }),
-    ).resolves.toMatchObject({
-      provider: 'perplexity-pro-search',
-      content: PRO_SEARCH_CONTENT,
-      model: 'sonar-pro',
-      usage: { costUsd: 0.014138 },
-    });
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({
-      url: 'https://api.perplexity.ai/v1/sonar',
-      options: {
-        body: {
-          model: 'sonar-pro',
-          stream: true,
-          stream_mode: 'concise',
-          web_search_options: { search_type: 'pro' },
-        },
-        retry: { mode: 'never' },
-      },
-    });
+    expect(typeof createProviderAttemptBridge).toBe('function');
+    expect(new InMemoryCoordinationStateStore()).toBeDefined();
+    expect(buildPrompt('worker')).toContain('# Research Query');
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,9 +7,7 @@ const shared: Options = {
   format: ['esm'],
   target: 'node22.12',
   outDir: 'dist',
-  splitting: false,
   sourcemap: true,
-  dts: true,
   define: {
     __VERSION__: JSON.stringify(pkg.version),
   },
@@ -18,38 +16,29 @@ const shared: Options = {
 export default defineConfig([
   {
     ...shared,
-    entry: { cli: 'src/cli.ts' },
-    platform: 'node',
-    clean: true,
-    banner: {
-      js: '#!/usr/bin/env node',
-    },
-  },
-  // The `core` and `node` entries MUST be built together with code splitting
-  // enabled so the shared provider registry (`src/adapters/index.ts`) becomes a
-  // single common chunk imported by BOTH dist/core.js and dist/node.js.
-  //
-  // Built separately (the previous setup), each entry inlined its own private
-  // copy of the registry Map. `registerCustomProviders()` from `librarium/node`
-  // then wrote to the node bundle's registry while `getProvider()`/`dispatch()`
-  // from `librarium/core` read the core bundle's separate registry, so the
-  // documented "import core for dispatch + node for custom providers" flow
-  // silently did nothing. Splitting within one build context fixes this because
-  // tsup/esbuild only shares modules that are reachable from multiple entries.
-  //
-  // Platform is `neutral`: core's reachable graph is edge-safe, and the
-  // Node-only code reachable only from `node-entry` (custom.ts -> child_process
-  // etc.) stays isolated in the node-specific chunk. Node built-ins resolve
-  // fine under the esm/node22.12 target. The shared chunk reachable from core must
-  // remain free of Node-only APIs -- the workers test guards this.
-  {
-    ...shared,
     entry: {
+      index: 'src/index.ts',
       core: 'src/core-entry.ts',
       node: 'src/node-entry.ts',
     },
+    // One neutral build context lets root/core/node share the exact same
+    // Worker-safe chunks. Node-only builtins remain external imports reachable
+    // exclusively from node.js; Node ESM accepts their bare specifiers. The
+    // packed metafile/chunk gate proves root and core cannot reach them.
     platform: 'neutral',
     splitting: true,
+    dts: true,
     clean: false,
+  },
+  {
+    ...shared,
+    entry: { cli: 'src/cli.ts' },
+    platform: 'node',
+    splitting: false,
+    dts: false,
+    clean: false,
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
   },
 ]);


### PR DESCRIPTION
## Summary

- make the root `librarium` import side-effect-free and Worker-safe
- replace broad `librarium/core` wildcard exports with an explicit planning, transport, coordination, and execution-port API
- narrow `librarium/node` to Node credentials and load-only trusted custom providers
- keep the CLI isolated behind the `librarium` executable and remove generated CLI declarations
- move the provider-attempt bridge into Worker-safe core and move run-directory creation into a Node-only module
- harden build cleanup, packed-package verification, declaration consumers, import side-effect checks, and Worker graph checks
- update the README, provider-development guide, and changelog to match the new boundary

## Breaking API boundary

The package root no longer executes the CLI when imported. Concrete adapters, the global registry, the legacy dispatcher, the file-writing runner, registration convenience, and raw keychain helpers are no longer public exports. A high-level v2 library runner is intentionally not exposed yet; complete configured runs continue through the CLI.

## Verification

- TypeScript typecheck
- Biome across 320 files
- 1,468 unit tests
- 24 Worker tests
- 11 integration tests
- packed tarball inventory, exact exports, declaration consumers, forbidden subpaths, import side effects, Worker dependency graph, and installed CLI checks
- independent package/API/security review consensus: GO

## Follow-ups

Versioned config migration, canonical CLI/MCP execution cutover, and durable artifact services remain separate reviewed changes.