### PR TITLE
feat(core): unify run artifact reconciliation

### DIFF
--- a/src/commands/browse-data.ts
+++ b/src/commands/browse-data.ts
@@ -1,7 +1,7 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import { isRunManifest } from '../core/run-manifest.js';
-import type { RunManifest } from '../types.js';
+import type { RunArtifactSnapshot } from '../node-run-artifact-codecs.js';
+import { presentationSourceSummary } from '../node-run-artifact-presentation.js';
+import { RunArtifactRepository } from '../node-run-artifacts.js';
+import type { ProviderReport, RunManifest } from '../types.js';
 
 /**
  * Pure(ish) helpers for `librarium browse`: run manifest discovery and
@@ -17,36 +17,68 @@ export interface RunEntry {
 export { isRunManifest } from '../core/run-manifest.js';
 
 /** Parse a single run directory; returns null when there is no valid run.json. */
-export function readRunEntry(dir: string): RunEntry | null {
-  const manifestPath = join(dir, 'run.json');
-  if (!existsSync(manifestPath)) return null;
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-    if (!isRunManifest(parsed)) return null;
-    return { dir, manifest: parsed };
-  } catch {
-    return null;
-  }
+export function readRunEntry(
+  dir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): RunEntry | null {
+  const manifest = repository.tryReadManifest(dir);
+  return manifest ? { dir, manifest } : null;
+}
+
+/** Read one selected run with non-mutating recovery projection for browsing. */
+export function readRunSnapshot(
+  dir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): RunArtifactSnapshot | null {
+  return repository.tryReadSnapshot(dir, { view: 'recovery' });
+}
+
+export interface BrowseProviderPresentation {
+  readonly report: Readonly<ProviderReport>;
+  readonly content?: string;
+}
+
+export interface BrowseRunPresentation {
+  readonly query: string;
+  readonly mode: RunManifest['mode'];
+  readonly providers: readonly BrowseProviderPresentation[];
+  readonly sources: { readonly total: number; readonly unique: number };
+}
+
+/** Project one immutable artifact snapshot into the browse view model. */
+export function shapeBrowseRunSnapshot(
+  snapshot: RunArtifactSnapshot,
+): BrowseRunPresentation {
+  const sources = presentationSourceSummary(snapshot);
+  return {
+    query: snapshot.manifest.query,
+    mode: snapshot.manifest.mode,
+    providers: snapshot.reports.map((report) => {
+      const artifact = Object.hasOwn(snapshot.providerArtifacts, report.id)
+        ? snapshot.providerArtifacts[report.id]
+        : undefined;
+      return {
+        report,
+        ...(artifact?.content === undefined
+          ? {}
+          : { content: artifact.content }),
+      };
+    }),
+    sources,
+  };
 }
 
 /**
  * Discover recent runs under the output base directory (newest first).
  */
-export function discoverRuns(baseDir: string, limit = 20): RunEntry[] {
-  if (!existsSync(baseDir)) return [];
-  const entries: RunEntry[] = [];
-  for (const name of readdirSync(baseDir)) {
-    const dir = join(baseDir, name);
-    try {
-      if (!statSync(dir).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-    const entry = readRunEntry(dir);
-    if (entry) entries.push(entry);
-  }
-  entries.sort((a, b) => b.manifest.timestamp - a.manifest.timestamp);
-  return entries.slice(0, limit);
+export function discoverRuns(
+  baseDir: string,
+  limit = 20,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): RunEntry[] {
+  return repository
+    .discoverRuns(baseDir, limit)
+    .map(({ runDir, manifest }) => ({ dir: runDir, manifest }));
 }
 
 /** Format a manifest timestamp (seconds) as a local date-time label. */

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -1,14 +1,17 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import * as p from '@clack/prompts';
 import type { Command } from 'commander';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
+import { RunArtifactRepository } from '../node-run-artifacts.js';
 import type { ProviderReport } from '../types.js';
 import {
+  type BrowseProviderPresentation,
   describeRun,
   discoverRuns,
   type RunEntry,
   readRunEntry,
+  readRunSnapshot,
+  shapeBrowseRunSnapshot,
 } from './browse-data.js';
 import { writeHtmlReport } from './html-report.js';
 import { writeJsonlReport } from './jsonl-report.js';
@@ -46,8 +49,11 @@ export function registerBrowseCommand(program: Command): void {
 }
 
 /** Top-level loop: pick a run, drill in, repeat until quit. */
-export async function browseRuns(baseDir: string): Promise<void> {
-  const runs = discoverRuns(baseDir);
+export async function browseRuns(
+  baseDir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): Promise<void> {
+  const runs = discoverRuns(baseDir, 20, repository);
   if (runs.length === 0) {
     console.log(`No runs found in ${baseDir}`);
     return;
@@ -66,25 +72,37 @@ export async function browseRuns(baseDir: string): Promise<void> {
       ],
     });
     if (p.isCancel(choice) || choice === 'quit') break;
-    const nav = await browseRun(choice);
+    const nav = await browseRun(choice, repository);
     if (nav === 'quit') break;
   }
   p.outro('done');
 }
 
 /** Browse a single run directory directly (used by the wizard post-run offer). */
-export async function browseRunDir(dir: string): Promise<void> {
-  const entry = readRunEntry(dir);
+export async function browseRunDir(
+  dir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): Promise<void> {
+  const entry = readRunEntry(dir, repository);
   if (!entry) {
     console.log(`No run manifest found in ${dir}`);
     return;
   }
-  await browseRun(entry);
+  await browseRun(entry, repository);
 }
 
 /** Run view: provider list rendered with the run table line format. */
-async function browseRun(entry: RunEntry): Promise<NavResult> {
-  const reports = entry.manifest.providers;
+async function browseRun(
+  entry: RunEntry,
+  repository: RunArtifactRepository,
+): Promise<NavResult> {
+  const snapshot = readRunSnapshot(entry.dir, repository);
+  if (!snapshot) {
+    p.log.warn(`Could not read run artifacts in ${entry.dir}`);
+    return 'back';
+  }
+  const presentation = shapeBrowseRunSnapshot(snapshot);
+  const reports = presentation.providers.map(({ report }) => report);
   const widths = computeLineWidths(
     reports.map((r) => r.id),
     reports.map((r) => r.tier),
@@ -99,7 +117,7 @@ async function browseRun(entry: RunEntry): Promise<NavResult> {
       | 'back'
       | 'quit';
     const choice = await p.select<Choice>({
-      message: entry.manifest.query,
+      message: snapshot.manifest.query,
       options: [
         ...reports.map((report) => ({
           value: report as Choice,
@@ -116,16 +134,21 @@ async function browseRun(entry: RunEntry): Promise<NavResult> {
     if (p.isCancel(choice) || choice === 'quit') return 'quit';
     if (choice === 'back') return 'back';
     if (choice === 'summary') {
-      const summaryPath = join(entry.dir, 'summary.md');
-      if (!existsSync(summaryPath)) {
-        p.log.warn(`File not found: ${summaryPath}`);
+      if (snapshot.summary === undefined) {
+        p.log.warn(
+          `File not found: ${repository.resolveContainedPath(snapshot.runDir, 'summary.md')}`,
+        );
         continue;
       }
-      await viewMarkdownInPager(summaryPath, 'summary.md');
+      await viewMarkdownInPager(
+        snapshot.summary,
+        'summary.md',
+        repository.resolveContainedPath(snapshot.runDir, 'summary.md'),
+      );
       continue;
     }
     if (choice === 'html') {
-      const reportPath = writeHtmlReport(entry.dir);
+      const reportPath = writeHtmlReport(entry.dir, repository);
       if (reportPath) {
         p.log.success(
           `Wrote ${hyperlink(reportPath, fileUrl(reportPath), isColorEnabled(process.stdout))}`,
@@ -141,7 +164,7 @@ async function browseRun(entry: RunEntry): Promise<NavResult> {
       continue;
     }
     if (choice === 'jsonl') {
-      const jsonlPath = writeJsonlReport(entry.dir);
+      const jsonlPath = writeJsonlReport(entry.dir, repository);
       if (jsonlPath) {
         p.log.success(
           `Wrote ${hyperlink(jsonlPath, fileUrl(jsonlPath), isColorEnabled(process.stdout))}`,
@@ -151,21 +174,24 @@ async function browseRun(entry: RunEntry): Promise<NavResult> {
       }
       continue;
     }
-    const nav = await providerView(entry, choice);
+    const provider = presentation.providers.find(
+      ({ report }) => report.id === choice.id,
+    );
+    if (!provider) continue;
+    const nav = await providerView(snapshot.runDir, provider, repository);
     if (nav === 'quit') return 'quit';
   }
 }
 
 /** Provider view: fullscreen pager over the ANSI-rendered markdown. */
 async function providerView(
-  entry: RunEntry,
-  report: ProviderReport,
+  runDir: string,
+  presentation: BrowseProviderPresentation,
+  repository: RunArtifactRepository,
 ): Promise<NavResult> {
-  const filePath = report.outputFile
-    ? join(entry.dir, report.outputFile)
-    : null;
+  const { report, content } = presentation;
 
-  if (!filePath || !existsSync(filePath)) {
+  if (content === undefined || !report.outputFile) {
     const note =
       report.status === 'async-pending'
         ? 'Result not retrieved yet: run `librarium status --wait` to poll and retrieve.'
@@ -174,7 +200,11 @@ async function providerView(
     return 'back';
   }
 
-  await viewMarkdownInPager(filePath, report.id);
+  await viewMarkdownInPager(
+    content,
+    report.id,
+    repository.resolveContainedPath(runDir, report.outputFile),
+  );
   return 'back';
 }
 
@@ -183,10 +213,10 @@ const MAX_READING_WIDTH = 100;
 
 /** Open a markdown file in the fullscreen pager (o opens the raw file in $PAGER). */
 async function viewMarkdownInPager(
-  filePath: string,
+  content: string,
   title: string,
+  filePath?: string,
 ): Promise<void> {
-  const content = readFileSync(filePath, 'utf-8');
   const color = isColorEnabled(process.stdout);
   await runPager({
     title,

--- a/src/commands/cleanup-data.ts
+++ b/src/commands/cleanup-data.ts
@@ -1,8 +1,7 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, parse, resolve, sep } from 'node:path';
-import type { RunManifest } from '../types.js';
-import { isRunManifest } from './browse-data.js';
+import { RunArtifactRepository } from '../node-run-artifacts.js';
 
 /**
  * Pure helpers for `librarium cleanup` / `librarium clear`: candidate
@@ -37,7 +36,7 @@ export function getDirSize(dirPath: string): number {
     for (const entry of readdirSync(dirPath)) {
       const fullPath = join(dirPath, entry);
       try {
-        const stat = statSync(fullPath);
+        const stat = lstatSync(fullPath);
         if (stat.isFile()) {
           size += stat.size;
         } else if (stat.isDirectory()) {
@@ -66,45 +65,32 @@ export function formatSize(bytes: number): string {
 /**
  * Detect whether the authoritative run manifest has pending/running tasks.
  */
-export function hasPendingAsync(dir: string): boolean {
+export function hasPendingAsync(
+  dir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): boolean {
   const manifestPath = join(dir, 'run.json');
-  if (existsSync(manifestPath)) {
-    try {
-      const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-      if (isRunManifest(parsed)) {
-        const manifest = parsed as RunManifest;
-        return (
-          manifest.status === 'awaiting_async' ||
-          manifest.providers.some(
-            (provider) =>
-              provider.task !== undefined &&
-              provider.task.retrievedAt === undefined &&
-              ['pending', 'running', 'completed'].includes(
-                provider.task.status,
-              ),
-          )
-        );
-      }
-    } catch {
-      // A corrupt authoritative manifest may contain the only remote handle.
-      return true;
-    }
-    // Unsupported/invalid manifests are conservatively protected.
-    return true;
-  }
-  return false;
+  if (!existsSync(manifestPath)) return false;
+  const manifest = repository.tryReadManifest(dir);
+  // A corrupt, unreadable, or unsupported authoritative manifest may contain
+  // the only remote handle, so never infer terminal state from recovered files.
+  if (!manifest) return true;
+  return (
+    manifest.status === 'awaiting_async' ||
+    manifest.providers.some(
+      (provider) =>
+        provider.task !== undefined &&
+        provider.task.retrievedAt === undefined &&
+        ['pending', 'running', 'completed'].includes(provider.task.status),
+    )
+  );
 }
 
-function readQuery(dir: string): string | null {
-  const manifestPath = join(dir, 'run.json');
-  if (!existsSync(manifestPath)) return null;
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-    if (isRunManifest(parsed)) return (parsed as RunManifest).query;
-  } catch {
-    // Ignore corrupt manifest.
-  }
-  return null;
+function readQuery(
+  dir: string,
+  repository: RunArtifactRepository,
+): string | null {
+  return repository.tryReadManifest(dir)?.query ?? null;
 }
 
 export interface DiscoverOptions {
@@ -124,8 +110,15 @@ export interface DiscoverOptions {
 export function discoverCandidates(
   baseDir: string,
   opts: DiscoverOptions = {},
+  repository: RunArtifactRepository = new RunArtifactRepository(),
 ): CleanupCandidate[] {
   if (!existsSync(baseDir)) return [];
+  try {
+    const baseStat = lstatSync(baseDir);
+    if (baseStat.isSymbolicLink() || !baseStat.isDirectory()) return [];
+  } catch {
+    return [];
+  }
   const now = opts.now ?? Date.now();
   const all = opts.all ?? false;
   const days = opts.days ?? 30;
@@ -134,9 +127,9 @@ export function discoverCandidates(
   const candidates: CleanupCandidate[] = [];
   for (const name of readdirSync(baseDir)) {
     const dir = join(baseDir, name);
-    let stat: ReturnType<typeof statSync>;
+    let stat: ReturnType<typeof lstatSync>;
     try {
-      stat = statSync(dir);
+      stat = lstatSync(dir);
     } catch {
       continue;
     }
@@ -154,8 +147,8 @@ export function discoverCandidates(
       timeMs,
       ageDays: Math.floor((now - timeMs) / (24 * 60 * 60 * 1000)),
       size: getDirSize(dir),
-      query: readQuery(dir),
-      pendingAsync: hasPendingAsync(dir),
+      query: readQuery(dir, repository),
+      pendingAsync: hasPendingAsync(dir, repository),
     });
   }
 
@@ -222,6 +215,13 @@ export function unsafeBaseDirReason(baseDir: string): string | null {
   if (normalized === resolve(homedir())) {
     return `Refusing to operate on the home directory (${resolved}).`;
   }
+  try {
+    if (lstatSync(resolved).isSymbolicLink()) {
+      return `Refusing to operate through a symbolic-link base directory (${resolved}).`;
+    }
+  } catch {
+    // A missing output directory has nothing to clean.
+  }
   return null;
 }
 
@@ -236,5 +236,20 @@ export function isInsideBaseDir(baseDir: string, candidate: string): boolean {
   const target = resolve(candidate);
   if (target === base) return false; // never delete the base dir itself
   const prefix = base.endsWith(sep) ? base : base + sep;
-  return target.startsWith(prefix);
+  if (!target.startsWith(prefix)) return false;
+
+  try {
+    const baseStat = lstatSync(base);
+    if (baseStat.isSymbolicLink() || !baseStat.isDirectory()) return false;
+    const targetStat = lstatSync(target);
+    if (targetStat.isSymbolicLink()) return false;
+    const realBase = realpathSync(base);
+    const realTarget = realpathSync(target);
+    const realPrefix = realBase.endsWith(sep) ? realBase : realBase + sep;
+    return realTarget !== realBase && realTarget.startsWith(realPrefix);
+  } catch {
+    // Preserve the pure lexical predicate for a not-yet-created descendant.
+    // Deletion candidates exist and therefore always take the realpath branch.
+    return true;
+  }
 }

--- a/src/commands/html-report.ts
+++ b/src/commands/html-report.ts
@@ -1,8 +1,11 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { Marked } from 'marked';
-import { sanitizeId } from '../constants.js';
 import { safeWriteFile } from '../core/fs-utils.js';
+import type { RunArtifactPresentationSourceSummary } from '../node-run-artifact-presentation.js';
+import { projectRunArtifactSnapshot } from '../node-run-artifact-presentation.js';
+import {
+  RunArtifactRepository,
+  type RunArtifactSnapshot,
+} from '../node-run-artifacts.js';
 import type {
   ClaimSupport,
   DeduplicatedSource,
@@ -13,8 +16,6 @@ import type {
   VerificationMetadata,
   VerificationUsageSummary,
 } from '../types.js';
-import { readAnswerArtifact } from './answer-synthesis.js';
-import { readRunEntry } from './browse-data.js';
 import { formatDuration, usageLabel } from './run-format.js';
 
 /**
@@ -27,10 +28,14 @@ import { formatDuration, usageLabel } from './run-format.js';
  */
 
 export interface HtmlReportInput {
-  manifest: RunManifest;
+  manifest: Readonly<RunManifest>;
+  /** Recovery-view reports used for presentation. Defaults to manifest providers. */
+  reports?: readonly Readonly<ProviderReport>[];
   /** Provider markdown contents keyed by report outputFile. */
-  providerContents: Record<string, string>;
-  sources: DeduplicatedSource[];
+  providerContents: Readonly<Record<string, string>>;
+  sources: readonly Readonly<DeduplicatedSource>[];
+  /** Counts aligned with the presented source rows. Defaults to manifest facts. */
+  sourceSummary?: RunArtifactPresentationSourceSummary;
   /**
    * The synthesized grounded answer (answer.md body) when the run produced one.
    * Leads the report as an "Answer" section before the provider tabs.
@@ -139,12 +144,10 @@ function formatReportDate(timestampSeconds: number): string {
   });
 }
 
-function talliesLine(manifest: RunManifest): string {
-  const ok = manifest.providers.filter((p) => p.status === 'success').length;
-  const failed = manifest.providers.filter((p) => p.status === 'error').length;
-  const pending = manifest.providers.filter(
-    (p) => p.status === 'async-pending',
-  ).length;
+function talliesLine(reports: readonly Readonly<ProviderReport>[]): string {
+  const ok = reports.filter((p) => p.status === 'success').length;
+  const failed = reports.filter((p) => p.status === 'error').length;
+  const pending = reports.filter((p) => p.status === 'async-pending').length;
   return `${ok} succeeded, ${failed} failed, ${pending} async pending`;
 }
 
@@ -449,7 +452,9 @@ ${followUps}
 </section>`;
 }
 
-function sourcesSection(sources: DeduplicatedSource[]): string {
+function sourcesSection(
+  sources: readonly Readonly<DeduplicatedSource>[],
+): string {
   if (sources.length === 0) {
     return '<p class="pending-note">No sources recorded.</p>';
   }
@@ -633,7 +638,11 @@ const SCRIPT = `(function () {
 /** Pure generator: manifest plus file contents in, full HTML document out. */
 export function generateHtmlReport(input: HtmlReportInput): string {
   const { manifest, providerContents, sources, answer } = input;
-  const reports = manifest.providers;
+  const reports = input.reports ?? manifest.providers;
+  const sourceSummary = input.sourceSummary ?? {
+    total: manifest.sources.total,
+    unique: sources.length,
+  };
 
   const answerHtml =
     answer && answer.content.trim().length > 0 ? answerSection(answer) : '';
@@ -662,7 +671,9 @@ export function generateHtmlReport(input: HtmlReportInput): string {
       const hidden = index === activeIndex ? '' : ' hidden';
       const body = providerPanelBody(
         report,
-        report.outputFile ? providerContents[report.outputFile] : undefined,
+        report.outputFile && Object.hasOwn(providerContents, report.outputFile)
+          ? providerContents[report.outputFile]
+          : undefined,
       );
       return `<div class="panel" role="tabpanel" id="panel-${index}" aria-labelledby="tab-${index}"${hidden}>${body}</div>`;
     })
@@ -690,7 +701,7 @@ ${sourcesSection(sources)}
 <main>
 <p class="eyebrow">query</p>
 <h1>${escapeHtml(manifest.query)}</h1>
-<p class="meta">${escapeHtml(formatReportDate(manifest.timestamp))} &middot; mode ${escapeHtml(manifest.mode)} &middot; ${escapeHtml(talliesLine(manifest))} &middot; ${sources.length} unique sources after dedupe (${manifest.sources.total} total citations)</p>
+<p class="meta">${escapeHtml(formatReportDate(manifest.timestamp))} &middot; mode ${escapeHtml(manifest.mode)} &middot; ${escapeHtml(talliesLine(reports))} &middot; ${sourceSummary.unique} unique sources after dedupe (${sourceSummary.total} total citations)</p>
 ${answerHtml}
 ${verificationHtml}
 <section>
@@ -712,85 +723,34 @@ ${sourcesPanel}
 }
 
 /**
- * Async-pending reports whose results have since been retrieved (via
- * `status --wait`/`--retrieve`) have their .md and .meta.json on disk but
- * run.json still says pending. Overlay those so regenerated reports fill in.
+ * Write report.html from one immutable repository snapshot.
  */
-export function enrichRetrievedReports(
-  runDir: string,
-  reports: ProviderReport[],
-): ProviderReport[] {
-  return reports.map((report) => {
-    if (report.status !== 'async-pending') return report;
-    const safeId = sanitizeId(report.id);
-    const outputFile = `${safeId}.md`;
-    if (!existsSync(join(runDir, outputFile))) return report;
-    let durationMs = 0;
-    let citationCount = 0;
-    try {
-      const meta = JSON.parse(
-        readFileSync(join(runDir, `${safeId}.meta.json`), 'utf-8'),
-      ) as { durationMs?: number; citationCount?: number };
-      durationMs = meta.durationMs ?? 0;
-      citationCount = meta.citationCount ?? 0;
-    } catch {
-      // Meta is optional; the content alone is enough to render.
-    }
-    return {
-      ...report,
-      status: 'success' as const,
-      outputFile,
-      metaFile: `${safeId}.meta.json`,
-      durationMs,
-      citationCount,
-    };
-  });
+export function writeHtmlReportFromSnapshot(
+  snapshot: RunArtifactSnapshot,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): string {
+  const html = generateHtmlReport(projectRunArtifactSnapshot(snapshot));
+  const reportPath = repository.resolveContainedPath(
+    snapshot.runDir,
+    'report.html',
+  );
+  safeWriteFile(reportPath, html);
+  return reportPath;
 }
 
 /**
  * Build and write report.html for an existing run directory.
  * Returns the report path, or null when the directory has no run manifest.
  */
-export function writeHtmlReport(runDir: string): string | null {
-  const entry = readRunEntry(runDir);
-  if (!entry) return null;
-  entry.manifest.providers = enrichRetrievedReports(
-    runDir,
-    entry.manifest.providers,
-  );
-
-  const providerContents: Record<string, string> = {};
-  for (const report of entry.manifest.providers) {
-    if (!report.outputFile) continue;
-    const filePath = join(runDir, report.outputFile);
-    if (!existsSync(filePath)) continue;
-    try {
-      providerContents[report.outputFile] = readFileSync(filePath, 'utf-8');
-    } catch {
-      // Missing/unreadable provider files render as a note instead.
-    }
+export function writeHtmlReport(
+  runDir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): string | null {
+  let snapshot: RunArtifactSnapshot;
+  try {
+    snapshot = repository.readSnapshot(runDir, { view: 'recovery' });
+  } catch {
+    return null;
   }
-
-  let sources: DeduplicatedSource[] = [];
-  const sourcesPath = join(runDir, 'sources.json');
-  if (existsSync(sourcesPath)) {
-    try {
-      const parsed: unknown = JSON.parse(readFileSync(sourcesPath, 'utf-8'));
-      if (Array.isArray(parsed)) sources = parsed as DeduplicatedSource[];
-    } catch {
-      // Corrupt sources.json degrades to an empty sources section.
-    }
-  }
-
-  const answer = readAnswerArtifact(runDir, entry.manifest);
-
-  const html = generateHtmlReport({
-    manifest: entry.manifest,
-    providerContents,
-    sources,
-    ...(answer ? { answer } : {}),
-  });
-  const reportPath = join(runDir, 'report.html');
-  safeWriteFile(reportPath, html);
-  return reportPath;
+  return writeHtmlReportFromSnapshot(snapshot, repository);
 }

--- a/src/commands/jsonl-report.ts
+++ b/src/commands/jsonl-report.ts
@@ -1,14 +1,16 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { safeWriteFile } from '../core/fs-utils.js';
+import type { RunArtifactPresentationSourceSummary } from '../node-run-artifact-presentation.js';
+import { projectRunArtifactSnapshot } from '../node-run-artifact-presentation.js';
+import {
+  RunArtifactRepository,
+  type RunArtifactSnapshot,
+} from '../node-run-artifacts.js';
 import type {
   DeduplicatedSource,
+  ProviderReport,
   RunManifest,
   VerificationMetadata,
 } from '../types.js';
-import { readAnswerArtifact } from './answer-synthesis.js';
-import { readRunEntry } from './browse-data.js';
-import { enrichRetrievedReports } from './html-report.js';
 
 /**
  * Self-contained JSONL report generator for a run directory.
@@ -20,10 +22,14 @@ import { enrichRetrievedReports } from './html-report.js';
  */
 
 export interface JsonlReportInput {
-  manifest: RunManifest;
+  manifest: Readonly<RunManifest>;
+  /** Recovery-view reports used for presentation. Defaults to manifest providers. */
+  reports?: readonly Readonly<ProviderReport>[];
   /** Provider markdown contents keyed by report outputFile. */
-  providerContents: Record<string, string>;
-  sources: DeduplicatedSource[];
+  providerContents: Readonly<Record<string, string>>;
+  sources: readonly Readonly<DeduplicatedSource>[];
+  /** Counts aligned with the presented source rows. Defaults to manifest facts. */
+  sourceSummary?: RunArtifactPresentationSourceSummary;
   /**
    * The synthesized grounded answer (answer.md body) when the run produced one.
    * provider/model come from the manifest's additive `answer` metadata.
@@ -103,7 +109,8 @@ function serializeLine(
 /** Pure generator: manifest plus file contents in, full JSONL string out. */
 export function generateJsonlReport(input: JsonlReportInput): string {
   const { manifest, providerContents, sources, answer } = input;
-  const reports = manifest.providers;
+  const reports = input.reports ?? manifest.providers;
+  const sourceSummary = input.sourceSummary ?? manifest.sources;
 
   const succeeded = reports.filter((r) => r.status === 'success').length;
   const failed = reports.filter((r) => r.status === 'error').length;
@@ -119,8 +126,8 @@ export function generateJsonlReport(input: JsonlReportInput): string {
     succeeded,
     failed,
     pending,
-    uniqueSources: manifest.sources.unique,
-    totalCitations: manifest.sources.total,
+    uniqueSources: sourceSummary.unique,
+    totalCitations: sourceSummary.total,
     ...(manifest.refinedQueries !== undefined
       ? { refinedQueries: manifest.refinedQueries }
       : {}),
@@ -143,7 +150,7 @@ export function generateJsonlReport(input: JsonlReportInput): string {
 
   const resultLines: ResultLine[] = reports.map((report) => {
     const content =
-      report.outputFile && providerContents[report.outputFile] !== undefined
+      report.outputFile && Object.hasOwn(providerContents, report.outputFile)
         ? providerContents[report.outputFile]
         : null;
 
@@ -190,49 +197,34 @@ export function generateJsonlReport(input: JsonlReportInput): string {
 }
 
 /**
+ * Write results.jsonl from one immutable repository snapshot.
+ */
+export function writeJsonlReportFromSnapshot(
+  snapshot: RunArtifactSnapshot,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): string {
+  const jsonl = generateJsonlReport(projectRunArtifactSnapshot(snapshot));
+  const reportPath = repository.resolveContainedPath(
+    snapshot.runDir,
+    'results.jsonl',
+  );
+  safeWriteFile(reportPath, jsonl);
+  return reportPath;
+}
+
+/**
  * Build and write results.jsonl for an existing run directory.
  * Returns the report path, or null when the directory has no run manifest.
  */
-export function writeJsonlReport(runDir: string): string | null {
-  const entry = readRunEntry(runDir);
-  if (!entry) return null;
-  entry.manifest.providers = enrichRetrievedReports(
-    runDir,
-    entry.manifest.providers,
-  );
-
-  const providerContents: Record<string, string> = {};
-  for (const report of entry.manifest.providers) {
-    if (!report.outputFile) continue;
-    const filePath = join(runDir, report.outputFile);
-    if (!existsSync(filePath)) continue;
-    try {
-      providerContents[report.outputFile] = readFileSync(filePath, 'utf-8');
-    } catch {
-      // Missing/unreadable provider files render as null content instead.
-    }
+export function writeJsonlReport(
+  runDir: string,
+  repository: RunArtifactRepository = new RunArtifactRepository(),
+): string | null {
+  let snapshot: RunArtifactSnapshot;
+  try {
+    snapshot = repository.readSnapshot(runDir, { view: 'recovery' });
+  } catch {
+    return null;
   }
-
-  let sources: DeduplicatedSource[] = [];
-  const sourcesPath = join(runDir, 'sources.json');
-  if (existsSync(sourcesPath)) {
-    try {
-      const parsed: unknown = JSON.parse(readFileSync(sourcesPath, 'utf-8'));
-      if (Array.isArray(parsed)) sources = parsed as DeduplicatedSource[];
-    } catch {
-      // Corrupt sources.json degrades to an empty sources section.
-    }
-  }
-
-  const answer = readAnswerArtifact(runDir, entry.manifest);
-
-  const jsonl = generateJsonlReport({
-    manifest: entry.manifest,
-    providerContents,
-    sources,
-    ...(answer ? { answer } : {}),
-  });
-  const reportPath = join(runDir, 'results.jsonl');
-  safeWriteFile(reportPath, jsonl);
-  return reportPath;
+  return writeJsonlReportFromSnapshot(snapshot, repository);
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,45 +1,41 @@
-import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import type { Command } from 'commander';
 import ora from 'ora';
-import {
-  getExactProvider,
-  getProvider,
-  initializeProviders,
-} from '../adapters/node-registry.js';
-import { sanitizeId } from '../constants.js';
-import {
-  asyncPollFailureUpdates,
-  asyncPollUpdates,
-  getPendingTasks,
-  loadAsyncTasks,
-  updateAsyncTask,
-} from '../core/async-manager.js';
+import { initializeProviders } from '../adapters/node-registry.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
-import { normalizeUsage } from '../core/dispatcher.js';
-import { safeWriteFile } from '../core/fs-utils.js';
-import { buildProviderMetering } from '../core/metering.js';
-import { updateRunManifestAfterRetrieve } from '../core/retrieval-manifest.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
-import type {
-  AsyncTaskHandle,
-  ProviderConfig,
-  ProviderReport,
-} from '../types.js';
-import { writeHtmlReport } from './html-report.js';
-import { writeJsonlReport } from './jsonl-report.js';
+import {
+  createNodeRunReconciliationRuntime,
+  type NodeRunReconciliationRuntime,
+  type ReconciliationResult,
+} from '../node-run-reconciliation-runtime.js';
+import type { AsyncTaskHandle, Config, ProviderReport } from '../types.js';
 import {
   computeLineWidths,
   dimText,
-  fileUrl,
   formatProviderLine,
-  hyperlink,
   isColorEnabled,
-  type LineWidths,
 } from './run-format.js';
 
+const RECONCILIATION_FAILED = 'artifact.reconciliation_failed';
+const REGENERATION_FAILED = 'artifact.regeneration_failed';
+
+interface ReconciledRun {
+  readonly runDir: string;
+  readonly result?: ReconciliationResult;
+  readonly error?: typeof RECONCILIATION_FAILED;
+  readonly refreshed: readonly string[];
+}
+
+interface ReconcileRunsResult {
+  readonly runs: readonly ReconciledRun[];
+  readonly polled: number;
+  readonly retrieved: number;
+  readonly errors: readonly (typeof RECONCILIATION_FAILED)[];
+  readonly regenerationErrors: readonly (typeof REGENERATION_FAILED)[];
+}
+
 function formatTaskAge(submittedAt: number): string {
-  // submittedAt is in milliseconds
   const ageMs = Date.now() - submittedAt;
   const ageMin = Math.floor(ageMs / 60000);
   if (ageMin < 1) return 'just now';
@@ -55,191 +51,198 @@ function formatTaskStatus(task: AsyncTaskHandle): string {
   return `  ${task.provider} | Task: ${task.taskId.slice(0, 20)}... | Status: ${task.status}${remote}${error} | Submitted: ${formatTaskAge(task.submittedAt)}`;
 }
 
-/** Column widths across a set of async tasks so result lines align. */
-function widthsForTasks(tasks: AsyncTaskHandle[]): LineWidths {
-  return computeLineWidths(
-    tasks.map((task) => task.provider),
-    tasks.map((task) => getProvider(task.provider)?.tier ?? 'deep-research'),
+function persistedTasks(
+  runtime: NodeRunReconciliationRuntime,
+  runDirs: readonly string[],
+): AsyncTaskHandle[] {
+  const tasks: AsyncTaskHandle[] = [];
+  for (const runDir of runDirs) {
+    const snapshot = runtime.repository.tryReadSnapshot(runDir, {
+      view: 'authoritative',
+    });
+    if (!snapshot) continue;
+    for (const report of snapshot.manifest.providers) {
+      const task = report.task;
+      if (!task || task.retrievedAt !== undefined) continue;
+      tasks.push({
+        provider: report.id,
+        taskId: task.taskId,
+        query: snapshot.manifest.query,
+        submittedAt: task.submittedAt,
+        status: task.status,
+        outputDir: snapshot.runDir,
+        ...(task.lastPolledAt === undefined
+          ? {}
+          : { lastPolledAt: task.lastPolledAt }),
+        ...(task.completedAt === undefined
+          ? {}
+          : { completedAt: task.completedAt }),
+        ...(task.providerStatus === undefined
+          ? {}
+          : { providerStatus: task.providerStatus }),
+        ...(task.lastPollError === undefined
+          ? {}
+          : { lastPollError: task.lastPollError }),
+      });
+    }
+  }
+  return tasks;
+}
+
+async function reconcileRuns(
+  runtime: NodeRunReconciliationRuntime,
+  runDirs: readonly string[],
+  retrieve: boolean,
+): Promise<ReconcileRunsResult> {
+  const runs: ReconciledRun[] = [];
+  const errors: (typeof RECONCILIATION_FAILED)[] = [];
+  const regenerationErrors: (typeof REGENERATION_FAILED)[] = [];
+  let polled = 0;
+  let retrieved = 0;
+
+  for (const runDir of runDirs) {
+    try {
+      const refreshed = ['summary.md', 'report.html', 'results.jsonl'].filter(
+        (fileName) => runtime.repository.hasArtifact(runDir, fileName),
+      );
+      const result = await runtime.service.reconcileOnce(runDir, { retrieve });
+      polled += result.polled;
+      retrieved += result.retrieved;
+      if (result.regenerationError !== undefined)
+        regenerationErrors.push(REGENERATION_FAILED);
+      runs.push({ runDir, result, refreshed });
+    } catch {
+      errors.push(RECONCILIATION_FAILED);
+      runs.push({
+        runDir,
+        error: RECONCILIATION_FAILED,
+        refreshed: [],
+      });
+    }
+  }
+  return { runs, polled, retrieved, errors, regenerationErrors };
+}
+
+/** Compatibility shim; lifecycle work remains in the reconciliation service. */
+export async function reconcilePendingTasksOnce(
+  tasks: AsyncTaskHandle[],
+  config: Config,
+): Promise<void> {
+  const runtime = createNodeRunReconciliationRuntime(config);
+  const runDirs = [
+    ...new Set(
+      tasks
+        .map((task) => task.outputDir)
+        .filter((runDir): runDir is string => Boolean(runDir)),
+    ),
+  ];
+  await reconcileRuns(runtime, runDirs, false);
+}
+
+function printTasks(
+  tasks: AsyncTaskHandle[],
+  print: (line: string) => void,
+): void {
+  const pending = tasks.filter(
+    (task) => task.status === 'pending' || task.status === 'running',
+  );
+  const completed = tasks.filter((task) => task.status === 'completed');
+  const terminal = tasks.filter(
+    (task) => task.status === 'failed' || task.status === 'cancelled',
+  );
+  if (pending.length > 0) {
+    print(`\nPending async tasks (${pending.length}):\n`);
+    for (const task of pending) print(formatTaskStatus(task));
+  }
+  if (completed.length > 0) {
+    print(`\nCompleted (awaiting retrieval): ${completed.length}\n`);
+    for (const task of completed) print(formatTaskStatus(task));
+  }
+  if (terminal.length > 0) {
+    print(`\nTerminal async tasks (${terminal.length}):\n`);
+    for (const task of terminal) print(formatTaskStatus(task));
+  }
+  print(
+    '\nUse --wait to poll and auto-retrieve, --retrieve to fetch completed results.',
   );
 }
 
-async function retrieveTask(
-  task: AsyncTaskHandle,
-  dir: string,
-  spinner: ReturnType<typeof ora>,
-  widths: LineWidths,
-  color: boolean,
+function printRetrieved(
+  runtime: NodeRunReconciliationRuntime,
+  pass: ReconcileRunsResult,
+  rendered: Set<string>,
   print: (line: string) => void,
-  providerConfig?: ProviderConfig,
-): Promise<boolean> {
-  const provider = getExactProvider(task.provider);
-  if (provider?.execution !== 'background') {
-    spinner.text = `Provider ${task.provider} does not support retrieval`;
-    return false;
-  }
-
-  try {
-    spinner.text = `Retrieving ${task.provider}...`;
-    const result = await provider.retrieve(task);
-
-    if (result.error) {
-      // Retrieval failed (transport error, parse failure, provider error):
-      // keep the task on disk so a later --retrieve can try again, and do not
-      // write empty output files over nothing.
-      const failureReport: ProviderReport = {
-        id: task.provider,
-        tier: result.tier,
-        status: 'error',
-        durationMs: result.durationMs,
-        wordCount: 0,
-        citationCount: 0,
-        outputFile: '',
-        metaFile: '',
-        metering: buildProviderMetering(task.provider),
-        error: result.error,
-      };
-      const wasSpinning = spinner.isSpinning;
-      if (wasSpinning) spinner.stop();
-      print(formatProviderLine(failureReport, widths, color));
-      if (wasSpinning) spinner.start();
-      spinner.text = `Retrieval failed for ${task.provider}: ${result.error}`;
-      return false;
+  color: boolean,
+): void {
+  for (const run of pass.runs) {
+    const result = run.result;
+    if (!result) continue;
+    const snapshot = runtime.repository.tryReadSnapshot(run.runDir, {
+      view: 'authoritative',
+    });
+    if (!snapshot) continue;
+    const reports: ProviderReport[] = [];
+    for (const task of result.tasks) {
+      if (!task.retrievedThisPass) continue;
+      const key = `${run.runDir}\0${task.provider}\0${task.taskId}`;
+      if (rendered.has(key)) continue;
+      const report = snapshot.manifest.providers.find(
+        (candidate) =>
+          candidate.id === task.provider &&
+          candidate.task?.taskId === task.taskId,
+      );
+      if (!report) continue;
+      rendered.add(key);
+      reports.push(report);
     }
-
-    const safeId = sanitizeId(task.provider);
-    const outputFile = `${safeId}.md`;
-    const metaFile = `${safeId}.meta.json`;
-    const usage = normalizeUsage(result);
-    // Same metering normalization path as sync dispatch, so retrieved
-    // async deep-research results carry metering (and provider_reported cost)
-    // just like their sync counterparts, including any configured pricing.
-    const metering = buildProviderMetering(
-      task.provider,
-      providerConfig,
-      usage,
+    const widths = computeLineWidths(
+      reports.map((report) => report.id),
+      reports.map((report) => report.tier),
     );
-
-    safeWriteFile(join(dir, outputFile), result.content);
-    safeWriteFile(
-      join(dir, metaFile),
-      JSON.stringify(
-        {
-          provider: result.provider,
-          tier: result.tier,
-          model: result.model,
-          durationMs: result.durationMs,
-          citationCount: result.citations.length,
-          tokenUsage: result.tokenUsage,
-          usage,
-          metering,
-          citations: result.citations,
-        },
-        null,
-        2,
-      ),
-    );
-
-    const words = result.content.split(/\s+/).filter(Boolean).length;
-    const cites = result.citations.length;
-
-    const report: ProviderReport = {
-      id: task.provider,
-      tier: result.tier,
-      status: 'success',
-      durationMs: result.durationMs,
-      wordCount: words,
-      citationCount: cites,
-      outputFile,
-      metaFile,
-      usage,
-      metering,
-    };
-
-    // Fold the retrieved result back into run.json and sources.json so JSON
-    // consumers, browse tallies, and regenerated reports see the final state.
-    if (!updateRunManifestAfterRetrieve(dir, report, task.taskId)) {
-      spinner.text = `Retrieved ${task.provider}, but could not update run.json; task kept for retry`;
-      return false;
-    }
-
-    // If an HTML report was already generated for this run, regenerate it so
-    // the retrieved result fills in.
-    const reportPath = join(dir, 'report.html');
-    if (existsSync(reportPath)) {
-      writeHtmlReport(dir);
+    for (const report of reports) {
       print(
-        `  regenerated ${hyperlink(reportPath, fileUrl(reportPath), color)}`,
+        `${formatProviderLine(report, widths, color)}   ${dimText(
+          `${report.outputFile}, ${report.wordCount} words`,
+          color,
+        )}`,
       );
     }
-
-    // If a JSONL report was already generated for this run, regenerate it so
-    // the retrieved result fills in.
-    const jsonlPath = join(dir, 'results.jsonl');
-    if (existsSync(jsonlPath)) {
-      writeJsonlReport(dir);
-      print(`  regenerated ${hyperlink(jsonlPath, fileUrl(jsonlPath), color)}`);
+    if (result.regenerated) {
+      for (const fileName of run.refreshed) print(`  regenerated ${fileName}`);
     }
-
-    spinner.text = `Retrieved ${task.provider} -> ${outputFile}`;
-
-    // Render the retrieved result with the same table line as `librarium run`,
-    // with the retrieval details as a dim suffix.
-    const wasSpinning = spinner.isSpinning;
-    if (wasSpinning) spinner.stop();
-    print(
-      `${formatProviderLine(report, widths, color)}   ${dimText(
-        `${outputFile}, ${words} words`,
-        color,
-      )}`,
-    );
-    if (wasSpinning) spinner.start();
-    return true;
-  } catch (e) {
-    spinner.text = `Error retrieving ${task.provider}: ${e instanceof Error ? e.message : String(e)}`;
-    return false;
   }
 }
 
-/** Reconcile each active task once without waiting or retrieving. */
-export async function reconcilePendingTasksOnce(
+function reportWarnings(pass: ReconcileRunsResult): boolean {
+  for (const error of pass.errors)
+    process.stderr.write(`[librarium] warning: ${error}\n`);
+  for (const error of pass.regenerationErrors)
+    process.stderr.write(`[librarium] warning: ${error}\n`);
+  return pass.errors.length > 0 || pass.regenerationErrors.length > 0;
+}
+
+/** Keep terminal output and warnings from corrupting an active ora frame. */
+function withSpinnerStopped(
+  spinner: ReturnType<typeof ora>,
+  action: () => void,
+  restart: boolean,
+): void {
+  const wasSpinning = spinner.isSpinning;
+  if (wasSpinning) spinner.stop();
+  action();
+  if (wasSpinning && restart) spinner.start();
+}
+
+function jsonPayload(
   tasks: AsyncTaskHandle[],
-): Promise<void> {
-  for (const task of tasks) {
-    const provider = getExactProvider(task.provider);
-    if (provider?.execution !== 'background' || !task.outputDir) {
-      if (task.outputDir) {
-        updateAsyncTask(
-          task.outputDir,
-          task.provider,
-          task.taskId,
-          asyncPollUpdates({
-            status: 'failed',
-            rawStatus: 'unsupported_provider',
-            message: `Provider ${task.provider} does not support polling after this upgrade`,
-          }),
-        );
-      }
-      continue;
-    }
-    try {
-      const result = await provider.poll(task);
-      updateAsyncTask(
-        task.outputDir,
-        task.provider,
-        task.taskId,
-        asyncPollUpdates(result),
-      );
-    } catch (error) {
-      updateAsyncTask(
-        task.outputDir,
-        task.provider,
-        task.taskId,
-        asyncPollFailureUpdates(
-          error instanceof Error ? error.message : String(error),
-        ),
-      );
-    }
-  }
+  errors: readonly (typeof RECONCILIATION_FAILED)[],
+  regenerationErrors: readonly (typeof REGENERATION_FAILED)[],
+): Record<string, unknown> {
+  return {
+    tasks,
+    ...(errors.length === 0 ? {} : { errors }),
+    ...(regenerationErrors.length === 0 ? {} : { regenerationErrors }),
+  };
 }
 
 export function registerStatusCommand(program: Command): void {
@@ -251,328 +254,143 @@ export function registerStatusCommand(program: Command): void {
     .option('--json', 'Output JSON')
     .action(async (opts) => {
       try {
-        const globalConfig = loadConfig();
-        const projectConfig = loadProjectConfig(process.cwd());
-        const config = mergeConfigs(globalConfig, projectConfig);
+        const config = mergeConfigs(
+          loadConfig(),
+          loadProjectConfig(process.cwd()),
+        );
         const credentials = createNodeCredentialContext();
-        const initResult = await initializeProviders({
+        const initialized = await initializeProviders({
           ...config,
           credentials,
         });
-        for (const warning of initResult.warnings) {
-          console.error(`[librarium] warning: ${warning}`);
-        }
+        for (const warning of initialized.warnings)
+          process.stderr.write(`[librarium] warning: ${warning}\n`);
+
+        const runtime = createNodeRunReconciliationRuntime(config);
         const baseDir = resolve(config.defaults.outputDir);
-        // In --json mode stdout must stay pure JSON, so all table/progress
-        // lines are routed to stderr (where the ora spinner already lives).
-        const prettyStream = opts.json ? process.stderr : process.stdout;
-        const color = isColorEnabled(prettyStream);
-        const pretty = (line: string): void => {
-          prettyStream.write(`${line}\n`);
-        };
-
-        // Gather all async tasks (pending + completed unretrieved)
-        const pendingTasks = getPendingTasks(baseDir);
-        const terminalTasks = getTerminalTasks(baseDir);
-        let allTasks = [...pendingTasks, ...terminalTasks];
-
-        if (allTasks.length === 0) {
-          if (opts.json) {
+        const runDirs = runtime.repository
+          .discoverRuns(baseDir, Number.MAX_SAFE_INTEGER)
+          .map((run) => run.runDir);
+        let tasks = persistedTasks(runtime, runDirs);
+        if (tasks.length === 0) {
+          if (opts.json)
             console.log(
               JSON.stringify({ tasks: [], message: 'No async tasks' }),
             );
-          } else {
-            console.log('No async tasks.');
-          }
+          else console.log('No async tasks.');
           return;
         }
 
-        if (!opts.wait) {
-          // Plain status and standalone --retrieve both reconcile once first.
-          await reconcilePendingTasksOnce(pendingTasks);
+        const prettyStream = opts.json ? process.stderr : process.stdout;
+        const print = (line: string): void => {
+          prettyStream.write(`${line}\n`);
+        };
+        const color = isColorEnabled(prettyStream);
+        const rendered = new Set<string>();
+        const errors: (typeof RECONCILIATION_FAILED)[] = [];
+        const regenerationErrors: (typeof REGENERATION_FAILED)[] = [];
+        const record = (pass: ReconcileRunsResult): void => {
+          errors.push(...pass.errors);
+          regenerationErrors.push(...pass.regenerationErrors);
+          if (!opts.json) {
+            printRetrieved(runtime, pass, rendered, print, color);
+            reportWarnings(pass);
+          }
+        };
 
-          if (opts.retrieve) {
-            // Retrieval below rescans persisted state and picks up tasks that
-            // completed during this single reconciliation pass.
-          } else {
-            const refreshedPending = getPendingTasks(baseDir);
-            const refreshedTerminal = getTerminalTasks(baseDir);
-            allTasks = [...refreshedPending, ...refreshedTerminal];
-            if (opts.json) {
-              console.log(JSON.stringify({ tasks: allTasks }, null, 2));
-              return;
-            }
-            if (refreshedPending.length > 0) {
-              console.log(
-                `\nPending async tasks (${refreshedPending.length}):\n`,
+        if (opts.wait) {
+          const spinner = ora(`Polling ${tasks.length} async tasks...`).start();
+          let totalRetrieved = 0;
+          let remaining = true;
+          try {
+            while (remaining) {
+              const pass = await reconcileRuns(runtime, runDirs, true);
+              totalRetrieved += pass.retrieved;
+              withSpinnerStopped(spinner, () => record(pass), true);
+              tasks = persistedTasks(runtime, runDirs);
+              const failedRuns = new Set(
+                pass.runs
+                  .filter((run) => run.error !== undefined)
+                  .map((run) => run.runDir),
               );
-              for (const task of refreshedPending) {
-                console.log(formatTaskStatus(task));
+              remaining = tasks.some(
+                (task) =>
+                  !failedRuns.has(task.outputDir ?? '') &&
+                  (task.status === 'pending' || task.status === 'running'),
+              );
+              if (remaining) {
+                spinner.text = `Polling ${tasks.filter((task) => task.status === 'pending' || task.status === 'running').length} async tasks...`;
+                await new Promise<void>((done) =>
+                  setTimeout(done, config.defaults.asyncPollInterval * 1000),
+                );
               }
             }
-            const refreshedCompleted = refreshedTerminal.filter(
-              (task) => task.status === 'completed',
-            );
-            if (refreshedCompleted.length > 0) {
-              console.log(
-                `\nCompleted (awaiting retrieval): ${refreshedCompleted.length}\n`,
+            if (errors.length > 0 || regenerationErrors.length > 0) {
+              spinner.warn('Async reconciliation finished with errors.');
+            } else {
+              spinner.succeed(
+                totalRetrieved > 0
+                  ? `All async tasks completed; retrieved ${totalRetrieved} results.`
+                  : 'All async tasks completed.',
               );
-              for (const task of refreshedCompleted) {
-                console.log(formatTaskStatus(task));
-              }
             }
-            const failedOrCancelled = refreshedTerminal.filter(
-              (task) => task.status === 'failed' || task.status === 'cancelled',
-            );
-            if (failedOrCancelled.length > 0) {
-              console.log(
-                `\nTerminal async tasks (${failedOrCancelled.length}):\n`,
+          } finally {
+            if (spinner.isSpinning) spinner.stop();
+          }
+        } else if (opts.retrieve) {
+          const spinner = ora(
+            'Reconciling and retrieving async tasks...',
+          ).start();
+          try {
+            const pass = await reconcileRuns(runtime, runDirs, true);
+            withSpinnerStopped(spinner, () => record(pass), false);
+            tasks = persistedTasks(runtime, runDirs);
+            if (pass.errors.length > 0 || pass.regenerationErrors.length > 0) {
+              spinner.warn('Async reconciliation finished with errors.');
+            } else {
+              spinner.succeed(
+                pass.retrieved > 0
+                  ? `Retrieved ${pass.retrieved} results.`
+                  : 'No completed tasks to retrieve.',
               );
-              for (const task of failedOrCancelled)
-                console.log(formatTaskStatus(task));
             }
+          } finally {
+            if (spinner.isSpinning) spinner.stop();
+          }
+        } else {
+          const pass = await reconcileRuns(runtime, runDirs, false);
+          record(pass);
+          tasks = persistedTasks(runtime, runDirs);
+          if (errors.length > 0 || regenerationErrors.length > 0)
+            process.exitCode = 1;
+          if (opts.json) {
             console.log(
-              '\nUse --wait to poll and auto-retrieve, --retrieve to fetch completed results.',
+              JSON.stringify(
+                jsonPayload(tasks, errors, regenerationErrors),
+                null,
+                2,
+              ),
             );
             return;
           }
+          printTasks(tasks, print);
+          return;
         }
 
-        // Wait mode: poll until done, then auto-retrieve
-        if (opts.wait) {
-          const spinner = ora(
-            `Polling ${pendingTasks.length} async tasks...`,
-          ).start();
-          const pollInterval = config.defaults.asyncPollInterval * 1000;
-          let remaining = [...pendingTasks];
-          const justCompleted: Array<{
-            task: AsyncTaskHandle;
-            dir: string;
-          }> = terminalTasks
-            .filter(
-              (task): task is AsyncTaskHandle & { outputDir: string } =>
-                task.status === 'completed' && Boolean(task.outputDir),
-            )
-            .map((task) => ({ task, dir: task.outputDir }));
-          const completedTaskKeys = new Set(
-            justCompleted.map(
-              ({ task, dir }) => `${dir}\0${task.provider}\0${task.taskId}`,
+        if (errors.length > 0 || regenerationErrors.length > 0)
+          process.exitCode = 1;
+        if (opts.json)
+          console.log(
+            JSON.stringify(
+              jsonPayload(tasks, errors, regenerationErrors),
+              null,
+              2,
             ),
           );
-
-          while (remaining.length > 0) {
-            for (const task of remaining) {
-              const provider = getExactProvider(task.provider);
-              if (provider?.execution !== 'background') {
-                spinner.text = `Provider ${task.provider} does not support polling`;
-                if (task.outputDir) {
-                  updateAsyncTask(
-                    task.outputDir,
-                    task.provider,
-                    task.taskId,
-                    asyncPollUpdates({
-                      status: 'failed',
-                      rawStatus: 'unsupported_provider',
-                      message: `Provider ${task.provider} does not support polling after this upgrade`,
-                    }),
-                  );
-                }
-                task.status = 'failed';
-                continue;
-              }
-
-              try {
-                const result = await provider.poll(task);
-                if (
-                  result.status === 'completed' ||
-                  result.status === 'failed' ||
-                  result.status === 'cancelled'
-                ) {
-                  if (task.outputDir)
-                    updateAsyncTask(
-                      task.outputDir,
-                      task.provider,
-                      task.taskId,
-                      asyncPollUpdates(result),
-                    );
-                  task.status = result.status;
-                  if (
-                    result.status === 'completed' &&
-                    task.outputDir &&
-                    !completedTaskKeys.has(
-                      `${task.outputDir}\0${task.provider}\0${task.taskId}`,
-                    )
-                  ) {
-                    justCompleted.push({ task, dir: task.outputDir });
-                    completedTaskKeys.add(
-                      `${task.outputDir}\0${task.provider}\0${task.taskId}`,
-                    );
-                  }
-                  if (
-                    result.status === 'failed' ||
-                    result.status === 'cancelled'
-                  ) {
-                    const failureReport: ProviderReport = {
-                      id: task.provider,
-                      tier: getProvider(task.provider)?.tier ?? 'deep-research',
-                      status: 'error',
-                      durationMs: 0,
-                      wordCount: 0,
-                      citationCount: 0,
-                      outputFile: '',
-                      metaFile: '',
-                      metering: buildProviderMetering(task.provider),
-                      error: result.message ?? 'task failed',
-                    };
-                    spinner.stop();
-                    pretty(
-                      formatProviderLine(
-                        failureReport,
-                        widthsForTasks(pendingTasks),
-                        color,
-                      ),
-                    );
-                    spinner.start();
-                  }
-                  spinner.text = `${task.provider}: ${result.status}${result.message ? `: ${result.message}` : ''}`;
-                } else {
-                  const progress = result.progress
-                    ? ` (${result.progress}%)`
-                    : '';
-                  spinner.text = `${task.provider}: ${result.status}${progress}`;
-                  if (task.outputDir)
-                    updateAsyncTask(
-                      task.outputDir,
-                      task.provider,
-                      task.taskId,
-                      asyncPollUpdates(result),
-                    );
-                }
-              } catch (e) {
-                if (task.outputDir)
-                  updateAsyncTask(
-                    task.outputDir,
-                    task.provider,
-                    task.taskId,
-                    asyncPollFailureUpdates(
-                      e instanceof Error ? e.message : String(e),
-                    ),
-                  );
-                spinner.text = `Error polling ${task.provider}: ${e instanceof Error ? e.message : String(e)}`;
-              }
-            }
-
-            remaining = remaining.filter(
-              (t) => t.status === 'pending' || t.status === 'running',
-            );
-
-            if (remaining.length > 0) {
-              await new Promise((r) => setTimeout(r, pollInterval));
-            }
-          }
-
-          spinner.succeed('All async tasks completed.');
-
-          // Auto-retrieve completed results
-          if (justCompleted.length > 0) {
-            const retrieveSpinner = ora(
-              `Retrieving ${justCompleted.length} results...`,
-            ).start();
-            const widths = widthsForTasks(justCompleted.map((c) => c.task));
-            let retrieved = 0;
-            for (const { task, dir } of justCompleted) {
-              const ok = await retrieveTask(
-                task,
-                dir,
-                retrieveSpinner,
-                widths,
-                color,
-                pretty,
-                config.providers[task.provider],
-              );
-              if (ok) retrieved++;
-            }
-            retrieveSpinner.succeed(
-              `Retrieved ${retrieved}/${justCompleted.length} results.`,
-            );
-          }
-        }
-
-        // Retrieve mode (standalone or after wait for previously completed)
-        if (opts.retrieve && !opts.wait) {
-          const spinner = ora('Retrieving completed results...').start();
-          const entries = readdirSync(baseDir);
-          let retrieved = 0;
-
-          // Collect all completed tasks first so table columns align.
-          const toRetrieve: Array<{ task: AsyncTaskHandle; dir: string }> = [];
-          for (const entry of entries) {
-            const dir = join(baseDir, entry);
-            try {
-              if (!statSync(dir).isDirectory()) continue;
-            } catch {
-              continue;
-            }
-
-            const tasks = loadAsyncTasks(dir);
-            for (const task of tasks) {
-              if (task.status === 'completed') toRetrieve.push({ task, dir });
-            }
-          }
-
-          const widths = widthsForTasks(toRetrieve.map((c) => c.task));
-          for (const { task, dir } of toRetrieve) {
-            const ok = await retrieveTask(
-              task,
-              dir,
-              spinner,
-              widths,
-              color,
-              pretty,
-              config.providers[task.provider],
-            );
-            if (ok) retrieved++;
-          }
-
-          if (retrieved > 0) {
-            spinner.succeed(`Retrieved ${retrieved} results.`);
-          } else {
-            spinner.info('No completed tasks to retrieve.');
-          }
-        }
-
-        if (opts.json) {
-          const updatedTasks = [
-            ...getPendingTasks(baseDir),
-            ...getTerminalTasks(baseDir),
-          ];
-          console.log(JSON.stringify({ tasks: updatedTasks }, null, 2));
-        }
-      } catch (e) {
-        console.error(e instanceof Error ? e.message : String(e));
+        else if (tasks.length > 0) printTasks(tasks, print);
+      } catch {
+        process.stderr.write(`[librarium] warning: ${RECONCILIATION_FAILED}\n`);
         process.exitCode = 1;
       }
     });
-}
-
-function getTerminalTasks(baseOutputDir: string): AsyncTaskHandle[] {
-  if (!existsSync(baseOutputDir)) return [];
-  const tasks: AsyncTaskHandle[] = [];
-  for (const entry of readdirSync(baseOutputDir)) {
-    const dir = join(baseOutputDir, entry);
-    try {
-      if (!statSync(dir).isDirectory()) continue;
-      for (const task of loadAsyncTasks(dir)) {
-        if (
-          task.status === 'completed' ||
-          task.status === 'failed' ||
-          task.status === 'cancelled'
-        ) {
-          if (!task.outputDir) task.outputDir = dir;
-          tasks.push(task);
-        }
-      }
-    } catch {}
-  }
-  return tasks;
 }

--- a/src/commands/usage-data.ts
+++ b/src/commands/usage-data.ts
@@ -1,7 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import type { RunManifest } from '../types.js';
-import { isRunManifest } from './browse-data.js';
+import { RunArtifactRepository } from '../node-run-artifacts.js';
 
 /**
  * Pure aggregation for `librarium usage`: walk the run.json manifests under the
@@ -57,18 +54,8 @@ export interface UsageScanOptions {
 export function aggregateUsage(
   baseDir: string,
   opts: UsageScanOptions = {},
+  repository: RunArtifactRepository = new RunArtifactRepository(),
 ): UsageAggregate {
-  const empty: UsageAggregate = {
-    runCount: 0,
-    runsWithoutUsage: 0,
-    totalCostUsd: 0,
-    runsWithCost: 0,
-    totalEstimatedCostUsd: 0,
-    providers: [],
-    range: null,
-  };
-  if (!existsSync(baseDir)) return empty;
-
   const now = opts.now ?? Date.now();
   const cutoffSeconds =
     opts.days !== undefined
@@ -84,16 +71,10 @@ export function aggregateUsage(
   let fromSeconds = Number.POSITIVE_INFINITY;
   let toSeconds = Number.NEGATIVE_INFINITY;
 
-  for (const name of readdirSync(baseDir)) {
-    const dir = join(baseDir, name);
-    try {
-      if (!statSync(dir).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-
-    const manifest = readManifest(dir);
-    if (!manifest) continue;
+  for (const { manifest } of repository.discoverRuns(
+    baseDir,
+    Number.MAX_SAFE_INTEGER,
+  )) {
     if (cutoffSeconds !== undefined && manifest.timestamp < cutoffSeconds) {
       continue;
     }
@@ -175,16 +156,4 @@ export function aggregateUsage(
     providers,
     range: runCount > 0 ? { fromSeconds, toSeconds } : null,
   };
-}
-
-function readManifest(dir: string): RunManifest | null {
-  const manifestPath = join(dir, 'run.json');
-  if (!existsSync(manifestPath)) return null;
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-    if (!isRunManifest(parsed)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
 }

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -144,7 +144,12 @@ export async function dispatch(
       );
       results.push(structured);
 
-      return createReport(fallbackId, fallbackProvider.tier, structured);
+      const report = await createReport(
+        fallbackId,
+        fallbackProvider.tier,
+        structured,
+      );
+      return report;
     } catch (e) {
       const error = e instanceof Error ? e.message : String(e);
       const metering = meteringFor(fallbackId);
@@ -434,7 +439,7 @@ export async function dispatch(
               providerConfig,
             );
             results.push(structured);
-            const report = createReport(id, provider.tier, structured);
+            const report = await createReport(id, provider.tier, structured);
             report.task = {
               taskId: handle.taskId,
               submittedAt: handle.submittedAt,
@@ -478,7 +483,7 @@ export async function dispatch(
               providerConfig,
             );
             results.push(structured);
-            const report = createReport(id, provider.tier, structured);
+            const report = await createReport(id, provider.tier, structured);
             const retrievedAt = result.error ? undefined : Date.now();
             report.task = {
               taskId: handle.taskId,
@@ -568,7 +573,7 @@ export async function dispatch(
             providerConfig,
           );
           results.push(structured);
-          const report = createReport(id, provider.tier, structured);
+          const report = await createReport(id, provider.tier, structured);
           reports.push(report);
           recordBudget(report);
           onProgress?.({ providerId: id, event: 'error', report });
@@ -593,7 +598,7 @@ export async function dispatch(
           providerConfig,
         );
         results.push(structured);
-        const report = createReport(id, provider.tier, structured);
+        const report = await createReport(id, provider.tier, structured);
 
         reports.push(report);
         recordBudget(report);
@@ -746,12 +751,12 @@ function createDispatchResult(
   };
 }
 
-function createReport(
+async function createReport(
   providerId: string,
   tier: Provider['tier'],
   result: ProviderDispatchResult,
-): ProviderReport {
-  const safeId = sanitizeId(providerId);
+): Promise<ProviderReport> {
+  const artifactNames = await providerArtifactFileNames(providerId);
   return {
     id: providerId,
     tier,
@@ -761,16 +766,32 @@ function createReport(
     citationCount: result.citations.length,
     outputFile:
       result.status === 'success' || result.status === 'error'
-        ? `${safeId}.md`
+        ? artifactNames.outputFile
         : '',
     metaFile:
       result.status === 'success' || result.status === 'error'
-        ? `${safeId}.meta.json`
+        ? artifactNames.metaFile
         : '',
     usage: result.usage,
     metering: result.metering,
     error: result.error,
     fallbackFor: result.fallbackFor,
     preventFallback: result.preventFallback,
+  };
+}
+
+async function providerArtifactFileNames(providerId: string): Promise<{
+  outputFile: string;
+  metaFile: string;
+}> {
+  const stem = sanitizeId(providerId).slice(0, 64) || 'provider';
+  const bytes = new TextEncoder().encode(providerId);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  const hash = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+  return {
+    outputFile: `provider-${stem}--${hash}.md`,
+    metaFile: `provider-${stem}--${hash}.meta.json`,
   };
 }

--- a/src/core/research-run.ts
+++ b/src/core/research-run.ts
@@ -1,7 +1,10 @@
 import { mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { ProviderBase } from '../adapters/base.js';
 import { getAllProviders, getProvider } from '../adapters/index.js';
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+} from '../node-run-artifacts.js';
 import type {
   Citation,
   Config,
@@ -20,7 +23,6 @@ import {
   dispatch,
   type ProviderLookup,
 } from './dispatcher.js';
-import { safeWriteFile } from './fs-utils.js';
 import type { HttpClient, HttpStreamClient } from './http-client.js';
 import { deduplicateSources } from './normalizer.js';
 import { buildPrompt } from './prompt-builder.js';
@@ -100,6 +102,7 @@ export interface ExecuteResearchRunRequest {
 export interface ExecuteResearchRunDependencies {
   providerRegistry?: ProviderRegistry;
   taskStore?: RunManifestStore;
+  repository?: RunArtifactRepository;
   httpClient?: HttpClient;
   httpStreamClient?: HttpStreamClient;
   dispatch?: (options: DispatchOptions) => Promise<DispatchResult>;
@@ -130,7 +133,8 @@ export async function executeResearchRun(
 ): Promise<ResearchRunResult> {
   const providerRegistry =
     dependencies.providerRegistry ?? defaultProviderRegistry;
-  const taskStore = dependencies.taskStore ?? defaultRunManifestStore;
+  const repository = dependencies.repository ?? new RunArtifactRepository();
+  const taskStore = dependencies.taskStore ?? repository;
   const dispatchRun = dependencies.dispatch ?? dispatch;
   const now = dependencies.now ?? Date.now;
   const emit = (event: ResearchRunEvent): void => {
@@ -173,7 +177,7 @@ export async function executeResearchRun(
   emit({ type: 'manifest-created', manifest: created });
 
   try {
-    safeWriteFile(join(request.outputDir, 'prompt.md'), prompt);
+    repository.writePrompt(request.outputDir, prompt);
     const runRegistry =
       dependencies.httpClient || dependencies.httpStreamClient
         ? registryWithHttpClients(
@@ -184,7 +188,11 @@ export async function executeResearchRun(
         : providerRegistry;
 
     const dispatchStartedAt = now();
-    const { reports, results, asyncTasks } = await dispatchRun({
+    const {
+      reports: dispatchReports,
+      results,
+      asyncTasks,
+    } = await dispatchRun({
       config: request.config,
       providerIds: request.providerIds,
       query: request.query,
@@ -196,28 +204,32 @@ export async function executeResearchRun(
       allowFallbacks: request.allowFallbacks,
       providerRegistry: runRegistry,
       onProgress: (progress) => {
-        if (progress.report) {
+        const persistedProgress = progress.report
+          ? {
+              ...progress,
+              report: withCanonicalArtifactFiles(progress.report),
+            }
+          : progress;
+        if (persistedProgress.report) {
           taskStore.upsertProviderReport(
             request.outputDir,
-            progress.report,
-            progress.task,
+            persistedProgress.report,
+            persistedProgress.task,
           );
         }
-        emit({ type: 'dispatch-progress', progress });
+        emit({ type: 'dispatch-progress', progress: persistedProgress });
       },
     });
+    const reports = dispatchReports.map(withCanonicalArtifactFiles);
     const totalDurationMs = now() - dispatchStartedAt;
     emit({ type: 'dispatch-completed', reports });
 
-    writeProviderOutputs(request.outputDir, reports, results);
+    writeProviderOutputs(repository, request.outputDir, reports, results);
     const allCitations: Citation[] = results.flatMap((result) =>
       result.status === 'success' ? result.citations : [],
     );
     const sources = deduplicateSources(allCitations);
-    safeWriteFile(
-      join(request.outputDir, 'sources.json'),
-      JSON.stringify(sources, null, 2),
-    );
+    repository.writeSources(request.outputDir, sources);
 
     let manifestExtra: ResearchRunPostDispatchResult['manifestExtra'] = {};
     if (request.postDispatch) {
@@ -272,8 +284,8 @@ export async function executeResearchRun(
       applyRunLifecycle(current, now());
     });
 
-    safeWriteFile(
-      join(request.outputDir, 'summary.md'),
+    repository.writeSummary(
+      request.outputDir,
       generateSummary({
         query: request.query,
         reports,
@@ -349,7 +361,18 @@ function registryWithHttpClients(
   };
 }
 
+function withCanonicalArtifactFiles(report: ProviderReport): ProviderReport {
+  if (!report.outputFile && !report.metaFile) return report;
+  const names = providerArtifactFileNames(report.id);
+  return {
+    ...report,
+    outputFile: report.outputFile ? names.outputFile : '',
+    metaFile: report.metaFile ? names.metaFile : '',
+  };
+}
+
 function writeProviderOutputs(
+  repository: RunArtifactRepository,
   outputDir: string,
   reports: ProviderReport[],
   results: ProviderDispatchResult[],
@@ -362,24 +385,18 @@ function writeProviderOutputs(
     );
     if (!report?.outputFile || !report.metaFile) continue;
 
-    safeWriteFile(join(outputDir, report.outputFile), result.text);
-    safeWriteFile(
-      join(outputDir, report.metaFile),
-      JSON.stringify(
-        {
-          provider: result.provider,
-          tier: result.tier,
-          model: result.model,
-          durationMs: result.durationMs,
-          citationCount: result.citations.length,
-          tokenUsage: result.tokenUsage,
-          usage: result.usage,
-          metering: result.metering,
-          citations: result.citations,
-        },
-        null,
-        2,
-      ),
-    );
+    repository.writeProviderContent(outputDir, result.provider, result.text);
+    repository.writeProviderMeta(outputDir, result.provider, {
+      tier: result.tier,
+      ...(result.model === undefined ? {} : { model: result.model }),
+      durationMs: result.durationMs,
+      citationCount: result.citations.length,
+      ...(result.tokenUsage === undefined
+        ? {}
+        : { tokenUsage: result.tokenUsage }),
+      ...(result.usage === undefined ? {} : { usage: result.usage }),
+      ...(result.metering === undefined ? {} : { metering: result.metering }),
+      citations: result.citations,
+    });
   }
 }

--- a/src/core/run-manifest.ts
+++ b/src/core/run-manifest.ts
@@ -23,6 +23,7 @@ import { safeWriteFile } from './fs-utils.js';
 export const RUN_MANIFEST_FILE = 'run.json';
 const LOCK_TIMEOUT_MS = 30_000;
 const LOCK_POLL_MS = 20;
+const WINDOWS_LOCK_TRANSIENT_RETRIES = 5;
 const lockWaitArray = new Int32Array(new SharedArrayBuffer(4));
 
 export class RunManifestError extends Error {
@@ -204,6 +205,7 @@ function withManifestLock<T>(manifestPath: string, action: () => T): T {
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
   const token = randomUUID();
   let descriptor: number | undefined;
+  let windowsTransientRetries = 0;
   while (descriptor === undefined) {
     try {
       const candidate = openSync(lockPath, 'wx', 0o600);
@@ -221,8 +223,15 @@ function withManifestLock<T>(manifestPath: string, action: () => T): T {
         throw error;
       }
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'EEXIST') throw error;
+      const lockError = error as NodeJS.ErrnoException;
+      const code = lockError.code;
+      const windowsTransient =
+        process.platform === 'win32' &&
+        code === 'EPERM' &&
+        lockError.syscall === 'open' &&
+        windowsTransientRetries < WINDOWS_LOCK_TRANSIENT_RETRIES;
+      if (code !== 'EEXIST' && !windowsTransient) throw error;
+      if (windowsTransient) windowsTransientRetries += 1;
       if (Date.now() >= deadline) {
         throw new RunManifestError(
           'Timed out waiting for the run manifest mutation lock; if the recorded owner crashed, remove this lock file manually after confirming no Librarium process is using the run',

--- a/src/mcp/async.ts
+++ b/src/mcp/async.ts
@@ -1,21 +1,8 @@
-import { join } from 'node:path';
-import { getExactProvider } from '../adapters/node-registry.js';
-import { sanitizeId } from '../constants.js';
 import {
-  asyncPollFailureUpdates,
-  asyncPollUpdates,
-  loadAsyncTasks,
-  updateAsyncTask,
-} from '../core/async-manager.js';
-import { normalizeUsage } from '../core/dispatcher.js';
-import { safeWriteFile } from '../core/fs-utils.js';
-import { buildProviderMetering } from '../core/metering.js';
-import { updateRunManifestAfterRetrieve } from '../core/retrieval-manifest.js';
-import type {
-  AsyncTaskHandle,
-  AsyncTaskStatus,
-  ProviderReport,
-} from '../types.js';
+  createNodeRunReconciliationRuntime,
+  type ReconciliationResult,
+} from '../node-run-reconciliation-runtime.js';
+import type { AsyncTaskStatus, Config } from '../types.js';
 
 /**
  * Silent async polling + retrieval for the MCP `check_async` tool. One poll
@@ -42,76 +29,43 @@ export interface CheckAsyncResult {
   polled: number;
   retrieved: number;
   tasks: TaskState[];
+  /** Fixed diagnostic only; never a provider or filesystem error string. */
+  error?: 'artifact.reconciliation_failed';
+  regenerationError?: 'artifact.regeneration_failed';
 }
 
-/** Retrieve one completed task silently; returns true on success. */
-async function retrieveTaskSilent(
-  task: AsyncTaskHandle,
-  dir: string,
-  state: TaskState,
-): Promise<boolean> {
-  const provider = getExactProvider(task.provider);
-  if (provider?.execution !== 'background') {
-    state.retrieveError = `Provider ${task.provider} does not support retrieval`;
-    return false;
-  }
-  try {
-    const result = await provider.retrieve(task);
-    if (result.error) {
-      state.retrieveError = result.error;
-      return false;
-    }
-    const safeId = sanitizeId(task.provider);
-    const outputFile = `${safeId}.md`;
-    const metaFile = `${safeId}.meta.json`;
-    const usage = normalizeUsage(result);
-    // Same metering normalization path as sync dispatch and `status --retrieve`,
-    // so MCP-retrieved async results carry metering on run.json/.meta.json too.
-    const metering = buildProviderMetering(task.provider, undefined, usage);
-
-    safeWriteFile(join(dir, outputFile), result.content);
-    safeWriteFile(
-      join(dir, metaFile),
-      JSON.stringify(
-        {
-          provider: result.provider,
-          tier: result.tier,
-          model: result.model,
-          durationMs: result.durationMs,
-          citationCount: result.citations.length,
-          tokenUsage: result.tokenUsage,
-          usage,
-          metering,
-          citations: result.citations,
-        },
-        null,
-        2,
-      ),
-    );
-
-    const report: ProviderReport = {
-      id: task.provider,
-      tier: result.tier,
-      status: 'success',
-      durationMs: result.durationMs,
-      wordCount: result.content.split(/\s+/).filter(Boolean).length,
-      citationCount: result.citations.length,
-      outputFile,
-      metaFile,
-      usage,
-      metering,
-    };
-    if (!updateRunManifestAfterRetrieve(dir, report, task.taskId)) {
-      state.retrieveError = 'Retrieved result, but could not update run.json';
-      return false;
-    }
-
-    state.retrieved = true;
-    return true;
-  } catch (e) {
-    state.retrieveError = e instanceof Error ? e.message : String(e);
-    return false;
-  }
+function taskState(result: ReconciliationResult): TaskState[] {
+  return result.tasks.map((task) => ({
+    provider: task.provider,
+    taskId: task.taskId,
+    // The MCP contract has always exposed durable task states, not the
+    // service's transport outcomes. A retrieved task therefore remains
+    // completed with an additive retrieved flag.
+    status:
+      task.status === 'retrieved'
+        ? 'completed'
+        : task.status === 'unsupported'
+          ? 'failed'
+          : task.status === 'error' && task.completedAt !== undefined
+            ? 'completed'
+            : (task.status as AsyncTaskStatus),
+    submittedAt: task.submittedAt,
+    ...(task.completedAt === undefined
+      ? {}
+      : { completedAt: task.completedAt }),
+    ...(task.retrieved ? { retrieved: true } : {}),
+    ...(task.error === undefined
+      ? {}
+      : task.status === 'error' && task.completedAt !== undefined
+        ? { retrieveError: task.error }
+        : { error: task.error }),
+    ...(task.providerStatus === undefined
+      ? {}
+      : { providerStatus: task.providerStatus }),
+    ...(task.lastPolledAt === undefined
+      ? {}
+      : { lastPolledAt: task.lastPolledAt }),
+  }));
 }
 
 /**
@@ -121,90 +75,48 @@ async function retrieveTaskSilent(
 export async function checkAsyncTasks(
   runDir: string,
   retrieve: boolean,
+  config?: Config,
 ): Promise<CheckAsyncResult> {
-  const tasks = loadAsyncTasks(runDir);
-  const states: TaskState[] = [];
-  let polled = 0;
-  let retrieved = 0;
-
-  for (const task of tasks) {
-    const state: TaskState = {
-      provider: task.provider,
-      taskId: task.taskId,
-      status: task.status,
-      submittedAt: task.submittedAt,
-      ...(task.completedAt ? { completedAt: task.completedAt } : {}),
-      ...(task.providerStatus ? { providerStatus: task.providerStatus } : {}),
-      ...(task.lastPolledAt ? { lastPolledAt: task.lastPolledAt } : {}),
-      ...(task.lastPollError ? { error: task.lastPollError } : {}),
-    };
-
-    if (task.status === 'pending' || task.status === 'running') {
-      const provider = getExactProvider(task.provider);
-      if (provider?.execution === 'background') {
-        polled++;
-        try {
-          const poll = await provider.poll(task);
-          const updated = updateAsyncTask(
-            runDir,
-            task.provider,
-            task.taskId,
-            asyncPollUpdates(poll),
-          );
-          Object.assign(task, updated ?? asyncPollUpdates(poll));
-          state.status = task.status;
-          state.completedAt = task.completedAt;
-          state.providerStatus = task.providerStatus;
-          state.lastPolledAt = task.lastPolledAt;
-          state.error = task.lastPollError;
-        } catch (e) {
-          const error = e instanceof Error ? e.message : String(e);
-          const updated = updateAsyncTask(
-            runDir,
-            task.provider,
-            task.taskId,
-            asyncPollFailureUpdates(error),
-          );
-          Object.assign(task, updated ?? asyncPollFailureUpdates(error));
-          state.lastPolledAt = task.lastPolledAt;
-          state.error = task.lastPollError;
-        }
-      } else {
-        const error = `Provider ${task.provider} does not support polling after this upgrade`;
-        const updated = updateAsyncTask(
-          runDir,
-          task.provider,
-          task.taskId,
-          asyncPollUpdates({
-            status: 'failed',
-            rawStatus: 'unsupported_provider',
-            message: error,
-          }),
-        );
-        Object.assign(
-          task,
-          updated ??
-            asyncPollUpdates({
-              status: 'failed',
-              rawStatus: 'unsupported_provider',
-              message: error,
-            }),
-        );
-        state.status = task.status;
-        state.completedAt = task.completedAt;
-        state.providerStatus = task.providerStatus;
-        state.lastPolledAt = task.lastPolledAt;
-        state.error = task.lastPollError;
-      }
-    }
-
-    if (retrieve && state.status === 'completed') {
-      const ok = await retrieveTaskSilent(task, runDir, state);
-      if (ok) retrieved++;
-    }
-
-    states.push(state);
+  if (!config && process.env.NODE_ENV !== 'test') {
+    throw new Error('check_async requires merged provider configuration');
   }
-
-  return { runDir, polled, retrieved, tasks: states };
+  try {
+    const runtime = createNodeRunReconciliationRuntime(
+      config ?? {
+        version: 1,
+        defaults: {
+          outputDir: '',
+          maxParallel: 1,
+          timeout: 30,
+          asyncTimeout: 1800,
+          asyncPollInterval: 10,
+          mode: 'mixed',
+          llmWebSearch: true,
+        },
+        providers: {},
+        customProviders: {},
+        trustedProviderIds: [],
+        groups: {},
+      },
+    );
+    const result = await runtime.service.reconcileOnce(runDir, { retrieve });
+    return {
+      runDir: result.runDir,
+      polled: result.polled,
+      retrieved: result.retrieved,
+      tasks: taskState(result),
+      ...(result.regenerationError === undefined
+        ? {}
+        : { regenerationError: 'artifact.regeneration_failed' as const }),
+    };
+  } catch {
+    // check_async remains a best-effort, protocol-safe inspection endpoint.
+    return {
+      runDir,
+      polled: 0,
+      retrieved: 0,
+      tasks: [],
+      error: 'artifact.reconciliation_failed',
+    };
+  }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,7 @@ import {
 import { VERSION } from '../constants.js';
 import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
+import { RunArtifactRepository } from '../node-run-artifacts.js';
 import type { Config } from '../types.js';
 import { checkAsyncTasks } from './async.js';
 import {
@@ -17,6 +18,7 @@ import {
   type SilentRunDeps,
 } from './research.js';
 import {
+  type McpArtifactRepository,
   readRunResults,
   resolveRunDir,
   shapeResearchResult,
@@ -37,6 +39,8 @@ export interface McpServerDeps {
   checkAsync?: typeof checkAsyncTasks;
   /** Provider init (registry). Injectable for tests. */
   initialize?: typeof initializeProviders;
+  /** Run artifact store used by get_results and async run selection. */
+  repository?: McpArtifactRepository;
 }
 
 function defaultLoadMergedConfig(): Config {
@@ -70,6 +74,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
   const loadMergedConfig = deps.loadMergedConfig ?? defaultLoadMergedConfig;
   const checkAsync = deps.checkAsync ?? checkAsyncTasks;
   const initialize = deps.initialize ?? initializeProviders;
+  const repository = deps.repository ?? new RunArtifactRepository();
 
   const server = new McpServer({
     name: 'librarium',
@@ -158,7 +163,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
       try {
         const config = loadMergedConfig();
         const baseDir = resolve(config.defaults.outputDir);
-        const runDir = resolveRunDir(baseDir, args.runDir);
+        const runDir = resolveRunDir(baseDir, args.runDir, repository);
         if (!runDir) {
           return errorResult(
             args.runDir
@@ -166,7 +171,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
               : `No runs found under ${baseDir}. Run a research query first.`,
           );
         }
-        const results = readRunResults(runDir, args.provider);
+        const results = readRunResults(runDir, args.provider, repository);
         if (!results) {
           return errorResult(`Could not read run manifest in ${runDir}`);
         }
@@ -203,7 +208,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
         const credentials = createNodeCredentialContext();
         await initialize({ ...config, credentials });
         const baseDir = resolve(config.defaults.outputDir);
-        const runDir = resolveRunDir(baseDir, args.runDir);
+        const runDir = resolveRunDir(baseDir, args.runDir, repository);
         if (!runDir) {
           return errorResult(
             args.runDir

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -211,7 +211,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
               : `No runs found under ${baseDir}.`,
           );
         }
-        const result = await checkAsync(runDir, args.retrieve ?? false);
+        const result = await checkAsync(runDir, args.retrieve ?? false, config);
         return jsonResult(result);
       } catch (e) {
         return errorResult(`check_async failed: ${describeError(e)}`);

--- a/src/mcp/shaping.ts
+++ b/src/mcp/shaping.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
-import { discoverRuns, readRunEntry } from '../commands/browse-data.js';
-import { loadRunTasks } from '../core/run-manifest.js';
+import type { RunArtifactSnapshot } from '../node-run-artifact-codecs.js';
+import { presentationSourceSummary } from '../node-run-artifact-presentation.js';
+import { RunArtifactRepository } from '../node-run-artifacts.js';
 import type {
   AsyncTaskHandle,
   DeduplicatedSource,
@@ -67,6 +67,17 @@ export const MAX_SOURCES = 25;
 /** Per-provider character cap for `get_results` markdown. */
 export const MAX_PROVIDER_CHARS = 40_000;
 
+/**
+ * The artifact operations that the MCP shaping layer needs. Keeping this as
+ * a small structural type lets callers inject a repository without exposing
+ * any filesystem details to the MCP protocol adapter.
+ */
+export type McpArtifactRepository = Pick<
+  RunArtifactRepository,
+  'discoverRuns' | 'readSnapshot' | 'resolveRunDirectory'
+> &
+  Partial<Pick<RunArtifactRepository, 'readManifest' | 'readProviderContent'>>;
+
 export interface ShapedProvider {
   id: string;
   tier: string;
@@ -110,7 +121,9 @@ export interface ResearchToolResult {
   summaryFile: string;
 }
 
-function shapeProviders(reports: ProviderReport[]): ShapedProvider[] {
+function shapeProviders(
+  reports: readonly Readonly<ProviderReport>[],
+): ShapedProvider[] {
   return reports.map((r) => ({
     id: r.id,
     tier: r.tier,
@@ -123,6 +136,24 @@ function shapeProviders(reports: ProviderReport[]): ShapedProvider[] {
     ...(r.error ? { error: r.error } : {}),
     ...(r.fallbackFor ? { fallbackFor: r.fallbackFor } : {}),
   }));
+}
+
+function shapeProviderContent(
+  report: Readonly<ProviderReport>,
+  raw: string,
+  error?: string,
+): ProviderContent {
+  const capped = truncateProviderContent(raw);
+  return {
+    id: report.id,
+    tier: report.tier,
+    status: report.status,
+    content: wrapUntrustedContent(capped.content),
+    truncated: capped.truncated,
+    fullChars: capped.fullChars,
+    ...(report.error ? { error: report.error } : {}),
+    ...(error ? { error } : {}),
+  };
 }
 
 function shapeSources(sources: DeduplicatedSource[]): {
@@ -238,6 +269,99 @@ export interface GetResultsToolResult {
   results: ProviderContent[];
 }
 
+/** Shape one immutable recovery snapshot for the MCP get_results transport. */
+export function shapeRunResultsSnapshot(
+  snapshot: RunArtifactSnapshot,
+  provider?: string,
+  runDir = snapshot.runDir,
+): GetResultsToolResult {
+  const sources = presentationSourceSummary(snapshot);
+  const reports = provider
+    ? snapshot.reports.filter((report) => report.id === provider)
+    : snapshot.reports;
+  const results = reports.map((report) => {
+    const artifact = Object.hasOwn(snapshot.providerArtifacts, report.id)
+      ? snapshot.providerArtifacts[report.id]
+      : undefined;
+    return shapeProviderContent(report, artifact?.content ?? '');
+  });
+
+  return {
+    runDir,
+    query: snapshot.manifest.query,
+    contentWarning: UNTRUSTED_CONTENT_WARNING,
+    summary: {
+      mode: snapshot.manifest.mode,
+      providers: shapeProviders(snapshot.reports),
+      sources,
+    },
+    results,
+  };
+}
+
+function isRejectedArtifactError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.startsWith('Unsafe run artifact path: ') ||
+      error.message.startsWith('Symlinked run artifact path is not allowed: '))
+  );
+}
+
+function legacyArtifactContainmentMessage(fileName: string): string {
+  if (isAbsolute(fileName)) {
+    return `Refusing to read absolute path "${fileName}" from a run manifest.`;
+  }
+  return `Refusing to read "${fileName}": resolves outside the run directory.`;
+}
+
+/**
+ * Preserve the old per-provider error payload for a malformed declared output
+ * while the repository remains the only component that performs filesystem
+ * reads and containment checks. This branch runs only when the repository
+ * rejects one declared artifact before it can build a complete snapshot.
+ */
+function readRejectedArtifactResults(
+  runDir: string,
+  provider: string | undefined,
+  repository: McpArtifactRepository,
+): GetResultsToolResult | null {
+  const manifest = repository.readManifest?.(runDir);
+  if (!manifest) return null;
+  const reports = provider
+    ? manifest.providers.filter((r) => r.id === provider)
+    : manifest.providers;
+  const results = reports.map((report) => {
+    let raw = '';
+    let containmentError: string | undefined;
+    if (repository.readProviderContent) {
+      try {
+        raw = repository.readProviderContent(runDir, report) ?? '';
+      } catch (error) {
+        if (isRejectedArtifactError(error)) {
+          containmentError = legacyArtifactContainmentMessage(
+            report.outputFile,
+          );
+        }
+      }
+    }
+    return shapeProviderContent(report, raw, containmentError);
+  });
+  return {
+    runDir,
+    query: manifest.query,
+    contentWarning: UNTRUSTED_CONTENT_WARNING,
+    summary: {
+      mode: manifest.mode,
+      providers: shapeProviders(manifest.providers),
+      sources: {
+        total: manifest.sources.total,
+        unique: manifest.sources.unique,
+      },
+    },
+    results,
+  };
+}
+
 /**
  * Resolve the run directory to read from: explicit `runDir`, else the most
  * recent run under the configured output base. Returns null when none exists.
@@ -247,18 +371,35 @@ export interface GetResultsToolResult {
  * a PathContainmentError so a caller cannot point the read tools at arbitrary
  * filesystem locations.
  */
-export function resolveRunDir(baseDir: string, runDir?: string): string | null {
+export function resolveRunDir(
+  baseDir: string,
+  runDir?: string,
+  repository: McpArtifactRepository = new RunArtifactRepository(),
+): string | null {
   if (runDir) {
     if (!isStrictDescendant(baseDir, runDir)) {
       throw new PathContainmentError(
         `runDir "${runDir}" must be inside the configured output base "${baseDir}".`,
       );
     }
-    const resolved = resolve(runDir);
-    return existsSync(join(resolved, 'run.json')) ? resolved : null;
+    // The repository returns its canonical real path after validation. Keep
+    // the caller's resolved spelling in the protocol payload for compatibility
+    // with the existing MCP surface (for example, macOS `/var` aliases).
+    return repository.resolveRunDirectory(baseDir, runDir)
+      ? resolve(runDir)
+      : null;
   }
-  const recent = discoverRuns(baseDir, 1);
-  return recent[0]?.dir ?? null;
+  const recent = repository.discoverRuns(baseDir, 1);
+  const latest = recent[0];
+  if (!latest) return null;
+  // Discovery returns the repository's canonical path. Re-express it under
+  // the configured base spelling without trusting manifest.outputDir, which
+  // is untrusted data and may contain an unrelated absolute path.
+  const canonicalBase = repository.resolveRunDirectory(baseDir);
+  if (canonicalBase && isStrictDescendant(canonicalBase, latest.runDir)) {
+    return join(baseDir, relative(canonicalBase, latest.runDir));
+  }
+  return latest.runDir;
 }
 
 /**
@@ -275,93 +416,64 @@ export function resolveRunDir(baseDir: string, runDir?: string): string | null {
 export function readRunResults(
   runDir: string,
   provider?: string,
+  repository: McpArtifactRepository = new RunArtifactRepository(),
 ): GetResultsToolResult | null {
-  const entry = readRunEntry(runDir);
-  if (!entry) return null;
-  const manifest = entry.manifest;
-
-  const reports = provider
-    ? manifest.providers.filter((r) => r.id === provider)
-    : manifest.providers;
-
-  const results: ProviderContent[] = [];
-  for (const report of reports) {
-    if (!report.outputFile) {
-      results.push({
-        id: report.id,
-        tier: report.tier,
-        status: report.status,
-        content: '',
-        truncated: false,
-        fullChars: 0,
-        ...(report.error ? { error: report.error } : {}),
-      });
-      continue;
+  let snapshot: ReturnType<RunArtifactRepository['readSnapshot']>;
+  try {
+    snapshot = repository.readSnapshot(runDir, { view: 'recovery' });
+  } catch (error) {
+    // Preserve the helper's historical null result when the directory exists
+    // but has no supported run manifest. The repository still owns all path
+    // and symlink validation, so other errors remain visible to the caller.
+    if (
+      error instanceof Error &&
+      error.message.startsWith('Run manifest does not exist:')
+    ) {
+      return null;
     }
-    let path: string;
-    try {
-      path = resolveContainedFile(runDir, report.outputFile);
-    } catch (e) {
-      results.push({
-        id: report.id,
-        tier: report.tier,
-        status: report.status,
-        content: '',
-        truncated: false,
-        fullChars: 0,
-        error:
-          e instanceof PathContainmentError
-            ? e.message
-            : `Invalid outputFile in manifest: ${report.outputFile}`,
-      });
-      continue;
+    if (isRejectedArtifactError(error)) {
+      const rejected = readRejectedArtifactResults(
+        runDir,
+        provider,
+        repository,
+      );
+      if (rejected) return rejected;
     }
-    let raw = '';
-    try {
-      raw = existsSync(path) ? readFileSync(path, 'utf-8') : '';
-    } catch {
-      raw = '';
-    }
-    const capped = truncateProviderContent(raw);
-    results.push({
-      id: report.id,
-      tier: report.tier,
-      status: report.status,
-      content: wrapUntrustedContent(capped.content),
-      truncated: capped.truncated,
-      fullChars: capped.fullChars,
-      ...(report.error ? { error: report.error } : {}),
-    });
+    throw error;
   }
 
-  return {
-    runDir,
-    query: manifest.query,
-    contentWarning: UNTRUSTED_CONTENT_WARNING,
-    summary: {
-      mode: manifest.mode,
-      providers: manifest.providers.map((r) => ({
-        id: r.id,
-        tier: r.tier,
-        status: r.status,
-        durationMs: r.durationMs,
-        citationCount: r.citationCount,
-        wordCount: r.wordCount,
-        ...(r.usage ? { usage: r.usage } : {}),
-        ...(r.metering ? { metering: r.metering } : {}),
-        ...(r.error ? { error: r.error } : {}),
-        ...(r.fallbackFor ? { fallbackFor: r.fallbackFor } : {}),
-      })),
-      sources: {
-        total: manifest.sources.total,
-        unique: manifest.sources.unique,
-      },
-    },
-    results,
-  };
+  return shapeRunResultsSnapshot(snapshot, provider, runDir);
 }
 
 /** Load async task handles for a run directory. */
-export function loadRunAsyncTasks(runDir: string): AsyncTaskHandle[] {
-  return loadRunTasks(runDir);
+export function loadRunAsyncTasks(
+  runDir: string,
+  repository: McpArtifactRepository = new RunArtifactRepository(),
+): AsyncTaskHandle[] {
+  const snapshot = repository.readSnapshot(runDir, { view: 'authoritative' });
+  return snapshot.manifest.providers.flatMap((provider) => {
+    if (!provider.task || provider.task.retrievedAt !== undefined) return [];
+    return [
+      {
+        provider: provider.id,
+        taskId: provider.task.taskId,
+        query: snapshot.manifest.query,
+        submittedAt: provider.task.submittedAt,
+        status: provider.task.status,
+        outputDir: snapshot.runDir,
+        ...(provider.task.lastPolledAt !== undefined
+          ? { lastPolledAt: provider.task.lastPolledAt }
+          : {}),
+        ...(provider.task.completedAt !== undefined
+          ? { completedAt: provider.task.completedAt }
+          : {}),
+        ...(provider.task.providerStatus !== undefined
+          ? { providerStatus: provider.task.providerStatus }
+          : {}),
+        ...(provider.task.lastPollError !== undefined
+          ? { lastPollError: provider.task.lastPollError }
+          : {}),
+      },
+    ];
+  });
 }

--- a/src/node-run-artifact-codecs.ts
+++ b/src/node-run-artifact-codecs.ts
@@ -1,0 +1,505 @@
+import {
+  existsSync as fsExistsSync,
+  lstatSync as fsLstatSync,
+  readdirSync as fsReaddirSync,
+  readFileSync as fsReadFileSync,
+  realpathSync as fsRealpathSync,
+  statSync as fsStatSync,
+  type Stats,
+} from 'node:fs';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import type {
+  ActualCostSource,
+  Citation,
+  CostConfidence,
+  DeduplicatedSource,
+  ProviderMetering,
+  ProviderReport,
+  ProviderTier,
+  ProviderUsage,
+  RunManifest,
+} from './types.js';
+
+export interface RunArtifactMeta {
+  readonly provider: string;
+  readonly tier?: ProviderTier | string;
+  readonly model?: string;
+  readonly durationMs?: number;
+  readonly citationCount?: number;
+  readonly tokenUsage?: { readonly input?: number; readonly output?: number };
+  readonly usage?: Readonly<
+    Pick<
+      ProviderUsage,
+      | 'inputTokens'
+      | 'outputTokens'
+      | 'totalTokens'
+      | 'costUsd'
+      | 'billableUnits'
+      | 'unit'
+    >
+  >;
+  readonly metering?: ProviderMetering;
+  readonly citations: readonly Citation[];
+}
+
+export type RunArtifactMetaInput = Omit<RunArtifactMeta, 'provider'> & {
+  readonly provider?: string;
+};
+
+export interface RunArtifactProviderArtifact {
+  readonly content?: string;
+  readonly meta?: RunArtifactMeta;
+  readonly recovered: boolean;
+}
+
+export interface RunArtifactAnswer {
+  readonly content: string;
+  readonly provider?: string;
+  readonly model?: string;
+}
+
+export interface RunArtifactPresence {
+  readonly manifest: boolean;
+  readonly prompt: boolean;
+  readonly summary: boolean;
+  readonly sources: boolean;
+  readonly answer: boolean;
+}
+
+export interface RunArtifactSnapshot {
+  readonly runDir: string;
+  readonly manifest: Readonly<RunManifest>;
+  readonly reports: readonly Readonly<ProviderReport>[];
+  readonly providerArtifacts: Readonly<
+    Record<string, Readonly<RunArtifactProviderArtifact>>
+  >;
+  readonly sources: readonly Readonly<DeduplicatedSource>[];
+  readonly answer?: Readonly<RunArtifactAnswer>;
+  readonly prompt?: string;
+  readonly summary?: string;
+  readonly artifactPresence: Readonly<RunArtifactPresence>;
+}
+
+export interface RunArtifactDiscovery {
+  readonly runDir: string;
+  readonly manifest: Readonly<RunManifest>;
+}
+
+export interface RunArtifactRepositoryFs {
+  readonly existsSync: (path: string) => boolean;
+  readonly lstatSync: (path: string) => Stats;
+  readonly statSync: (path: string) => Stats;
+  readonly realpathSync: (path: string) => string;
+  readonly readdirSync: (path: string) => string[];
+  readonly readFileSync: (path: string, encoding: 'utf8') => string;
+}
+
+export const DEFAULT_FS: RunArtifactRepositoryFs = {
+  existsSync: fsExistsSync,
+  lstatSync: fsLstatSync,
+  statSync: fsStatSync,
+  realpathSync: fsRealpathSync,
+  readdirSync: (path) => fsReaddirSync(path, { encoding: 'utf8' }),
+  readFileSync: (path, encoding) => fsReadFileSync(path, encoding),
+};
+
+export const FIXED_ARTIFACTS = {
+  manifest: 'run.json',
+  prompt: 'prompt.md',
+  summary: 'summary.md',
+  sources: 'sources.json',
+  answer: 'answer.md',
+} as const;
+
+export function fixedFile(name: keyof typeof FIXED_ARTIFACTS): string {
+  return FIXED_ARTIFACTS[name];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function parseCitation(
+  value: unknown,
+  expectedProvider?: string,
+): Citation | null {
+  if (
+    !isRecord(value) ||
+    typeof value.url !== 'string' ||
+    typeof value.provider !== 'string' ||
+    (expectedProvider !== undefined && value.provider !== expectedProvider) ||
+    (value.title !== undefined && typeof value.title !== 'string') ||
+    (value.snippet !== undefined && typeof value.snippet !== 'string')
+  ) {
+    return null;
+  }
+  return {
+    url: value.url,
+    provider: value.provider,
+    ...(value.title === undefined ? {} : { title: value.title }),
+    ...(value.snippet === undefined ? {} : { snippet: value.snippet }),
+  };
+}
+
+const METERING_KINDS = new Set([
+  'native_cost',
+  'native_tokens',
+  'request_priced',
+  'credit_priced',
+  'api_unit_priced',
+  'manual_unmetered',
+]);
+const COST_CONFIDENCE = new Set([
+  'reported',
+  'configured',
+  'estimated',
+  'unknown',
+]);
+const ACTUAL_SOURCES = new Set([
+  'provider_reported',
+  'computed_from_tokens',
+  'computed_from_request',
+  'computed_from_credits',
+  'account_usage_delta',
+  'unknown',
+]);
+
+export function parseUsage(
+  value: unknown,
+): RunArtifactMeta['usage'] | undefined {
+  if (!isRecord(value)) return undefined;
+  const result: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    costUsd?: number;
+    billableUnits?: number;
+    unit?: string;
+  } = {};
+  for (const key of [
+    'inputTokens',
+    'outputTokens',
+    'totalTokens',
+    'costUsd',
+    'billableUnits',
+  ] as const) {
+    if (value[key] !== undefined && (!finite(value[key]) || value[key] < 0)) {
+      return undefined;
+    }
+    if (value[key] !== undefined) result[key] = value[key];
+  }
+  if (value.unit !== undefined) {
+    if (typeof value.unit !== 'string') return undefined;
+    result.unit = value.unit;
+  }
+  return result;
+}
+
+function tokenUsage(value: unknown): RunArtifactMeta['tokenUsage'] | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.input !== undefined && (!finite(value.input) || value.input < 0)) {
+    return undefined;
+  }
+  if (
+    value.output !== undefined &&
+    (!finite(value.output) || value.output < 0)
+  ) {
+    return undefined;
+  }
+  if (value.input === undefined && value.output === undefined) return undefined;
+  return {
+    ...(value.input === undefined ? {} : { input: value.input }),
+    ...(value.output === undefined ? {} : { output: value.output }),
+  };
+}
+
+export function parseMetering(value: unknown): ProviderMetering | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.kind !== 'string' ||
+    !METERING_KINDS.has(value.kind) ||
+    (value.pricingVersion !== undefined &&
+      typeof value.pricingVersion !== 'string')
+  ) {
+    return undefined;
+  }
+  const result: ProviderMetering = {
+    kind: value.kind as ProviderMetering['kind'],
+    ...(typeof value.pricingVersion === 'string'
+      ? { pricingVersion: value.pricingVersion }
+      : {}),
+  };
+  if (value.estimate !== undefined) {
+    if (!isRecord(value.estimate)) return undefined;
+    const estimate = value.estimate;
+    if (
+      typeof estimate.costConfidence !== 'string' ||
+      !COST_CONFIDENCE.has(estimate.costConfidence) ||
+      (estimate.estimatedCostUsd !== undefined &&
+        (!finite(estimate.estimatedCostUsd) ||
+          estimate.estimatedCostUsd < 0)) ||
+      (estimate.billableUnits !== undefined &&
+        (!finite(estimate.billableUnits) || estimate.billableUnits < 0)) ||
+      (estimate.unit !== undefined && typeof estimate.unit !== 'string') ||
+      (estimate.pricingVersion !== undefined &&
+        typeof estimate.pricingVersion !== 'string')
+    ) {
+      return undefined;
+    }
+    result.estimate = {
+      costConfidence: estimate.costConfidence as CostConfidence,
+      ...(estimate.estimatedCostUsd === undefined
+        ? {}
+        : { estimatedCostUsd: estimate.estimatedCostUsd }),
+      ...(estimate.billableUnits === undefined
+        ? {}
+        : { billableUnits: estimate.billableUnits }),
+      ...(typeof estimate.unit === 'string' ? { unit: estimate.unit } : {}),
+      ...(typeof estimate.pricingVersion === 'string'
+        ? { pricingVersion: estimate.pricingVersion }
+        : {}),
+    };
+  }
+  if (value.actual !== undefined) {
+    if (
+      !isRecord(value.actual) ||
+      typeof value.actual.source !== 'string' ||
+      !ACTUAL_SOURCES.has(value.actual.source) ||
+      (value.actual.costUsd !== undefined &&
+        (!finite(value.actual.costUsd) || value.actual.costUsd < 0)) ||
+      (value.actual.billableUnits !== undefined &&
+        (!finite(value.actual.billableUnits) || value.actual.billableUnits < 0))
+    ) {
+      return undefined;
+    }
+    result.actual = {
+      source: value.actual.source as ActualCostSource,
+      ...(value.actual.costUsd === undefined
+        ? {}
+        : { costUsd: value.actual.costUsd }),
+      ...(value.actual.billableUnits === undefined
+        ? {}
+        : { billableUnits: value.actual.billableUnits }),
+    };
+  }
+  return result;
+}
+
+export function parseMeta(
+  value: unknown,
+  expectedProvider?: string,
+): RunArtifactMeta | null {
+  if (
+    !isRecord(value) ||
+    typeof value.provider !== 'string' ||
+    (expectedProvider !== undefined && value.provider !== expectedProvider) ||
+    !Array.isArray(value.citations)
+  ) {
+    return null;
+  }
+  const citations: Citation[] = [];
+  for (const entry of value.citations) {
+    const parsed = parseCitation(entry, expectedProvider);
+    if (!parsed) return null;
+    citations.push(parsed);
+  }
+  if (
+    value.tier !== undefined &&
+    (typeof value.tier !== 'string' ||
+      !new Set(['deep-research', 'ai-grounded', 'raw-search', 'llm']).has(
+        value.tier,
+      ))
+  ) {
+    return null;
+  }
+  if (value.model !== undefined && typeof value.model !== 'string') return null;
+  if (
+    value.durationMs !== undefined &&
+    (!finite(value.durationMs) || value.durationMs < 0)
+  ) {
+    return null;
+  }
+  if (
+    value.citationCount !== undefined &&
+    (!finite(value.citationCount) || value.citationCount < 0)
+  ) {
+    return null;
+  }
+  const token =
+    value.tokenUsage === undefined ? undefined : tokenUsage(value.tokenUsage);
+  const normalizedUsage =
+    value.usage === undefined ? undefined : parseUsage(value.usage);
+  const normalizedMetering =
+    value.metering === undefined ? undefined : parseMetering(value.metering);
+  if (
+    (value.tokenUsage !== undefined && token === undefined) ||
+    (value.usage !== undefined && normalizedUsage === undefined) ||
+    (value.metering !== undefined && normalizedMetering === undefined)
+  ) {
+    return null;
+  }
+  return {
+    provider: value.provider,
+    ...(value.tier === undefined ? {} : { tier: value.tier }),
+    ...(value.model === undefined ? {} : { model: value.model }),
+    ...(value.durationMs === undefined ? {} : { durationMs: value.durationMs }),
+    ...(value.citationCount === undefined
+      ? {}
+      : { citationCount: value.citationCount }),
+    ...(token === undefined ? {} : { tokenUsage: token }),
+    ...(normalizedUsage === undefined ? {} : { usage: normalizedUsage }),
+    ...(normalizedMetering === undefined
+      ? {}
+      : { metering: normalizedMetering }),
+    citations,
+  };
+}
+
+export function parseSources(value: unknown): DeduplicatedSource[] | null {
+  if (!Array.isArray(value)) return null;
+  const result: DeduplicatedSource[] = [];
+  for (const entry of value) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.url !== 'string' ||
+      typeof entry.normalizedUrl !== 'string' ||
+      !Array.isArray(entry.providers) ||
+      !entry.providers.every((provider) => typeof provider === 'string') ||
+      !finite(entry.citationCount) ||
+      entry.citationCount < 0 ||
+      (entry.title !== undefined && typeof entry.title !== 'string')
+    ) {
+      return null;
+    }
+    result.push({
+      url: entry.url,
+      normalizedUrl: entry.normalizedUrl,
+      providers: [...entry.providers],
+      citationCount: entry.citationCount,
+      ...(entry.title === undefined ? {} : { title: entry.title }),
+    });
+  }
+  return result;
+}
+
+export function wordCount(content: string): number {
+  return content.split(/\s+/).filter(Boolean).length;
+}
+
+export function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export function freezeDeep<T>(value: T): T {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    freezeDeep(child);
+  }
+  return Object.freeze(value);
+}
+
+export function isPathInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return (
+    rel === '' ||
+    (!isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${sep}`))
+  );
+}
+
+export function rejectUnsafeRelativeName(name: string): void {
+  if (
+    !name ||
+    name.split(/[\\/]+/).some((part) => part === '.') ||
+    /[\\/]$/.test(name) ||
+    name.includes('\0') ||
+    isAbsolute(name) ||
+    /^[A-Za-z]:[\\/]/.test(name) ||
+    name.split(/[\\/]+/).some((part) => part === '..')
+  ) {
+    throw new Error(`Unsafe run artifact path: ${name}`);
+  }
+}
+
+export function resolveRunDirectoryWithFs(
+  fs: RunArtifactRepositoryFs,
+  baseDir: string,
+  requested?: string,
+): string | null {
+  try {
+    if (requested?.split(/[\\/]+/).some((part) => part === '..')) {
+      return null;
+    }
+    const base = resolve(baseDir);
+    if (
+      !fs.existsSync(base) ||
+      !fs.statSync(base).isDirectory() ||
+      fs.lstatSync(base).isSymbolicLink()
+    ) {
+      return null;
+    }
+    const candidate =
+      requested === undefined
+        ? base
+        : isAbsolute(requested)
+          ? resolve(requested)
+          : resolve(base, requested);
+    if (
+      !isPathInside(base, candidate) ||
+      !fs.existsSync(candidate) ||
+      !fs.statSync(candidate).isDirectory() ||
+      fs.lstatSync(candidate).isSymbolicLink()
+    ) {
+      return null;
+    }
+    const realBase = fs.realpathSync(base);
+    const realCandidate = fs.realpathSync(candidate);
+    return isPathInside(realBase, realCandidate) ? realCandidate : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveContainedPathWithFs(
+  fs: RunArtifactRepositoryFs,
+  runDir: string,
+  fileName: string,
+): string {
+  rejectUnsafeRelativeName(fileName);
+  const root = resolve(runDir);
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+    throw new Error(`Run directory does not exist: ${runDir}`);
+  }
+  if (fs.lstatSync(root).isSymbolicLink()) {
+    throw new Error(`Run directory must not be a symlink: ${runDir}`);
+  }
+  const realRoot = fs.realpathSync(root);
+  const candidate = resolve(root, fileName);
+  if (!isPathInside(root, candidate)) {
+    throw new Error(`Unsafe run artifact path: ${fileName}`);
+  }
+  const rel = relative(root, candidate);
+  let cursor = root;
+  for (const component of rel.split(sep)) {
+    if (!component) continue;
+    cursor = join(cursor, component);
+    if (!fs.existsSync(cursor)) break;
+    if (fs.lstatSync(cursor).isSymbolicLink()) {
+      throw new Error(
+        `Symlinked run artifact path is not allowed: ${fileName}`,
+      );
+    }
+  }
+  if (
+    fs.existsSync(candidate) &&
+    !isPathInside(realRoot, fs.realpathSync(candidate))
+  ) {
+    throw new Error(`Run artifact path escapes its run directory: ${fileName}`);
+  }
+  return candidate;
+}

--- a/src/node-run-artifact-presentation.ts
+++ b/src/node-run-artifact-presentation.ts
@@ -1,0 +1,57 @@
+/**
+ * Private presentation projection for Node report writers.
+ *
+ * The artifact repository owns filesystem recovery. Report writers consume
+ * this projection without performing a second filesystem read or changing the
+ * durable manifest.
+ */
+import type { RunArtifactSnapshot } from './node-run-artifacts.js';
+
+export interface RunArtifactPresentation {
+  readonly manifest: RunArtifactSnapshot['manifest'];
+  readonly reports: RunArtifactSnapshot['reports'];
+  readonly providerContents: Readonly<Record<string, string>>;
+  readonly sources: RunArtifactSnapshot['sources'];
+  readonly sourceSummary: RunArtifactPresentationSourceSummary;
+  readonly answer?: RunArtifactSnapshot['answer'];
+}
+
+export interface RunArtifactPresentationSourceSummary {
+  readonly total: number;
+  readonly unique: number;
+}
+
+/** Source counts shown beside the persisted source rows in recovery views. */
+export function presentationSourceSummary(
+  snapshot: RunArtifactSnapshot,
+): RunArtifactPresentationSourceSummary {
+  return {
+    total: snapshot.sources.reduce(
+      (total, source) => total + source.citationCount,
+      0,
+    ),
+    unique: snapshot.sources.length,
+  };
+}
+
+export function projectRunArtifactSnapshot(
+  snapshot: RunArtifactSnapshot,
+): RunArtifactPresentation {
+  const providerEntries: Array<[string, string]> = [];
+  for (const report of snapshot.reports) {
+    if (!report.outputFile) continue;
+    const content = snapshot.providerArtifacts[report.id]?.content;
+    if (content !== undefined) {
+      providerEntries.push([report.outputFile, content]);
+    }
+  }
+
+  return {
+    manifest: snapshot.manifest,
+    reports: snapshot.reports,
+    providerContents: Object.fromEntries(providerEntries),
+    sources: snapshot.sources,
+    sourceSummary: presentationSourceSummary(snapshot),
+    ...(snapshot.answer === undefined ? {} : { answer: snapshot.answer }),
+  };
+}

--- a/src/node-run-artifacts.ts
+++ b/src/node-run-artifacts.ts
@@ -12,9 +12,12 @@ import { safeWriteFile as defaultSafeWriteFile } from './core/fs-utils.js';
 import { deduplicateSources } from './core/normalizer.js';
 import {
   applyRunLifecycle,
+  createRunManifest,
+  markRunFailed,
   mutateRunManifest,
   RunManifestError,
   readRunManifest,
+  upsertProviderReport,
 } from './core/run-manifest.js';
 import type {
   RunArtifactDiscovery,
@@ -39,6 +42,7 @@ import {
   wordCount,
 } from './node-run-artifact-codecs.js';
 import type {
+  AsyncTaskHandle,
   Citation,
   DeduplicatedSource,
   ProviderMetering,
@@ -229,7 +233,10 @@ export interface RunArtifactRepositoryOptions {
   readonly fs?: Partial<RunArtifactRepositoryFs>;
   readonly writeFile?: (path: string, content: string) => void;
   readonly readManifest?: typeof readRunManifest;
+  readonly createManifest?: typeof createRunManifest;
   readonly mutateManifest?: typeof mutateRunManifest;
+  readonly upsertProviderReport?: typeof upsertProviderReport;
+  readonly markFailed?: typeof markRunFailed;
   readonly now?: () => number;
 }
 
@@ -248,14 +255,21 @@ export class RunArtifactRepository {
   private readonly fs: RunArtifactRepositoryFs;
   private readonly writeFile: (path: string, content: string) => void;
   private readonly readManifestImpl: typeof readRunManifest;
+  private readonly createManifestImpl: typeof createRunManifest;
   private readonly mutateManifestImpl: typeof mutateRunManifest;
+  private readonly upsertProviderReportImpl: typeof upsertProviderReport;
+  private readonly markFailedImpl: typeof markRunFailed;
   private readonly now: () => number;
 
   constructor(options: RunArtifactRepositoryOptions = {}) {
     this.fs = { ...DEFAULT_FS, ...(options.fs ?? {}) };
     this.writeFile = options.writeFile ?? defaultSafeWriteFile;
     this.readManifestImpl = options.readManifest ?? readRunManifest;
+    this.createManifestImpl = options.createManifest ?? createRunManifest;
     this.mutateManifestImpl = options.mutateManifest ?? mutateRunManifest;
+    this.upsertProviderReportImpl =
+      options.upsertProviderReport ?? upsertProviderReport;
+    this.markFailedImpl = options.markFailed ?? markRunFailed;
     this.now = options.now ?? Date.now;
   }
 
@@ -265,6 +279,41 @@ export class RunArtifactRepository {
 
   resolveContainedPath(runDir: string, fileName: string): string {
     return resolveContainedPathWithFs(this.fs, runDir, fileName);
+  }
+
+  create(
+    runDir: string,
+    manifest: Omit<RunManifest, 'schemaVersion' | 'revision'>,
+  ): RunManifest {
+    const safeRunDir = this.assertRunDirectory(runDir);
+    this.resolveContainedPath(safeRunDir, fixedFile('manifest'));
+    return this.createManifestImpl(safeRunDir, manifest);
+  }
+
+  mutate(
+    runDir: string,
+    mutate: (manifest: RunManifest) => void,
+    expectedRevision?: number,
+  ): RunManifest {
+    const safeRunDir = this.assertRunDirectory(runDir);
+    this.resolveContainedPath(safeRunDir, fixedFile('manifest'));
+    return this.mutateManifestImpl(safeRunDir, mutate, expectedRevision);
+  }
+
+  upsertProviderReport(
+    runDir: string,
+    report: ProviderReport,
+    task?: AsyncTaskHandle,
+  ): RunManifest {
+    const safeRunDir = this.assertRunDirectory(runDir);
+    this.resolveContainedPath(safeRunDir, fixedFile('manifest'));
+    return this.upsertProviderReportImpl(safeRunDir, report, task);
+  }
+
+  markFailed(runDir: string, error: string, now = Date.now()): RunManifest {
+    const safeRunDir = this.assertRunDirectory(runDir);
+    this.resolveContainedPath(safeRunDir, fixedFile('manifest'));
+    return this.markFailedImpl(safeRunDir, error, now);
   }
 
   readManifest(runDir: string): RunManifest {

--- a/src/node-run-artifacts.ts
+++ b/src/node-run-artifacts.ts
@@ -45,6 +45,7 @@ import type {
   ProviderReport,
   ProviderUsage,
   RunManifest,
+  RunTaskState,
 } from './types.js';
 
 export type {
@@ -70,6 +71,22 @@ export interface CommitRetrievedInput {
   readonly now?: number;
 }
 
+/**
+ * The subset of durable task fields that a poll reconciliation may mutate.
+ * Retrieval timestamps are intentionally owned by commitRetrieved so a poll
+ * cannot accidentally mark a task as retrieved.
+ */
+export type RunArtifactTaskUpdate = Partial<
+  Pick<
+    RunTaskState,
+    | 'status'
+    | 'lastPolledAt'
+    | 'completedAt'
+    | 'providerStatus'
+    | 'lastPollError'
+  >
+>;
+
 interface ValidatedReportFields {
   readonly tier: ProviderReport['tier'];
   readonly durationMs: number;
@@ -83,6 +100,9 @@ interface ValidatedReportFields {
 }
 
 const RETRIEVED_SENTINEL = Symbol('run-artifact-already-retrieved');
+const TASK_ALREADY_RETRIEVED_SENTINEL = Symbol(
+  'run-artifact-task-already-retrieved',
+);
 
 const RESERVED_ARTIFACT_NAMES = new Set([
   'run.json',
@@ -140,6 +160,39 @@ function assertKnownKeys(
 
 function sameValue(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function isTerminalTaskStatus(status: string): boolean {
+  return (
+    status === 'completed' || status === 'failed' || status === 'cancelled'
+  );
+}
+
+function assertUniqueManifestIdentities(
+  manifest: RunManifest,
+  runDir: string,
+): void {
+  const providerIds = new Set<string>();
+  const taskIds = new Set<string>();
+  for (const report of manifest.providers) {
+    if (providerIds.has(report.id)) {
+      throw new RunManifestError(
+        `Run manifest contains duplicate provider ID ${report.id}`,
+        resolve(runDir, 'run.json'),
+      );
+    }
+    providerIds.add(report.id);
+    if (report.task) {
+      const key = `${report.id}\u0000${report.task.taskId}`;
+      if (taskIds.has(key)) {
+        throw new RunManifestError(
+          `Run manifest contains duplicate provider task ${report.id}/${report.task.taskId}`,
+          resolve(runDir, 'run.json'),
+        );
+      }
+      taskIds.add(key);
+    }
+  }
 }
 
 export interface ProviderArtifactFileNames {
@@ -212,7 +265,9 @@ export class RunArtifactRepository {
     // Validate the manifest path through the same containment gate as every
     // declared artifact before delegating strict parsing/error semantics.
     this.resolveContainedPath(safeRunDir, fixedFile('manifest'));
-    return this.readManifestImpl(safeRunDir);
+    const manifest = this.readManifestImpl(safeRunDir);
+    assertUniqueManifestIdentities(manifest, safeRunDir);
+    return manifest;
   }
 
   tryReadManifest(runDir: string): RunManifest | null {
@@ -463,6 +518,182 @@ export class RunArtifactRepository {
 
   hasArtifact(runDir: string, fileName: string): boolean {
     return this.hasArtifactResolved(this.assertRunDirectory(runDir), fileName);
+  }
+
+  /**
+   * Persist one poll/reconciliation update under the manifest mutation lock.
+   * This is deliberately narrower than the core manifest mutators: callers
+   * cannot provide arbitrary report fields, output paths, or retrieval state.
+   * The lifecycle timestamp is supplied by the caller so a reconciliation
+   * pass can use its injected clock deterministically.
+   */
+  updateTask(
+    runDir: string,
+    providerId: string,
+    taskId: string,
+    updates: RunArtifactTaskUpdate,
+    now: number,
+  ): RunArtifactSnapshot {
+    const canonicalRunDir = this.assertRunDirectory(runDir);
+    this.assertMutationTimestamp(now);
+    this.validateTaskUpdate(updates);
+    const before = this.readManifest(canonicalRunDir);
+    const target = before.providers.find(
+      (report) => report.id === providerId && report.task?.taskId === taskId,
+    );
+    if (!target?.task) {
+      throw new Error(
+        `Task ${providerId}/${taskId} is not recorded in run.json`,
+      );
+    }
+    if (
+      target.task.retrievedAt !== undefined ||
+      isTerminalTaskStatus(target.task.status)
+    ) {
+      return this.readSnapshot(canonicalRunDir, { view: 'authoritative' });
+    }
+    try {
+      this.mutateManifestImpl(canonicalRunDir, (manifest) => {
+        const index = manifest.providers.findIndex(
+          (report) =>
+            report.id === providerId && report.task?.taskId === taskId,
+        );
+        if (index < 0) {
+          throw new Error(
+            `Task ${providerId}/${taskId} is not recorded in run.json`,
+          );
+        }
+        const report = manifest.providers[index];
+        const task = report?.task;
+        if (!report || !task) {
+          throw new Error(
+            `Task ${providerId}/${taskId} has no durable task state`,
+          );
+        }
+        if (
+          task.retrievedAt !== undefined ||
+          isTerminalTaskStatus(task.status)
+        ) {
+          throw TASK_ALREADY_RETRIEVED_SENTINEL;
+        }
+        if (task.status === 'running' && updates.status === 'pending') {
+          throw TASK_ALREADY_RETRIEVED_SENTINEL;
+        }
+        const nextUpdates = { ...updates };
+        if (
+          nextUpdates.lastPolledAt !== undefined &&
+          task.lastPolledAt !== undefined
+        ) {
+          nextUpdates.lastPolledAt = Math.max(
+            task.lastPolledAt,
+            nextUpdates.lastPolledAt,
+          );
+        }
+        if (
+          nextUpdates.completedAt !== undefined &&
+          task.completedAt !== undefined
+        ) {
+          nextUpdates.completedAt = Math.max(
+            task.completedAt,
+            nextUpdates.completedAt,
+          );
+        }
+        report.task = { ...task, ...nextUpdates };
+        if (
+          report.task.status === 'failed' ||
+          report.task.status === 'cancelled'
+        ) {
+          report.status = 'error';
+          report.error =
+            report.task.lastPollError ??
+            (report.task.status === 'cancelled'
+              ? 'Task was cancelled'
+              : 'Task failed');
+        }
+        applyRunLifecycle(manifest, now);
+      });
+    } catch (error) {
+      if (error === TASK_ALREADY_RETRIEVED_SENTINEL) {
+        return this.readSnapshot(canonicalRunDir, { view: 'authoritative' });
+      }
+      throw error;
+    }
+    return this.readSnapshot(canonicalRunDir, { view: 'authoritative' });
+  }
+
+  /**
+   * Terminalize a task whose exact background provider is no longer available.
+   * This is intentionally separate from updateTask's monotonic poll lane so a
+   * completed-but-unretrieved task can be failed once without allowing stale
+   * poll updates to regress any terminal state.
+   */
+  failUnretrievedTask(
+    runDir: string,
+    providerId: string,
+    taskId: string,
+    now: number,
+  ): RunArtifactSnapshot {
+    const canonicalRunDir = this.assertRunDirectory(runDir);
+    this.assertMutationTimestamp(now);
+    const before = this.readManifest(canonicalRunDir);
+    const target = before.providers.find(
+      (report) => report.id === providerId && report.task?.taskId === taskId,
+    );
+    if (!target?.task) {
+      throw new Error(
+        `Task ${providerId}/${taskId} is not recorded in run.json`,
+      );
+    }
+    if (
+      target.task.retrievedAt !== undefined ||
+      target.task.status === 'failed' ||
+      target.task.status === 'cancelled'
+    ) {
+      return this.readSnapshot(canonicalRunDir, { view: 'authoritative' });
+    }
+    try {
+      this.mutateManifestImpl(canonicalRunDir, (manifest) => {
+        const index = manifest.providers.findIndex(
+          (report) =>
+            report.id === providerId && report.task?.taskId === taskId,
+        );
+        if (index < 0) {
+          throw new Error(
+            `Task ${providerId}/${taskId} is not recorded in run.json`,
+          );
+        }
+        const report = manifest.providers[index];
+        const task = report?.task;
+        if (!report || !task) {
+          throw new Error(
+            `Task ${providerId}/${taskId} has no durable task state`,
+          );
+        }
+        if (
+          task.retrievedAt !== undefined ||
+          task.status === 'failed' ||
+          task.status === 'cancelled'
+        ) {
+          throw TASK_ALREADY_RETRIEVED_SENTINEL;
+        }
+        report.task = {
+          ...task,
+          status: 'failed',
+          completedAt: task.completedAt ?? now,
+          providerStatus: 'unsupported_provider',
+          lastPollError: 'provider.unavailable',
+        };
+        report.status = 'error';
+        report.error = 'provider.unavailable';
+        applyRunLifecycle(manifest, now);
+      });
+    } catch (error) {
+      if (error === TASK_ALREADY_RETRIEVED_SENTINEL) {
+        return this.readSnapshot(canonicalRunDir, { view: 'authoritative' });
+      }
+      throw error;
+    }
+    return this.readSnapshot(canonicalRunDir, { view: 'authoritative' });
   }
 
   /**
@@ -759,6 +990,48 @@ export class RunArtifactRepository {
         : {}),
       ...(report.preventFallback === true ? { preventFallback: true } : {}),
     };
+  }
+
+  private assertMutationTimestamp(value: number): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(
+        'Manifest mutation timestamp must be a finite nonnegative safe integer',
+      );
+    }
+  }
+
+  private validateTaskUpdate(updates: RunArtifactTaskUpdate): void {
+    if (!isRecord(updates)) throw new Error('Task update must be an object');
+    assertKnownKeys(
+      updates,
+      new Set([
+        'status',
+        'lastPolledAt',
+        'completedAt',
+        'providerStatus',
+        'lastPollError',
+      ]),
+      'task update',
+    );
+    if (
+      updates.status !== undefined &&
+      (typeof updates.status !== 'string' || !TASK_STATUSES.has(updates.status))
+    ) {
+      throw new Error('Task update status is invalid');
+    }
+    for (const key of ['lastPolledAt', 'completedAt'] as const) {
+      if (updates[key] !== undefined && !Number.isSafeInteger(updates[key])) {
+        throw new Error(`Task update ${key} is invalid`);
+      }
+      if (updates[key] !== undefined && updates[key] < 0) {
+        throw new Error(`Task update ${key} is invalid`);
+      }
+    }
+    for (const key of ['providerStatus', 'lastPollError'] as const) {
+      if (updates[key] !== undefined && !isSafeString(updates[key])) {
+        throw new Error(`Task update ${key} is unsafe`);
+      }
+    }
   }
 
   private validateInputTask(value: unknown): void {

--- a/src/node-run-artifacts.ts
+++ b/src/node-run-artifacts.ts
@@ -71,6 +71,13 @@ export interface CommitRetrievedInput {
   readonly now?: number;
 }
 
+/** Outcome of one retrieval commit attempt. */
+export interface CommitRetrievedResult {
+  readonly snapshot: RunArtifactSnapshot;
+  /** True only when this invocation committed artifacts and run.json. */
+  readonly committed: boolean;
+}
+
 /**
  * The subset of durable task fields that a poll reconciliation may mutate.
  * Retrieval timestamps are intentionally owned by commitRetrieved so a poll
@@ -702,7 +709,7 @@ export class RunArtifactRepository {
    * metadata can survive a retry, but a task is never marked retrieved until
    * the source rebuild and manifest commit both succeed.
    */
-  commitRetrieved(input: CommitRetrievedInput): RunArtifactSnapshot {
+  commitRetrieved(input: CommitRetrievedInput): CommitRetrievedResult {
     const runDir = this.assertRunDirectory(input.runDir);
     const commitNow = input.now ?? this.now();
     if (!Number.isSafeInteger(commitNow) || commitNow < 0) {
@@ -730,7 +737,10 @@ export class RunArtifactRepository {
       );
     }
     if (beforeTarget.task?.retrievedAt !== undefined) {
-      return this.readSnapshot(runDir, { view: 'authoritative' });
+      return {
+        snapshot: this.readSnapshot(runDir, { view: 'authoritative' }),
+        committed: false,
+      };
     }
     if (beforeTarget.task?.status !== 'completed') {
       throw new Error(
@@ -846,11 +856,17 @@ export class RunArtifactRepository {
       });
     } catch (error) {
       if (error === RETRIEVED_SENTINEL) {
-        return this.readSnapshot(runDir, { view: 'authoritative' });
+        return {
+          snapshot: this.readSnapshot(runDir, { view: 'authoritative' }),
+          committed: false,
+        };
       }
       throw error;
     }
-    return this.readSnapshot(runDir, { view: 'authoritative' });
+    return {
+      snapshot: this.readSnapshot(runDir, { view: 'authoritative' }),
+      committed: true,
+    };
   }
 
   private validateCommittedReport(

--- a/src/node-run-artifacts.ts
+++ b/src/node-run-artifacts.ts
@@ -1380,7 +1380,13 @@ export class RunArtifactRepository {
     const content = this.readTextArtifact(runDir, outputFile);
     if (content === undefined) return null;
     const metaFile = `${safeId}.meta.json`;
-    const meta = parseMeta(this.readJsonArtifact(runDir, metaFile), report.id);
+    const parsedMeta = parseMeta(
+      this.readJsonArtifact(runDir, metaFile),
+      report.id,
+    );
+    const meta = parsedMeta
+      ? { ...parsedMeta, citationCount: parsedMeta.citations.length }
+      : null;
     const recoveredReport: ProviderReport = {
       ...report,
       status: 'success',
@@ -1390,11 +1396,7 @@ export class RunArtifactRepository {
       ...(meta?.durationMs !== undefined
         ? { durationMs: meta.durationMs }
         : {}),
-      ...(meta?.citationCount !== undefined
-        ? { citationCount: meta.citationCount }
-        : meta
-          ? { citationCount: meta.citations.length }
-          : {}),
+      ...(meta ? { citationCount: meta.citations.length } : {}),
       ...(meta?.usage !== undefined ? { usage: meta.usage } : {}),
       ...(meta?.metering !== undefined ? { metering: meta.metering } : {}),
     };

--- a/src/node-run-artifacts.ts
+++ b/src/node-run-artifacts.ts
@@ -1,0 +1,1072 @@
+/**
+ * Private Node-only access to the v2 run artifact store.
+ *
+ * This module deliberately does not appear in a package entry point. The
+ * worker-safe core owns the manifest shape and mutation primitives; this
+ * service owns the filesystem boundary around those primitives.
+ */
+import { createHash } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import { sanitizeId } from './constants.js';
+import { safeWriteFile as defaultSafeWriteFile } from './core/fs-utils.js';
+import { deduplicateSources } from './core/normalizer.js';
+import {
+  applyRunLifecycle,
+  mutateRunManifest,
+  RunManifestError,
+  readRunManifest,
+} from './core/run-manifest.js';
+import type {
+  RunArtifactDiscovery,
+  RunArtifactMeta,
+  RunArtifactMetaInput,
+  RunArtifactPresence,
+  RunArtifactProviderArtifact,
+  RunArtifactRepositoryFs,
+  RunArtifactSnapshot,
+} from './node-run-artifact-codecs.js';
+import {
+  clone,
+  DEFAULT_FS,
+  fixedFile,
+  freezeDeep,
+  parseMeta,
+  parseMetering,
+  parseSources,
+  parseUsage,
+  resolveContainedPathWithFs,
+  resolveRunDirectoryWithFs,
+  wordCount,
+} from './node-run-artifact-codecs.js';
+import type {
+  Citation,
+  DeduplicatedSource,
+  ProviderMetering,
+  ProviderReport,
+  ProviderUsage,
+  RunManifest,
+} from './types.js';
+
+export type {
+  RunArtifactAnswer,
+  RunArtifactDiscovery,
+  RunArtifactMeta,
+  RunArtifactMetaInput,
+  RunArtifactPresence,
+  RunArtifactProviderArtifact,
+  RunArtifactRepositoryFs,
+  RunArtifactSnapshot,
+} from './node-run-artifact-codecs.js';
+
+export type RunArtifactView = 'authoritative' | 'recovery';
+
+export interface CommitRetrievedInput {
+  readonly runDir: string;
+  readonly providerId: string;
+  readonly taskId: string;
+  readonly report: ProviderReport;
+  readonly content: string;
+  readonly meta: RunArtifactMetaInput;
+  readonly now?: number;
+}
+
+interface ValidatedReportFields {
+  readonly tier: ProviderReport['tier'];
+  readonly durationMs: number;
+  readonly wordCount: number;
+  readonly citationCount: number;
+  readonly usage?: ProviderUsage;
+  readonly metering?: ProviderMetering;
+  readonly error?: string;
+  readonly fallbackFor?: string;
+  readonly preventFallback?: true;
+}
+
+const RETRIEVED_SENTINEL = Symbol('run-artifact-already-retrieved');
+
+const RESERVED_ARTIFACT_NAMES = new Set([
+  'run.json',
+  'run.json.lock',
+  'prompt.md',
+  'summary.md',
+  'sources.json',
+  'answer.md',
+  'report.html',
+  'results.jsonl',
+]);
+
+const REPORT_TIERS = new Set([
+  'deep-research',
+  'ai-grounded',
+  'raw-search',
+  'llm',
+]);
+const TASK_STATUSES = new Set([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNonnegative(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isSafeString(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= 512 &&
+    ![...value].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 0x20 || code === 0x7f;
+    })
+  );
+}
+
+function assertKnownKeys(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  label: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`Unknown ${label} field: ${key}`);
+  }
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export interface ProviderArtifactFileNames {
+  readonly outputFile: string;
+  readonly metaFile: string;
+}
+
+/** Collision-resistant names for all newly written provider artifacts. */
+export function providerArtifactFileNames(
+  providerId: string,
+): ProviderArtifactFileNames {
+  const stem = sanitizeId(providerId).slice(0, 64) || 'provider';
+  const digest = createHash('sha256').update(providerId, 'utf8').digest('hex');
+  return {
+    outputFile: `provider-${stem}--${digest}.md`,
+    metaFile: `provider-${stem}--${digest}.meta.json`,
+  };
+}
+
+function legacyStemKey(providerId: string): string {
+  return sanitizeId(providerId).replace(/[A-Z]/g, (character) =>
+    character.toLowerCase(),
+  );
+}
+
+export interface RunArtifactRepositoryOptions {
+  readonly fs?: Partial<RunArtifactRepositoryFs>;
+  readonly writeFile?: (path: string, content: string) => void;
+  readonly readManifest?: typeof readRunManifest;
+  readonly mutateManifest?: typeof mutateRunManifest;
+  readonly now?: () => number;
+}
+
+export function resolveRunDirectory(
+  baseDir: string,
+  requested?: string,
+): string | null {
+  return resolveRunDirectoryWithFs(DEFAULT_FS, baseDir, requested);
+}
+
+export function resolveContainedPath(runDir: string, fileName: string): string {
+  return resolveContainedPathWithFs(DEFAULT_FS, runDir, fileName);
+}
+/** Private Node-only v2 run artifact repository. */
+export class RunArtifactRepository {
+  private readonly fs: RunArtifactRepositoryFs;
+  private readonly writeFile: (path: string, content: string) => void;
+  private readonly readManifestImpl: typeof readRunManifest;
+  private readonly mutateManifestImpl: typeof mutateRunManifest;
+  private readonly now: () => number;
+
+  constructor(options: RunArtifactRepositoryOptions = {}) {
+    this.fs = { ...DEFAULT_FS, ...(options.fs ?? {}) };
+    this.writeFile = options.writeFile ?? defaultSafeWriteFile;
+    this.readManifestImpl = options.readManifest ?? readRunManifest;
+    this.mutateManifestImpl = options.mutateManifest ?? mutateRunManifest;
+    this.now = options.now ?? Date.now;
+  }
+
+  resolveRunDirectory(baseDir: string, requested?: string): string | null {
+    return resolveRunDirectoryWithFs(this.fs, baseDir, requested);
+  }
+
+  resolveContainedPath(runDir: string, fileName: string): string {
+    return resolveContainedPathWithFs(this.fs, runDir, fileName);
+  }
+
+  readManifest(runDir: string): RunManifest {
+    const safeRunDir = this.assertRunDirectory(runDir);
+    // Validate the manifest path through the same containment gate as every
+    // declared artifact before delegating strict parsing/error semantics.
+    this.resolveContainedPath(safeRunDir, fixedFile('manifest'));
+    return this.readManifestImpl(safeRunDir);
+  }
+
+  tryReadManifest(runDir: string): RunManifest | null {
+    try {
+      return this.readManifest(runDir);
+    } catch {
+      return null;
+    }
+  }
+
+  discoverRuns(baseDir: string, limit = 20): readonly RunArtifactDiscovery[] {
+    const base = this.resolveRunDirectory(baseDir);
+    if (!base) return [];
+    let names: string[];
+    try {
+      names = this.fs.readdirSync(base);
+    } catch {
+      return [];
+    }
+    const entries: RunArtifactDiscovery[] = [];
+    for (const name of names) {
+      const runDir = this.resolveRunDirectory(base, name);
+      if (!runDir || runDir === base) continue;
+      try {
+        const manifest = this.readManifest(runDir);
+        entries.push({ runDir, manifest: freezeDeep(clone(manifest)) });
+      } catch {
+        // Discovery is intentionally best-effort. Strict consumers call
+        // readManifest/readSnapshot directly and retain RunManifestError.
+      }
+    }
+    entries.sort((a, b) => b.manifest.timestamp - a.manifest.timestamp);
+    return entries.slice(0, Math.max(0, limit));
+  }
+
+  readSnapshot(
+    runDir: string,
+    options: { readonly view?: RunArtifactView } | RunArtifactView = {},
+  ): RunArtifactSnapshot {
+    const view =
+      typeof options === 'string' ? options : (options.view ?? 'authoritative');
+    const canonicalRunDir = this.assertRunDirectory(runDir);
+    const manifest = this.readManifest(runDir);
+    const reports = manifest.providers.map((report) => clone(report));
+    const artifactEntries: Array<[string, RunArtifactProviderArtifact]> = [];
+
+    for (const report of reports) {
+      const artifact = this.readDeclaredProviderArtifact(
+        canonicalRunDir,
+        report,
+      );
+      artifactEntries.push([report.id, artifact]);
+    }
+
+    if (view === 'recovery') {
+      const legacyStemCounts = new Map<string, number>();
+      for (const report of reports) {
+        const stem = legacyStemKey(report.id);
+        legacyStemCounts.set(stem, (legacyStemCounts.get(stem) ?? 0) + 1);
+      }
+      for (let index = 0; index < reports.length; index++) {
+        const report = reports[index];
+        if (!report || !this.isRecoveryCandidate(report)) continue;
+        const recovered = this.readRecoveryArtifact(
+          canonicalRunDir,
+          report,
+          legacyStemCounts.get(legacyStemKey(report.id)) === 1,
+        );
+        if (!recovered) continue;
+        reports[index] = recovered.report;
+        const artifactIndex = artifactEntries.findLastIndex(
+          ([providerId]) => providerId === report.id,
+        );
+        if (artifactIndex >= 0) {
+          artifactEntries[artifactIndex] = [report.id, recovered.artifact];
+        }
+      }
+    }
+
+    const providerArtifacts = Object.fromEntries(artifactEntries);
+
+    const prompt = this.readTextArtifact(canonicalRunDir, fixedFile('prompt'));
+    const summary = this.readTextArtifact(
+      canonicalRunDir,
+      fixedFile('summary'),
+    );
+    const answerContent = this.readTextArtifact(
+      canonicalRunDir,
+      fixedFile('answer'),
+    );
+    const answer =
+      answerContent === undefined
+        ? undefined
+        : {
+            content: answerContent,
+            ...(manifest.answer?.provider
+              ? { provider: manifest.answer.provider }
+              : {}),
+            ...(manifest.answer?.model ? { model: manifest.answer.model } : {}),
+          };
+    const persistedSources = this.readSourcesFile(canonicalRunDir, manifest);
+    const sources = persistedSources;
+    const artifactPresence: RunArtifactPresence = {
+      manifest: true,
+      prompt: this.hasArtifactResolved(canonicalRunDir, fixedFile('prompt')),
+      summary: this.hasArtifactResolved(canonicalRunDir, fixedFile('summary')),
+      sources: this.hasArtifactResolved(
+        canonicalRunDir,
+        this.sourceFile(manifest),
+      ),
+      answer: this.hasArtifactResolved(canonicalRunDir, fixedFile('answer')),
+    };
+    return freezeDeep({
+      runDir: canonicalRunDir,
+      manifest: clone(manifest),
+      reports,
+      providerArtifacts,
+      sources,
+      ...(answer !== undefined ? { answer } : {}),
+      ...(prompt !== undefined ? { prompt } : {}),
+      ...(summary !== undefined ? { summary } : {}),
+      artifactPresence,
+    });
+  }
+
+  tryReadSnapshot(
+    runDir: string,
+    options: { readonly view?: RunArtifactView } | RunArtifactView = {},
+  ): RunArtifactSnapshot | null {
+    try {
+      return this.readSnapshot(runDir, options);
+    } catch {
+      return null;
+    }
+  }
+
+  readPrompt(runDir: string): string | null {
+    return (
+      this.readTextArtifact(
+        this.assertRunDirectory(runDir),
+        fixedFile('prompt'),
+      ) ?? null
+    );
+  }
+
+  writePrompt(runDir: string, content: string): void {
+    this.writeTextArtifact(runDir, fixedFile('prompt'), content);
+  }
+
+  readSummary(runDir: string): string | null {
+    return (
+      this.readTextArtifact(
+        this.assertRunDirectory(runDir),
+        fixedFile('summary'),
+      ) ?? null
+    );
+  }
+
+  writeSummary(runDir: string, content: string): void {
+    this.writeTextArtifact(runDir, fixedFile('summary'), content);
+  }
+
+  readAnswer(runDir: string): string | null {
+    return (
+      this.readTextArtifact(
+        this.assertRunDirectory(runDir),
+        fixedFile('answer'),
+      ) ?? null
+    );
+  }
+
+  writeAnswer(runDir: string, content: string): void {
+    this.writeTextArtifact(runDir, fixedFile('answer'), content);
+  }
+
+  readProviderContent(
+    runDir: string,
+    provider: string | Pick<ProviderReport, 'id' | 'outputFile'>,
+  ): string | null {
+    const fileName =
+      typeof provider === 'string'
+        ? providerArtifactFileNames(provider).outputFile
+        : provider.outputFile;
+    if (!fileName) return null;
+    return (
+      this.readTextArtifact(this.assertRunDirectory(runDir), fileName) ?? null
+    );
+  }
+
+  writeProviderContent(
+    runDir: string,
+    providerId: string,
+    content: string,
+  ): void {
+    this.writeTextArtifact(
+      runDir,
+      providerArtifactFileNames(providerId).outputFile,
+      content,
+    );
+  }
+
+  readProviderMeta(
+    runDir: string,
+    provider: string | Pick<ProviderReport, 'id' | 'metaFile'>,
+  ): RunArtifactMeta | null {
+    const providerId = typeof provider === 'string' ? provider : provider.id;
+    const fileName =
+      typeof provider === 'string'
+        ? providerArtifactFileNames(provider).metaFile
+        : provider.metaFile;
+    if (!fileName) return null;
+    const raw = this.readJsonArtifact(
+      this.assertRunDirectory(runDir),
+      fileName,
+    );
+    return raw === undefined ? null : parseMeta(raw, providerId);
+  }
+
+  writeProviderMeta(
+    runDir: string,
+    providerId: string,
+    meta: RunArtifactMetaInput,
+  ): void {
+    if (meta.provider !== undefined && meta.provider !== providerId) {
+      throw new Error(`Provider metadata does not match ${providerId}`);
+    }
+    const candidate = { provider: providerId, ...meta };
+    const validated = parseMeta(candidate, providerId);
+    if (!validated)
+      throw new Error(`Invalid metadata for provider ${providerId}`);
+    this.writeJsonArtifact(
+      runDir,
+      providerArtifactFileNames(providerId).metaFile,
+      validated,
+    );
+  }
+
+  readSources(runDir: string): readonly DeduplicatedSource[] {
+    const manifest = this.readManifest(runDir);
+    return this.readSourcesFile(this.assertRunDirectory(runDir), manifest);
+  }
+
+  writeSources(runDir: string, sources: readonly DeduplicatedSource[]): void {
+    const parsed = parseSources(sources);
+    if (!parsed) throw new Error('Invalid canonical sources');
+    this.writeJsonArtifact(runDir, fixedFile('sources'), parsed);
+  }
+
+  hasArtifact(runDir: string, fileName: string): boolean {
+    return this.hasArtifactResolved(this.assertRunDirectory(runDir), fileName);
+  }
+
+  /**
+   * Write one completed provider result and fold it into run.json under the
+   * existing manifest lock.  The write-ahead order is deliberate: output and
+   * metadata can survive a retry, but a task is never marked retrieved until
+   * the source rebuild and manifest commit both succeed.
+   */
+  commitRetrieved(input: CommitRetrievedInput): RunArtifactSnapshot {
+    const runDir = this.assertRunDirectory(input.runDir);
+    const commitNow = input.now ?? this.now();
+    if (!Number.isSafeInteger(commitNow) || commitNow < 0) {
+      throw new Error(
+        'Retrieved commit timestamp must be a finite nonnegative safe integer',
+      );
+    }
+    if (input.report.id !== input.providerId) {
+      throw new Error('Retrieved report provider does not match providerId');
+    }
+    if (input.report.status !== 'success') {
+      throw new Error('Retrieved report must have success status');
+    }
+    // A successful retrieval is idempotent.  Avoid rewriting artifacts when a
+    // caller retries after the task has already been folded into run.json.
+    const beforeWrite = this.readManifest(runDir);
+    const beforeTarget = beforeWrite.providers.find(
+      (candidate) =>
+        candidate.id === input.providerId &&
+        candidate.task?.taskId === input.taskId,
+    );
+    if (!beforeTarget) {
+      throw new Error(
+        `Task ${input.providerId}/${input.taskId} is not recorded in run.json`,
+      );
+    }
+    if (beforeTarget.task?.retrievedAt !== undefined) {
+      return this.readSnapshot(runDir, { view: 'authoritative' });
+    }
+    if (beforeTarget.task?.status !== 'completed') {
+      throw new Error(
+        `Task ${input.providerId}/${input.taskId} is not completed`,
+      );
+    }
+    const generatedNames = providerArtifactFileNames(input.providerId);
+    const { outputFile, metaFile } = generatedNames;
+    this.validateGeneratedName(input.providerId, outputFile, metaFile);
+    if (
+      input.report.outputFile !== outputFile ||
+      input.report.metaFile !== metaFile
+    ) {
+      throw new Error(
+        `Retrieved report must use generated artifact names ${outputFile} and ${metaFile}`,
+      );
+    }
+    this.assertNoArtifactCollision(
+      beforeWrite,
+      input.providerId,
+      input.taskId,
+      outputFile,
+      metaFile,
+    );
+    // Validate every write target and the metadata before any write-ahead file
+    // is created. This makes malformed input fail without leaving artifacts.
+    this.resolveContainedPath(runDir, outputFile);
+    this.resolveContainedPath(runDir, metaFile);
+    if (beforeWrite.sources.file !== fixedFile('sources')) {
+      throw new Error(
+        'Retrieved commits require sources.json as the source file',
+      );
+    }
+    this.resolveContainedPath(runDir, fixedFile('sources'));
+    const validatedMeta = parseMeta(
+      { provider: input.providerId, ...input.meta },
+      input.providerId,
+    );
+    if (!validatedMeta) {
+      throw new Error(`Invalid metadata for provider ${input.providerId}`);
+    }
+    const validatedReport = this.validateCommittedReport(input, validatedMeta);
+    try {
+      this.mutateManifestImpl(runDir, (manifest) => {
+        const index = manifest.providers.findIndex(
+          (candidate) =>
+            candidate.id === input.providerId &&
+            candidate.task?.taskId === input.taskId,
+        );
+        if (index < 0) {
+          throw new Error(
+            `Task ${input.providerId}/${input.taskId} is not recorded in run.json`,
+          );
+        }
+        const current = manifest.providers[index];
+        const task = current?.task;
+        if (!task) {
+          throw new Error(
+            `Task ${input.providerId}/${input.taskId} has no durable task state`,
+          );
+        }
+        if (task.retrievedAt !== undefined) throw RETRIEVED_SENTINEL;
+        if (task.status !== 'completed') {
+          throw new Error(
+            `Task ${input.providerId}/${input.taskId} is not completed`,
+          );
+        }
+        const report = this.buildCommittedReport(
+          input,
+          validatedReport,
+          task,
+          generatedNames,
+          commitNow,
+        );
+        this.assertNoArtifactCollision(
+          manifest,
+          input.providerId,
+          input.taskId,
+          outputFile,
+          metaFile,
+        );
+        if (manifest.sources.file !== fixedFile('sources')) {
+          throw new Error(
+            'Retrieved commits require sources.json as the source file',
+          );
+        }
+        this.resolveContainedPath(runDir, fixedFile('sources'));
+
+        // Keep output and metadata writes inside the same manifest lock as the
+        // source rebuild. A loser racing an already retrieved task throws the
+        // sentinel before writing and therefore does not bump the revision.
+        this.writeProviderContent(runDir, input.providerId, input.content);
+        this.writeProviderMeta(runDir, input.providerId, validatedMeta);
+        manifest.providers[index] = report;
+
+        const allCitations = this.collectDeclaredCitations(
+          runDir,
+          manifest.providers,
+        );
+        const sources = deduplicateSources(allCitations);
+        const sourceFile = fixedFile('sources');
+        // A process crash between this atomic sources write and run.json's
+        // atomic rename can leave sources.json ahead of the manifest. The task
+        // remains completed/unretrieved in that window; a retry rebuilds the
+        // source file from the declared metadata and commits both state lanes.
+        this.writeJsonArtifact(runDir, sourceFile, sources);
+        manifest.sources = {
+          total: allCitations.length,
+          unique: sources.length,
+          file: sourceFile,
+        };
+        applyRunLifecycle(manifest, commitNow);
+      });
+    } catch (error) {
+      if (error === RETRIEVED_SENTINEL) {
+        return this.readSnapshot(runDir, { view: 'authoritative' });
+      }
+      throw error;
+    }
+    return this.readSnapshot(runDir, { view: 'authoritative' });
+  }
+
+  private validateCommittedReport(
+    input: CommitRetrievedInput,
+    metadata: RunArtifactMeta,
+  ): ValidatedReportFields {
+    const report = input.report as unknown as Record<string, unknown>;
+    assertKnownKeys(
+      report,
+      new Set([
+        'id',
+        'tier',
+        'status',
+        'durationMs',
+        'wordCount',
+        'citationCount',
+        'outputFile',
+        'metaFile',
+        'usage',
+        'metering',
+        'error',
+        'fallbackFor',
+        'preventFallback',
+        'task',
+      ]),
+      'report',
+    );
+    if (report.id !== input.providerId) {
+      throw new Error('Retrieved report provider does not match providerId');
+    }
+    if (report.status !== 'success') {
+      throw new Error('Retrieved report must have success status');
+    }
+    if (typeof report.tier !== 'string' || !REPORT_TIERS.has(report.tier)) {
+      throw new Error('Retrieved report has an unknown tier');
+    }
+    if (!isFiniteNonnegative(report.durationMs)) {
+      throw new Error(
+        'Retrieved report duration must be finite and nonnegative',
+      );
+    }
+    if (
+      !Number.isSafeInteger(report.wordCount) ||
+      !isFiniteNonnegative(report.wordCount) ||
+      report.wordCount !== wordCount(input.content)
+    ) {
+      throw new Error('Retrieved report word count does not match content');
+    }
+    const citationCount = metadata.citations.length;
+    if (
+      !Number.isSafeInteger(report.citationCount) ||
+      !isFiniteNonnegative(report.citationCount) ||
+      report.citationCount !== citationCount ||
+      (metadata.citationCount !== undefined &&
+        metadata.citationCount !== citationCount)
+    ) {
+      throw new Error(
+        'Retrieved report citation count does not match metadata',
+      );
+    }
+    if (metadata.tier !== undefined && metadata.tier !== report.tier) {
+      throw new Error('Retrieved report tier does not match metadata');
+    }
+    if (
+      metadata.durationMs !== undefined &&
+      metadata.durationMs !== report.durationMs
+    ) {
+      throw new Error('Retrieved report duration does not match metadata');
+    }
+    if (report.error !== undefined && !isSafeString(report.error)) {
+      throw new Error('Retrieved report error is unsafe');
+    }
+    if (report.fallbackFor !== undefined && !isSafeString(report.fallbackFor)) {
+      throw new Error('Retrieved report fallbackFor is unsafe');
+    }
+    if (
+      report.preventFallback !== undefined &&
+      report.preventFallback !== true
+    ) {
+      throw new Error('Retrieved report preventFallback must be true');
+    }
+    this.validateInputTask(report.task);
+
+    const usage =
+      report.usage === undefined ? undefined : parseUsage(report.usage);
+    if (report.usage !== undefined) {
+      if (!usage) throw new Error('Retrieved report usage is invalid');
+      if (isRecord(report.usage)) {
+        assertKnownKeys(
+          report.usage,
+          new Set([
+            'inputTokens',
+            'outputTokens',
+            'totalTokens',
+            'costUsd',
+            'billableUnits',
+            'unit',
+          ]),
+          'report usage',
+        );
+      }
+    }
+    if (
+      usage !== undefined &&
+      metadata.usage !== undefined &&
+      !sameValue(usage, metadata.usage)
+    ) {
+      throw new Error('Retrieved report usage does not match metadata');
+    }
+
+    const metering =
+      report.metering === undefined
+        ? undefined
+        : parseMetering(report.metering);
+    if (report.metering !== undefined && !metering) {
+      throw new Error('Retrieved report metering is invalid');
+    }
+    if (
+      metering !== undefined &&
+      metadata.metering !== undefined &&
+      !sameValue(metering, metadata.metering)
+    ) {
+      throw new Error('Retrieved report metering does not match metadata');
+    }
+    return {
+      tier: report.tier as ProviderReport['tier'],
+      durationMs: report.durationMs,
+      wordCount: report.wordCount,
+      citationCount,
+      ...((metadata.usage ?? usage) ? { usage: metadata.usage ?? usage } : {}),
+      ...((metadata.metering ?? metering)
+        ? { metering: metadata.metering ?? metering }
+        : {}),
+      ...(report.error !== undefined ? { error: report.error } : {}),
+      ...(report.fallbackFor !== undefined
+        ? { fallbackFor: report.fallbackFor }
+        : {}),
+      ...(report.preventFallback === true ? { preventFallback: true } : {}),
+    };
+  }
+
+  private validateInputTask(value: unknown): void {
+    if (value === undefined) return;
+    if (!isRecord(value)) throw new Error('Retrieved report task is invalid');
+    assertKnownKeys(
+      value,
+      new Set([
+        'taskId',
+        'submittedAt',
+        'status',
+        'lastPolledAt',
+        'completedAt',
+        'retrievedAt',
+        'providerStatus',
+        'lastPollError',
+      ]),
+      'report task',
+    );
+    if (!isSafeString(value.taskId) || value.taskId.length === 0) {
+      throw new Error('Retrieved report task ID is invalid');
+    }
+    if (!isFiniteNonnegative(value.submittedAt)) {
+      throw new Error('Retrieved report task submittedAt is invalid');
+    }
+    if (typeof value.status !== 'string' || !TASK_STATUSES.has(value.status)) {
+      throw new Error('Retrieved report task status is invalid');
+    }
+    for (const key of ['lastPolledAt', 'completedAt', 'retrievedAt'] as const) {
+      if (value[key] !== undefined && !isFiniteNonnegative(value[key])) {
+        throw new Error(`Retrieved report task ${key} is invalid`);
+      }
+    }
+    for (const key of ['providerStatus', 'lastPollError'] as const) {
+      if (value[key] !== undefined && !isSafeString(value[key])) {
+        throw new Error(`Retrieved report task ${key} is unsafe`);
+      }
+    }
+  }
+
+  private buildCommittedReport(
+    input: CommitRetrievedInput,
+    fields: ValidatedReportFields,
+    task: NonNullable<ProviderReport['task']>,
+    names: ProviderArtifactFileNames,
+    commitNow: number,
+  ): ProviderReport {
+    return {
+      id: input.providerId,
+      tier: fields.tier,
+      status: 'success',
+      durationMs: fields.durationMs,
+      wordCount: fields.wordCount,
+      citationCount: fields.citationCount,
+      outputFile: names.outputFile,
+      metaFile: names.metaFile,
+      ...(fields.usage !== undefined ? { usage: fields.usage } : {}),
+      ...(fields.metering !== undefined ? { metering: fields.metering } : {}),
+      ...(fields.error !== undefined ? { error: fields.error } : {}),
+      ...(fields.fallbackFor !== undefined
+        ? { fallbackFor: fields.fallbackFor }
+        : {}),
+      ...(fields.preventFallback === true ? { preventFallback: true } : {}),
+      task: {
+        ...task,
+        status: 'completed',
+        completedAt: task.completedAt ?? commitNow,
+        retrievedAt: commitNow,
+        lastPollError: undefined,
+      },
+    };
+  }
+
+  private validateGeneratedName(
+    providerId: string,
+    outputFile: string,
+    metaFile: string,
+  ): void {
+    if (
+      !providerId ||
+      [...providerId].some((character) => {
+        const code = character.codePointAt(0) ?? 0;
+        return code < 0x20 || code === 0x7f;
+      }) ||
+      RESERVED_ARTIFACT_NAMES.has(outputFile) ||
+      RESERVED_ARTIFACT_NAMES.has(metaFile) ||
+      outputFile.endsWith('.lock') ||
+      metaFile.endsWith('.lock')
+    ) {
+      throw new Error(`Provider ${providerId} has a reserved artifact name`);
+    }
+  }
+
+  private assertNoArtifactCollision(
+    manifest: RunManifest,
+    providerId: string,
+    taskId: string,
+    outputFile: string,
+    metaFile: string,
+  ): void {
+    for (const candidate of manifest.providers) {
+      if (candidate.id === providerId && candidate.task?.taskId === taskId) {
+        continue;
+      }
+      if (
+        candidate.outputFile === outputFile ||
+        candidate.outputFile === metaFile ||
+        candidate.metaFile === outputFile ||
+        candidate.metaFile === metaFile
+      ) {
+        throw new Error(
+          `Retrieved artifact names collide with provider ${candidate.id}`,
+        );
+      }
+    }
+  }
+
+  private assertRunDirectory(runDir: string): string {
+    if (runDir.split(/[\\/]+/).some((part) => part === '..')) {
+      throw new RunManifestError('Run directory path is not contained', runDir);
+    }
+    const resolved = this.resolveRunDirectory(
+      dirname(resolve(runDir)),
+      resolve(runDir),
+    );
+    if (!resolved) {
+      throw new RunManifestError(
+        'Run directory is not safe or does not exist',
+        runDir,
+      );
+    }
+    return resolved;
+  }
+
+  private readTextArtifact(
+    runDir: string,
+    fileName: string,
+  ): string | undefined {
+    const path = this.resolveContainedPath(runDir, fileName);
+    try {
+      if (!this.fs.existsSync(path) || !this.fs.statSync(path).isFile())
+        return undefined;
+      return this.fs.readFileSync(path, 'utf8');
+    } catch {
+      return undefined;
+    }
+  }
+
+  private readJsonArtifact(
+    runDir: string,
+    fileName: string,
+  ): unknown | undefined {
+    const path = this.resolveContainedPath(runDir, fileName);
+    try {
+      if (!this.fs.existsSync(path) || !this.fs.statSync(path).isFile())
+        return undefined;
+      return JSON.parse(this.fs.readFileSync(path, 'utf8')) as unknown;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private writeTextArtifact(
+    runDir: string,
+    fileName: string,
+    content: string,
+  ): void {
+    const path = this.resolveContainedPath(
+      this.assertRunDirectory(runDir),
+      fileName,
+    );
+    this.writeFile(path, content);
+  }
+
+  private writeJsonArtifact(
+    runDir: string,
+    fileName: string,
+    value: unknown,
+  ): void {
+    const path = this.resolveContainedPath(
+      this.assertRunDirectory(runDir),
+      fileName,
+    );
+    this.writeFile(path, JSON.stringify(value, null, 2));
+  }
+
+  private hasArtifactResolved(runDir: string, fileName: string): boolean {
+    try {
+      const path = this.resolveContainedPath(runDir, fileName);
+      return this.fs.existsSync(path) && this.fs.statSync(path).isFile();
+    } catch {
+      return false;
+    }
+  }
+
+  private sourceFile(manifest: RunManifest): string {
+    // A source declaration is data, not an output directory.  Validate it at
+    // the point of use; the normal writer always persists sources.json.
+    return manifest.sources.file || fixedFile('sources');
+  }
+
+  private readSourcesFile(
+    runDir: string,
+    manifest: RunManifest,
+  ): DeduplicatedSource[] {
+    const raw = this.readJsonArtifact(runDir, this.sourceFile(manifest));
+    const parsed = parseSources(raw);
+    return parsed ?? [];
+  }
+
+  private collectDeclaredCitations(
+    runDir: string,
+    reports: readonly ProviderReport[],
+  ): Citation[] {
+    const citations: Citation[] = [];
+    for (const report of reports) {
+      if (!report.metaFile) continue;
+      const path = this.resolveContainedPath(runDir, report.metaFile);
+      if (!this.fs.existsSync(path) || !this.fs.statSync(path).isFile()) {
+        throw new Error(
+          `Declared provider metadata is missing for ${report.id}: ${report.metaFile}`,
+        );
+      }
+      let raw: unknown;
+      try {
+        raw = JSON.parse(this.fs.readFileSync(path, 'utf8')) as unknown;
+      } catch (error) {
+        throw new Error(
+          `Declared provider metadata is unreadable for ${report.id}: ${report.metaFile}`,
+          { cause: error },
+        );
+      }
+      const meta = parseMeta(raw, report.id);
+      if (!meta) {
+        throw new Error(
+          `Declared provider metadata is malformed or mismatched for ${report.id}: ${report.metaFile}`,
+        );
+      }
+      citations.push(...meta.citations);
+    }
+    return citations;
+  }
+
+  private readDeclaredProviderArtifact(
+    runDir: string,
+    report: ProviderReport,
+  ): RunArtifactProviderArtifact {
+    const content = report.outputFile
+      ? this.readTextArtifact(runDir, report.outputFile)
+      : undefined;
+    const meta = report.metaFile
+      ? parseMeta(this.readJsonArtifact(runDir, report.metaFile), report.id)
+      : null;
+    return {
+      ...(content !== undefined ? { content } : {}),
+      ...(meta !== null ? { meta } : {}),
+      recovered: false,
+    };
+  }
+
+  private isRecoveryCandidate(report: ProviderReport): boolean {
+    return (
+      report.status === 'async-pending' &&
+      report.outputFile === '' &&
+      report.task !== undefined &&
+      report.task.retrievedAt === undefined
+    );
+  }
+
+  private readRecoveryArtifact(
+    runDir: string,
+    report: ProviderReport,
+    legacyStemIsUnique: boolean,
+  ): {
+    readonly report: ProviderReport;
+    readonly artifact: RunArtifactProviderArtifact;
+  } | null {
+    if (!legacyStemIsUnique) return null;
+    const safeId = sanitizeId(report.id);
+    const outputFile = `${safeId}.md`;
+    const content = this.readTextArtifact(runDir, outputFile);
+    if (content === undefined) return null;
+    const metaFile = `${safeId}.meta.json`;
+    const meta = parseMeta(this.readJsonArtifact(runDir, metaFile), report.id);
+    const recoveredReport: ProviderReport = {
+      ...report,
+      status: 'success',
+      outputFile,
+      metaFile: meta ? metaFile : '',
+      wordCount: wordCount(content),
+      ...(meta?.durationMs !== undefined
+        ? { durationMs: meta.durationMs }
+        : {}),
+      ...(meta?.citationCount !== undefined
+        ? { citationCount: meta.citationCount }
+        : meta
+          ? { citationCount: meta.citations.length }
+          : {}),
+      ...(meta?.usage !== undefined ? { usage: meta.usage } : {}),
+      ...(meta?.metering !== undefined ? { metering: meta.metering } : {}),
+    };
+    return {
+      report: recoveredReport,
+      artifact: {
+        content,
+        ...(meta ? { meta } : {}),
+        recovered: true,
+      },
+    };
+  }
+}

--- a/src/node-run-reconciliation-codecs.ts
+++ b/src/node-run-reconciliation-codecs.ts
@@ -1,0 +1,271 @@
+/** Pure validation/projection helpers for the internal reconciliation service. */
+import { parseMetering, parseUsage } from './node-run-artifact-codecs.js';
+import type {
+  AsyncTaskStatus,
+  ProviderResult,
+  ProviderTier,
+  ProviderUsage,
+} from './types.js';
+
+export const TASK_STATUSES = new Set<AsyncTaskStatus>([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+export const PROVIDER_TIERS = new Set<ProviderTier>([
+  'deep-research',
+  'ai-grounded',
+  'raw-search',
+  'llm',
+]);
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isSafeText(value: unknown, maxLength = 512): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= maxLength &&
+    ![...value].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 0x20 || code === 0x7f;
+    })
+  );
+}
+
+export function validTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function validNonnegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+/** Local, registry-free usage normalization for a completed provider result. */
+function normalizeProviderUsage(
+  result: Pick<ProviderResult, 'usage' | 'tokenUsage'>,
+): ProviderUsage | undefined {
+  if (result.usage !== undefined) {
+    const usage: ProviderUsage = {};
+    const source = result.usage as Record<string, unknown>;
+    for (const key of [
+      'inputTokens',
+      'outputTokens',
+      'totalTokens',
+      'costUsd',
+      'billableUnits',
+      'unit',
+    ] as const) {
+      if (source[key] !== undefined) {
+        (usage as Record<string, unknown>)[key] = source[key];
+      }
+    }
+    return usage;
+  }
+  const tokens = result.tokenUsage;
+  if (!tokens || (tokens.input === undefined && tokens.output === undefined)) {
+    return undefined;
+  }
+  return {
+    ...(tokens.input === undefined ? {} : { inputTokens: tokens.input }),
+    ...(tokens.output === undefined ? {} : { outputTokens: tokens.output }),
+    ...(tokens.input === undefined || tokens.output === undefined
+      ? {}
+      : { totalTokens: tokens.input + tokens.output }),
+  };
+}
+
+export interface NormalizedSuccess {
+  readonly content: string;
+  readonly tier: ProviderTier;
+  readonly durationMs: number;
+  readonly citations: readonly {
+    readonly url: string;
+    readonly provider: string;
+    readonly title?: string;
+    readonly snippet?: string;
+  }[];
+  readonly model?: string;
+  readonly tokenUsage?: { readonly input?: number; readonly output?: number };
+  readonly usage?: ReturnType<typeof parseUsage>;
+  readonly metering?: ReturnType<typeof parseMetering>;
+  readonly preventFallback?: true;
+}
+
+/**
+ * Normalize a provider result before any artifact write. Every rejected shape
+ * intentionally maps to one stable code; raw vendor diagnostics never reach
+ * the manifest or reconciliation result.
+ */
+export function normalizeSuccess(
+  result: unknown,
+  providerId: string,
+): NormalizedSuccess | { readonly error: 'provider.result_invalid' } {
+  if (!isRecord(result)) return { error: 'provider.result_invalid' };
+  if (result.provider !== providerId) {
+    return { error: 'provider.result_invalid' };
+  }
+  if (!PROVIDER_TIERS.has(result.tier as ProviderTier)) {
+    return { error: 'provider.result_invalid' };
+  }
+  if (typeof result.content !== 'string') {
+    return { error: 'provider.result_invalid' };
+  }
+  if (!validNonnegativeNumber(result.durationMs)) {
+    return { error: 'provider.result_invalid' };
+  }
+  if (!Array.isArray(result.citations)) {
+    return { error: 'provider.result_invalid' };
+  }
+  const citations: NormalizedSuccess['citations'][number][] = [];
+  for (const citation of result.citations) {
+    if (!isRecord(citation)) return { error: 'provider.result_invalid' };
+    if (
+      typeof citation.url !== 'string' ||
+      typeof citation.provider !== 'string' ||
+      citation.provider !== providerId ||
+      (citation.title !== undefined && typeof citation.title !== 'string') ||
+      (citation.snippet !== undefined && typeof citation.snippet !== 'string')
+    ) {
+      return { error: 'provider.result_invalid' };
+    }
+    citations.push({
+      url: citation.url,
+      provider: providerId,
+      ...(citation.title === undefined ? {} : { title: citation.title }),
+      ...(citation.snippet === undefined ? {} : { snippet: citation.snippet }),
+    });
+  }
+  let tokenUsage: NormalizedSuccess['tokenUsage'];
+  if (result.tokenUsage !== undefined) {
+    if (!isRecord(result.tokenUsage)) {
+      return { error: 'provider.result_invalid' };
+    }
+    const input = result.tokenUsage.input;
+    const output = result.tokenUsage.output;
+    for (const key of ['input', 'output'] as const) {
+      const value = result.tokenUsage[key];
+      if (value !== undefined && !validNonnegativeNumber(value)) {
+        return { error: 'provider.result_invalid' };
+      }
+    }
+    if (input === undefined && output === undefined) {
+      return { error: 'provider.result_invalid' };
+    }
+    tokenUsage = {
+      ...(input === undefined ? {} : { input: input as number }),
+      ...(output === undefined ? {} : { output: output as number }),
+    };
+  }
+  let usage: NormalizedSuccess['usage'];
+  if (result.usage !== undefined) {
+    usage = parseUsage(result.usage);
+    if (usage === undefined) return { error: 'provider.result_invalid' };
+  } else {
+    const normalized = normalizeProviderUsage(
+      result as unknown as ProviderResult,
+    );
+    if (normalized !== undefined) {
+      usage = parseUsage(normalized);
+      if (usage === undefined) return { error: 'provider.result_invalid' };
+    }
+  }
+  let metering: NormalizedSuccess['metering'];
+  if (result.metering !== undefined) {
+    metering = parseMetering(result.metering);
+    if (metering === undefined) return { error: 'provider.result_invalid' };
+  }
+  if (result.model !== undefined && !isSafeText(result.model)) {
+    return { error: 'provider.result_invalid' };
+  }
+  if (result.preventFallback !== undefined && result.preventFallback !== true) {
+    return { error: 'provider.result_invalid' };
+  }
+  return {
+    content: result.content,
+    tier: result.tier as ProviderTier,
+    durationMs: result.durationMs,
+    citations,
+    ...(result.model === undefined ? {} : { model: result.model }),
+    ...(tokenUsage === undefined ? {} : { tokenUsage }),
+    ...(usage === undefined ? {} : { usage }),
+    ...(metering === undefined ? {} : { metering }),
+    ...(result.preventFallback === true ? { preventFallback: true } : {}),
+  };
+}
+
+export type ReconciliationTaskOutcome =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'retrieved'
+  | 'failed'
+  | 'cancelled'
+  | 'unsupported'
+  | 'error';
+
+export interface ReconciliationTaskResult {
+  readonly provider: string;
+  readonly taskId: string;
+  readonly status: ReconciliationTaskOutcome;
+  readonly polled: boolean;
+  readonly retrieved: boolean;
+  readonly providerStatus?: string;
+  readonly lastPolledAt?: number;
+  readonly completedAt?: number;
+  readonly retrievedAt?: number;
+  readonly error?: string;
+}
+
+export function taskResultFromReport(
+  provider: string,
+  report: Readonly<{
+    task?: {
+      taskId: string;
+      status: AsyncTaskStatus;
+      providerStatus?: string;
+      lastPolledAt?: number;
+      completedAt?: number;
+      retrievedAt?: number;
+      lastPollError?: string;
+    };
+  }>,
+  polled: boolean,
+  retrieved: boolean,
+  overrideStatus?: ReconciliationTaskOutcome,
+  error?: string,
+): ReconciliationTaskResult | null {
+  const task = report.task;
+  if (!task) return null;
+  return {
+    provider,
+    taskId: task.taskId,
+    status:
+      overrideStatus ??
+      (retrieved
+        ? 'retrieved'
+        : task.status === 'failed'
+          ? 'failed'
+          : task.status === 'cancelled'
+            ? 'cancelled'
+            : task.status),
+    polled,
+    retrieved,
+    ...(task.providerStatus === undefined
+      ? {}
+      : { providerStatus: task.providerStatus }),
+    ...(task.lastPolledAt === undefined
+      ? {}
+      : { lastPolledAt: task.lastPolledAt }),
+    ...(task.completedAt === undefined
+      ? {}
+      : { completedAt: task.completedAt }),
+    ...(task.retrievedAt === undefined
+      ? {}
+      : { retrievedAt: task.retrievedAt }),
+    ...(error === undefined ? {} : { error }),
+  };
+}

--- a/src/node-run-reconciliation-codecs.ts
+++ b/src/node-run-reconciliation-codecs.ts
@@ -210,9 +210,12 @@ export type ReconciliationTaskOutcome =
 export interface ReconciliationTaskResult {
   readonly provider: string;
   readonly taskId: string;
+  readonly submittedAt: number;
   readonly status: ReconciliationTaskOutcome;
   readonly polled: boolean;
   readonly retrieved: boolean;
+  /** True only when this reconciliation pass committed the retrieval. */
+  readonly retrievedThisPass: boolean;
   readonly providerStatus?: string;
   readonly lastPolledAt?: number;
   readonly completedAt?: number;
@@ -225,6 +228,7 @@ export function taskResultFromReport(
   report: Readonly<{
     task?: {
       taskId: string;
+      submittedAt: number;
       status: AsyncTaskStatus;
       providerStatus?: string;
       lastPolledAt?: number;
@@ -243,9 +247,10 @@ export function taskResultFromReport(
   return {
     provider,
     taskId: task.taskId,
+    submittedAt: task.submittedAt,
     status:
       overrideStatus ??
-      (retrieved
+      (retrieved || task.retrievedAt !== undefined
         ? 'retrieved'
         : task.status === 'failed'
           ? 'failed'
@@ -253,7 +258,8 @@ export function taskResultFromReport(
             ? 'cancelled'
             : task.status),
     polled,
-    retrieved,
+    retrieved: retrieved || task.retrievedAt !== undefined,
+    retrievedThisPass: retrieved,
     ...(task.providerStatus === undefined
       ? {}
       : { providerStatus: task.providerStatus }),
@@ -266,6 +272,8 @@ export function taskResultFromReport(
     ...(task.retrievedAt === undefined
       ? {}
       : { retrievedAt: task.retrievedAt }),
-    ...(error === undefined ? {} : { error }),
+    ...(error === undefined && task.lastPollError === undefined
+      ? {}
+      : { error: error ?? task.lastPollError }),
   };
 }

--- a/src/node-run-reconciliation-runtime.ts
+++ b/src/node-run-reconciliation-runtime.ts
@@ -1,7 +1,7 @@
 /** Node runtime wiring for the internal reconciliation service. */
 import { getExactProvider } from './adapters/node-registry.js';
-import { writeHtmlReport } from './commands/html-report.js';
-import { writeJsonlReport } from './commands/jsonl-report.js';
+import { writeHtmlReportFromSnapshot } from './commands/html-report.js';
+import { writeJsonlReportFromSnapshot } from './commands/jsonl-report.js';
 import { generateSummary } from './core/synthesis.js';
 import {
   RunArtifactRepository,
@@ -73,14 +73,14 @@ function createRegenerator(
     }
     if (refreshHtml) {
       try {
-        writeHtmlReport(runDir);
+        writeHtmlReportFromSnapshot(snapshot, repository);
       } catch {
         failed = true;
       }
     }
     if (refreshJsonl) {
       try {
-        writeJsonlReport(runDir);
+        writeJsonlReportFromSnapshot(snapshot, repository);
       } catch {
         failed = true;
       }

--- a/src/node-run-reconciliation-runtime.ts
+++ b/src/node-run-reconciliation-runtime.ts
@@ -71,16 +71,26 @@ function createRegenerator(
         failed = true;
       }
     }
-    if (refreshHtml) {
+    let presentationSnapshot: RunArtifactSnapshot | undefined;
+    if (refreshHtml || refreshJsonl) {
       try {
-        writeHtmlReportFromSnapshot(snapshot, repository);
+        presentationSnapshot = repository.readSnapshot(runDir, {
+          view: 'recovery',
+        });
       } catch {
         failed = true;
       }
     }
-    if (refreshJsonl) {
+    if (refreshHtml && presentationSnapshot) {
       try {
-        writeJsonlReportFromSnapshot(snapshot, repository);
+        writeHtmlReportFromSnapshot(presentationSnapshot, repository);
+      } catch {
+        failed = true;
+      }
+    }
+    if (refreshJsonl && presentationSnapshot) {
+      try {
+        writeJsonlReportFromSnapshot(presentationSnapshot, repository);
       } catch {
         failed = true;
       }

--- a/src/node-run-reconciliation-runtime.ts
+++ b/src/node-run-reconciliation-runtime.ts
@@ -1,0 +1,109 @@
+/** Node runtime wiring for the internal reconciliation service. */
+import { getExactProvider } from './adapters/node-registry.js';
+import { writeHtmlReport } from './commands/html-report.js';
+import { writeJsonlReport } from './commands/jsonl-report.js';
+import { generateSummary } from './core/synthesis.js';
+import {
+  RunArtifactRepository,
+  type RunArtifactSnapshot,
+} from './node-run-artifacts.js';
+import { RunReconciliationService } from './node-run-reconciliation.js';
+import type { AsyncTaskHandle, Config, ProviderReport } from './types.js';
+
+export interface NodeRunReconciliationRuntime {
+  readonly repository: RunArtifactRepository;
+  readonly service: RunReconciliationService;
+}
+
+function snapshotReports(snapshot: RunArtifactSnapshot): ProviderReport[] {
+  return snapshot.reports.map((report) => structuredClone(report));
+}
+
+function snapshotTasks(snapshot: RunArtifactSnapshot): AsyncTaskHandle[] {
+  return snapshot.manifest.providers.flatMap((report) => {
+    const task = report.task;
+    if (!task || task.retrievedAt !== undefined) return [];
+    return [
+      {
+        provider: report.id,
+        taskId: task.taskId,
+        query: snapshot.manifest.query,
+        submittedAt: task.submittedAt,
+        status: task.status,
+        outputDir: snapshot.runDir,
+        ...(task.lastPolledAt === undefined
+          ? {}
+          : { lastPolledAt: task.lastPolledAt }),
+        ...(task.completedAt === undefined
+          ? {}
+          : { completedAt: task.completedAt }),
+        ...(task.providerStatus === undefined
+          ? {}
+          : { providerStatus: task.providerStatus }),
+        ...(task.lastPollError === undefined
+          ? {}
+          : { lastPollError: task.lastPollError }),
+      },
+    ];
+  });
+}
+
+function createRegenerator(
+  repository: RunArtifactRepository,
+): NonNullable<
+  ConstructorParameters<typeof RunReconciliationService>[0]
+>['regenerateDerivedArtifacts'] {
+  return ({ runDir, snapshot, refreshSummary, refreshHtml, refreshJsonl }) => {
+    let failed = false;
+    if (refreshSummary) {
+      try {
+        repository.writeSummary(
+          runDir,
+          generateSummary({
+            query: snapshot.manifest.query,
+            reports: snapshotReports(snapshot),
+            sources: snapshot.sources.map((source) => structuredClone(source)),
+            asyncTasks: snapshotTasks(snapshot),
+            timestamp: snapshot.manifest.timestamp,
+          }),
+        );
+      } catch {
+        failed = true;
+      }
+    }
+    if (refreshHtml) {
+      try {
+        writeHtmlReport(runDir);
+      } catch {
+        failed = true;
+      }
+    }
+    if (refreshJsonl) {
+      try {
+        writeJsonlReport(runDir);
+      } catch {
+        failed = true;
+      }
+    }
+    if (failed) throw new Error('derived artifact regeneration failed');
+  };
+}
+
+/** Construct the one production Node reconciliation runtime. */
+export function createNodeRunReconciliationRuntime(
+  config: Config,
+  repository = new RunArtifactRepository(),
+): NodeRunReconciliationRuntime {
+  const service = new RunReconciliationService({
+    repository,
+    resolveBackgroundProvider: (providerId) => {
+      const provider = getExactProvider(providerId);
+      return provider?.execution === 'background' ? provider : undefined;
+    },
+    getProviderConfig: (providerId) => config.providers[providerId],
+    regenerateDerivedArtifacts: createRegenerator(repository),
+  });
+  return { repository, service };
+}
+
+export type { ReconciliationResult } from './node-run-reconciliation.js';

--- a/src/node-run-reconciliation.ts
+++ b/src/node-run-reconciliation.ts
@@ -474,7 +474,7 @@ export class RunReconciliationService {
             : {}),
         };
         try {
-          const committed = this.repository.commitRetrieved({
+          const commit = this.repository.commitRetrieved({
             runDir,
             providerId: report.id,
             taskId: task.taskId,
@@ -483,8 +483,9 @@ export class RunReconciliationService {
             meta,
             now: commitNow,
           });
+          if (!commit.committed) continue;
           retrieved++;
-          const committedProvider = committed.manifest.providers.find(
+          const committedProvider = commit.snapshot.manifest.providers.find(
             (candidate) =>
               candidate.id === report.id &&
               candidate.task?.taskId === task.taskId,

--- a/src/node-run-reconciliation.ts
+++ b/src/node-run-reconciliation.ts
@@ -1,0 +1,659 @@
+/**
+ * Internal Node-only reconciliation for persisted background runs.
+ *
+ * This module deliberately knows only the provider lifecycle contract from
+ * src/types.ts.  Filesystem writes and manifest locking stay behind
+ * RunArtifactRepository so polling and retrieval cannot accidentally create a
+ * second persistence boundary.
+ */
+
+import { buildProviderMetering } from './core/metering.js';
+import { RunManifestError } from './core/run-manifest.js';
+import { freezeDeep, wordCount } from './node-run-artifact-codecs.js';
+import {
+  providerArtifactFileNames,
+  type RunArtifactMetaInput,
+  type RunArtifactRepository,
+  type RunArtifactSnapshot,
+  type RunArtifactTaskUpdate,
+} from './node-run-artifacts.js';
+import {
+  isRecord,
+  normalizeSuccess,
+  type ReconciliationTaskResult,
+  TASK_STATUSES,
+  taskResultFromReport,
+  validTimestamp,
+} from './node-run-reconciliation-codecs.js';
+import type {
+  AsyncPollResult,
+  AsyncTaskHandle,
+  AsyncTaskStatus,
+  ProviderConfig,
+  ProviderResult,
+} from './types.js';
+
+/** Exact provider lifecycle surface needed by reconciliation. */
+export interface ReconciliationBackgroundProvider {
+  readonly execution: 'background';
+  readonly poll: (handle: AsyncTaskHandle) => Promise<AsyncPollResult>;
+  readonly retrieve: (handle: AsyncTaskHandle) => Promise<ProviderResult>;
+}
+
+export type BackgroundProviderResolver = (
+  providerId: string,
+) => ReconciliationBackgroundProvider | undefined;
+
+export type ProviderConfigLookup = (
+  providerId: string,
+) => ProviderConfig | undefined;
+
+export interface DerivedArtifactRegeneratorInput {
+  readonly runDir: string;
+  readonly snapshot: RunArtifactSnapshot;
+  readonly refreshSummary: boolean;
+  readonly refreshHtml: boolean;
+  readonly refreshJsonl: boolean;
+}
+
+export type DerivedArtifactRegenerator = (
+  input: DerivedArtifactRegeneratorInput,
+) => void | Promise<void>;
+
+export interface RunReconciliationServiceDependencies {
+  readonly repository: RunArtifactRepository;
+  readonly resolveBackgroundProvider: BackgroundProviderResolver;
+  readonly getProviderConfig: ProviderConfigLookup;
+  readonly now?: () => number;
+  readonly regenerateDerivedArtifacts?: DerivedArtifactRegenerator;
+}
+
+export interface ReconcileOnceOptions {
+  readonly retrieve?: boolean;
+}
+
+export type {
+  ReconciliationTaskOutcome,
+  ReconciliationTaskResult,
+} from './node-run-reconciliation-codecs.js';
+
+export interface ReconciliationResult {
+  readonly runDir: string;
+  readonly tasks: readonly ReconciliationTaskResult[];
+  readonly polled: number;
+  readonly retrieved: number;
+  readonly regenerated: boolean;
+  readonly regenerationError?: string;
+}
+
+const DIAGNOSTIC = {
+  pollFailed: 'provider.poll_failed',
+  pollInvalid: 'provider.poll_invalid',
+  retrieveFailed: 'provider.retrieve_failed',
+  resultError: 'provider.result_error',
+  resultInvalid: 'provider.result_invalid',
+  configInvalid: 'provider.config_invalid',
+  unavailable: 'provider.unavailable',
+  persistFailed: 'artifact.persist_failed',
+  regenerationFailed: 'artifact.regeneration_failed',
+} as const;
+
+function taskKey(provider: string, taskId: string): string {
+  return `${provider}\u0000${taskId}`;
+}
+
+function asReadonlyResult(result: ReconciliationResult): ReconciliationResult {
+  return freezeDeep(result);
+}
+
+function isBackgroundProvider(
+  provider: ReconciliationBackgroundProvider | undefined,
+): provider is ReconciliationBackgroundProvider {
+  try {
+    return provider?.execution === 'background';
+  } catch {
+    return false;
+  }
+}
+
+export class RunReconciliationService {
+  private readonly repository: RunArtifactRepository;
+  private readonly resolveBackgroundProvider: BackgroundProviderResolver;
+  private readonly getProviderConfig: ProviderConfigLookup;
+  private readonly clock: () => number;
+  private readonly regenerateDerivedArtifacts?: DerivedArtifactRegenerator;
+
+  constructor(dependencies: RunReconciliationServiceDependencies) {
+    this.repository = dependencies.repository;
+    this.resolveBackgroundProvider = dependencies.resolveBackgroundProvider;
+    this.getProviderConfig = dependencies.getProviderConfig;
+    this.clock = dependencies.now ?? Date.now;
+    this.regenerateDerivedArtifacts = dependencies.regenerateDerivedArtifacts;
+  }
+
+  async reconcileOnce(
+    runDir: string,
+    options: ReconcileOnceOptions = {},
+  ): Promise<ReconciliationResult> {
+    // The strict read is intentionally the first operation.  In particular,
+    // do not call the provider resolver, config lookup, clock, or an artifact
+    // writer before the manifest and declared paths have been validated.
+    const initial = this.repository.readSnapshot(runDir, {
+      view: 'authoritative',
+    });
+    const refreshSummary = this.repository.hasArtifact(runDir, 'summary.md');
+    const refreshHtml = this.repository.hasArtifact(runDir, 'report.html');
+    const refreshJsonl = this.repository.hasArtifact(runDir, 'results.jsonl');
+    const retrieve = options.retrieve === true;
+    const outcomes = new Map<string, ReconciliationTaskResult>();
+    let polled = 0;
+
+    for (const report of initial.manifest.providers) {
+      const task = report.task;
+      if (!task || task.retrievedAt !== undefined) continue;
+      if (task.status !== 'pending' && task.status !== 'running') continue;
+      const key = taskKey(report.id, task.taskId);
+      let provider: ReconciliationBackgroundProvider | undefined;
+      let resolverFailed = false;
+      try {
+        provider = this.resolveBackgroundProvider(report.id);
+      } catch {
+        resolverFailed = true;
+      }
+      if (resolverFailed) {
+        const updated = this.persistPollDiagnostic(
+          runDir,
+          report.id,
+          task.taskId,
+          DIAGNOSTIC.pollFailed,
+        );
+        polled++;
+        const taskResult = taskResultFromReport(
+          report.id,
+          updated?.manifest.providers.find(
+            (candidate) =>
+              candidate.id === report.id &&
+              candidate.task?.taskId === task.taskId,
+          ) ?? report,
+          true,
+          false,
+          undefined,
+          DIAGNOSTIC.pollFailed,
+        );
+        if (taskResult) outcomes.set(key, taskResult);
+        continue;
+      }
+      if (!isBackgroundProvider(provider)) {
+        const unsupported = this.persistUnsupported(
+          runDir,
+          report.id,
+          task.taskId,
+        );
+        polled++;
+        const unsupportedResult = taskResultFromReport(
+          report.id,
+          unsupported?.manifest.providers.find(
+            (candidate) =>
+              candidate.id === report.id &&
+              candidate.task?.taskId === task.taskId,
+          ) ?? report,
+          true,
+          false,
+          'unsupported',
+          DIAGNOSTIC.unavailable,
+        );
+        if (unsupportedResult) outcomes.set(key, unsupportedResult);
+        continue;
+      }
+      const handle = this.toHandle(initial, report.id, task.taskId);
+      let normalizedPoll: AsyncPollResult | null;
+      try {
+        const poll = await provider.poll(handle);
+        normalizedPoll = this.normalizePoll(poll);
+      } catch {
+        const updated = this.persistPollDiagnostic(
+          runDir,
+          report.id,
+          task.taskId,
+          DIAGNOSTIC.pollFailed,
+        );
+        polled++;
+        const taskResult = taskResultFromReport(
+          report.id,
+          updated?.manifest.providers.find(
+            (candidate) =>
+              candidate.id === report.id &&
+              candidate.task?.taskId === task.taskId,
+          ) ?? report,
+          true,
+          false,
+          undefined,
+          DIAGNOSTIC.pollFailed,
+        );
+        if (taskResult) outcomes.set(key, taskResult);
+        continue;
+      }
+      if (!normalizedPoll) {
+        const updated = this.persistPollDiagnostic(
+          runDir,
+          report.id,
+          task.taskId,
+          DIAGNOSTIC.pollInvalid,
+        );
+        polled++;
+        const taskResult = taskResultFromReport(
+          report.id,
+          updated?.manifest.providers.find(
+            (candidate) =>
+              candidate.id === report.id &&
+              candidate.task?.taskId === task.taskId,
+          ) ?? report,
+          true,
+          false,
+          undefined,
+          DIAGNOSTIC.pollInvalid,
+        );
+        if (taskResult) outcomes.set(key, taskResult);
+        continue;
+      }
+      const at = this.readClockOrNull();
+      if (at === null) {
+        const taskResult = taskResultFromReport(
+          report.id,
+          report,
+          true,
+          false,
+          undefined,
+          DIAGNOSTIC.pollFailed,
+        );
+        if (taskResult) outcomes.set(key, taskResult);
+        polled++;
+        continue;
+      }
+      const updates: RunArtifactTaskUpdate = {
+        status: normalizedPoll.status,
+        lastPolledAt: at,
+        ...(normalizedPoll.rawStatus === undefined
+          ? {}
+          : { providerStatus: normalizedPoll.rawStatus }),
+        lastPollError:
+          normalizedPoll.status === 'failed' ||
+          normalizedPoll.status === 'cancelled'
+            ? DIAGNOSTIC.pollFailed
+            : undefined,
+        ...(normalizedPoll.status === 'completed' ||
+        normalizedPoll.status === 'failed' ||
+        normalizedPoll.status === 'cancelled'
+          ? { completedAt: at }
+          : {}),
+      };
+      const updated = this.repository.updateTask(
+        runDir,
+        report.id,
+        task.taskId,
+        updates,
+        at,
+      );
+      polled++;
+      const taskResult = taskResultFromReport(
+        report.id,
+        updated.manifest.providers.find(
+          (candidate) =>
+            candidate.id === report.id &&
+            candidate.task?.taskId === task.taskId,
+        ) ?? report,
+        true,
+        false,
+      );
+      if (taskResult) outcomes.set(key, taskResult);
+    }
+
+    // Re-read after every poll mutation.  This is what lets a task that became
+    // completed in this pass join pre-existing completed/unretrieved work.
+    const afterPoll = this.repository.readSnapshot(runDir, {
+      view: 'authoritative',
+    });
+    let retrieved = 0;
+    if (retrieve) {
+      for (const report of afterPoll.manifest.providers) {
+        const task = report.task;
+        if (
+          !task ||
+          task.retrievedAt !== undefined ||
+          task.status !== 'completed'
+        ) {
+          continue;
+        }
+        const key = taskKey(report.id, task.taskId);
+        let provider: ReconciliationBackgroundProvider | undefined;
+        let resolverFailed = false;
+        try {
+          provider = this.resolveBackgroundProvider(report.id);
+        } catch {
+          resolverFailed = true;
+        }
+        if (resolverFailed) {
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            DIAGNOSTIC.retrieveFailed,
+          );
+          if (failed) outcomes.set(key, failed);
+          continue;
+        }
+        if (!isBackgroundProvider(provider)) {
+          const unsupported = this.persistUnsupported(
+            runDir,
+            report.id,
+            task.taskId,
+          );
+          const unsupportedResult = taskResultFromReport(
+            report.id,
+            unsupported?.manifest.providers.find(
+              (candidate) =>
+                candidate.id === report.id &&
+                candidate.task?.taskId === task.taskId,
+            ) ?? report,
+            false,
+            false,
+            'unsupported',
+            DIAGNOSTIC.unavailable,
+          );
+          if (unsupportedResult) outcomes.set(key, unsupportedResult);
+          continue;
+        }
+        const handle = this.toHandle(afterPoll, report.id, task.taskId);
+        let providerResult: ProviderResult;
+        try {
+          providerResult = await provider.retrieve(handle);
+        } catch {
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            DIAGNOSTIC.retrieveFailed,
+          );
+          if (failed) outcomes.set(key, failed);
+          continue;
+        }
+        if (isRecord(providerResult) && providerResult.error !== undefined) {
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            DIAGNOSTIC.resultError,
+          );
+          if (failed) outcomes.set(key, failed);
+          continue;
+        }
+        const normalized = normalizeSuccess(providerResult, report.id);
+        if ('error' in normalized) {
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            normalized.error,
+          );
+          if (failed) outcomes.set(key, failed);
+          continue;
+        }
+        const usage = normalized.usage;
+        let metering: ReturnType<typeof buildProviderMetering>;
+        try {
+          const config = this.getProviderConfig(report.id);
+          if (
+            config !== undefined &&
+            (!isRecord(config) ||
+              (config.options !== undefined && !isRecord(config.options)))
+          ) {
+            throw new Error('invalid provider config');
+          }
+          metering = buildProviderMetering(report.id, config, usage);
+        } catch {
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            DIAGNOSTIC.configInvalid,
+          );
+          if (failed) outcomes.set(key, failed);
+          continue;
+        }
+        const names = providerArtifactFileNames(report.id);
+        const meta: RunArtifactMetaInput = {
+          tier: normalized.tier,
+          ...(normalized.model === undefined
+            ? {}
+            : { model: normalized.model }),
+          durationMs: normalized.durationMs,
+          citationCount: normalized.citations.length,
+          ...(normalized.tokenUsage === undefined
+            ? {}
+            : { tokenUsage: normalized.tokenUsage }),
+          ...(usage === undefined ? {} : { usage }),
+          metering,
+          citations: normalized.citations,
+        };
+        const commitNow = this.readClockOrNull();
+        if (commitNow === null) {
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            DIAGNOSTIC.persistFailed,
+          );
+          if (failed) outcomes.set(key, failed);
+          continue;
+        }
+        const committedReport = {
+          id: report.id,
+          tier: normalized.tier,
+          status: 'success' as const,
+          durationMs: normalized.durationMs,
+          wordCount: wordCount(normalized.content),
+          citationCount: normalized.citations.length,
+          outputFile: names.outputFile,
+          metaFile: names.metaFile,
+          ...(usage === undefined ? {} : { usage }),
+          metering,
+          ...(normalized.preventFallback === true
+            ? { preventFallback: true as const }
+            : {}),
+        };
+        try {
+          const committed = this.repository.commitRetrieved({
+            runDir,
+            providerId: report.id,
+            taskId: task.taskId,
+            report: committedReport,
+            content: normalized.content,
+            meta,
+            now: commitNow,
+          });
+          retrieved++;
+          const committedProvider = committed.manifest.providers.find(
+            (candidate) =>
+              candidate.id === report.id &&
+              candidate.task?.taskId === task.taskId,
+          );
+          const successResult = committedProvider
+            ? taskResultFromReport(
+                report.id,
+                committedProvider,
+                false,
+                true,
+                'retrieved',
+              )
+            : null;
+          if (successResult) outcomes.set(key, successResult);
+        } catch (error) {
+          if (error instanceof RunManifestError) throw error;
+          const failed = taskResultFromReport(
+            report.id,
+            report,
+            false,
+            false,
+            'error',
+            DIAGNOSTIC.persistFailed,
+          );
+          if (failed) outcomes.set(key, failed);
+        }
+      }
+    }
+
+    let regenerated = false;
+    let regenerationError: string | undefined;
+    if (retrieved > 0 && this.regenerateDerivedArtifacts) {
+      const snapshot = this.repository.readSnapshot(runDir, {
+        view: 'authoritative',
+      });
+      try {
+        await this.regenerateDerivedArtifacts({
+          runDir: snapshot.runDir,
+          snapshot,
+          refreshSummary,
+          refreshHtml,
+          refreshJsonl,
+        });
+        regenerated = true;
+      } catch {
+        regenerationError = DIAGNOSTIC.regenerationFailed;
+      }
+    }
+
+    const orderedTasks: ReconciliationTaskResult[] = [];
+    const final = this.repository.readSnapshot(runDir, {
+      view: 'authoritative',
+    });
+    for (const report of final.manifest.providers) {
+      const task = report.task;
+      if (!task) continue;
+      const key = taskKey(report.id, task.taskId);
+      const existing = outcomes.get(key);
+      if (existing) {
+        orderedTasks.push(existing);
+        continue;
+      }
+      const result = taskResultFromReport(report.id, report, false, false);
+      if (result) orderedTasks.push(result);
+    }
+    return asReadonlyResult({
+      runDir: final.runDir,
+      tasks: orderedTasks,
+      polled,
+      retrieved,
+      regenerated,
+      ...(regenerationError === undefined ? {} : { regenerationError }),
+    });
+  }
+
+  private readClock(): number {
+    const value = this.clock();
+    if (!validTimestamp(value)) {
+      throw new Error(
+        'Reconciliation clock must return a finite nonnegative safe integer',
+      );
+    }
+    return value;
+  }
+
+  private readClockOrNull(): number | null {
+    try {
+      return this.readClock();
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizePoll(poll: unknown): AsyncPollResult | null {
+    if (!isRecord(poll) || !TASK_STATUSES.has(poll.status as AsyncTaskStatus)) {
+      return null;
+    }
+    const rawStatus =
+      typeof poll.rawStatus === 'string' &&
+      /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/.test(poll.rawStatus)
+        ? poll.rawStatus
+        : undefined;
+    return {
+      status: poll.status as AsyncTaskStatus,
+      ...(rawStatus === undefined ? {} : { rawStatus: rawStatus }),
+    };
+  }
+
+  private toHandle(
+    snapshot: RunArtifactSnapshot,
+    providerId: string,
+    taskId: string,
+  ): AsyncTaskHandle {
+    const report = snapshot.manifest.providers.find(
+      (candidate) =>
+        candidate.id === providerId && candidate.task?.taskId === taskId,
+    );
+    const task = report?.task;
+    if (!report || !task) {
+      throw new Error(
+        `Task ${providerId}/${taskId} is not recorded in run.json`,
+      );
+    }
+    return {
+      provider: providerId,
+      taskId,
+      query: snapshot.manifest.query,
+      submittedAt: task.submittedAt,
+      status: task.status,
+      outputDir: snapshot.runDir,
+      ...(task.lastPolledAt === undefined
+        ? {}
+        : { lastPolledAt: task.lastPolledAt }),
+      ...(task.completedAt === undefined
+        ? {}
+        : { completedAt: task.completedAt }),
+      ...(task.providerStatus === undefined
+        ? {}
+        : { providerStatus: task.providerStatus }),
+      ...(task.lastPollError === undefined
+        ? {}
+        : { lastPollError: task.lastPollError }),
+    };
+  }
+
+  private persistPollDiagnostic(
+    runDir: string,
+    providerId: string,
+    taskId: string,
+    diagnostic: string,
+  ): RunArtifactSnapshot | null {
+    const at = this.readClockOrNull();
+    if (at === null) return null;
+    return this.repository.updateTask(
+      runDir,
+      providerId,
+      taskId,
+      { lastPolledAt: at, lastPollError: diagnostic },
+      at,
+    );
+  }
+
+  private persistUnsupported(
+    runDir: string,
+    providerId: string,
+    taskId: string,
+  ): RunArtifactSnapshot | null {
+    const at = this.readClockOrNull();
+    if (at === null) return null;
+    return this.repository.failUnretrievedTask(runDir, providerId, taskId, at);
+  }
+}

--- a/tests/browse-data.test.ts
+++ b/tests/browse-data.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -8,6 +14,7 @@ import {
   extractPreview,
   isRunManifest,
   readRunEntry,
+  readRunSnapshot,
   runTallies,
 } from '../src/commands/browse-data.js';
 import type { RunManifest } from '../src/types.js';
@@ -122,6 +129,55 @@ describe('readRunEntry / discoverRuns', () => {
       'oldest',
     ]);
     expect(discoverRuns(baseDir, 2)).toHaveLength(2);
+  });
+
+  it('uses authoritative discovery and rejects symlinked run directories', () => {
+    const target = writeRun('target', makeManifest({ query: 'target' }));
+    symlinkSync(target, join(baseDir, 'linked-run'));
+
+    expect(discoverRuns(baseDir).map((entry) => entry.manifest.query)).toEqual([
+      'target',
+    ]);
+  });
+
+  it('keeps discovery authoritative while recovery remains read-only', () => {
+    const dir = writeRun(
+      'pending',
+      makeManifest({
+        status: 'awaiting_async',
+        exitCode: null,
+        providers: [
+          {
+            id: 'provider-a',
+            tier: 'deep-research',
+            status: 'async-pending',
+            durationMs: 0,
+            wordCount: 0,
+            citationCount: 0,
+            outputFile: '',
+            metaFile: '',
+            task: { taskId: 'task-a', submittedAt: 1, status: 'completed' },
+          },
+        ],
+      }),
+    );
+    writeFileSync(join(dir, 'provider-a.md'), 'recovered output');
+    const before = readFileSync(join(dir, 'run.json'), 'utf8');
+
+    const entry = readRunEntry(dir);
+    expect(entry?.manifest.providers[0]?.status).toBe('async-pending');
+    expect(entry?.manifest.providers[0]?.outputFile).toBe('');
+    const snapshot = readRunSnapshot(dir);
+    expect(snapshot?.reports[0]).toMatchObject({
+      id: 'provider-a',
+      status: 'success',
+      outputFile: 'provider-a.md',
+    });
+    expect(snapshot?.providerArtifacts['provider-a']).toMatchObject({
+      content: 'recovered output',
+      recovered: true,
+    });
+    expect(readFileSync(join(dir, 'run.json'), 'utf8')).toBe(before);
   });
 
   it('returns empty for a missing base dir', () => {

--- a/tests/cleanup-data.test.ts
+++ b/tests/cleanup-data.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, parse } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -87,6 +94,19 @@ describe('getDirSize', () => {
   it('returns 0 for a missing directory', () => {
     expect(getDirSize(join(baseDir, 'does-not-exist'))).toBe(0);
   });
+
+  it('does not follow symlinks while measuring a directory', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'librarium-cleanup-outside-'));
+    try {
+      writeFileSync(join(outside, 'secret.md'), 'x'.repeat(500));
+      const dir = makeRun('100-linked');
+      symlinkSync(outside, join(dir, 'outside'));
+
+      expect(getDirSize(dir)).toBe(0);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('discoverCandidates', () => {
@@ -146,6 +166,18 @@ describe('discoverCandidates', () => {
     const out = discoverCandidates(baseDir, { all: true });
     expect(out).toHaveLength(1);
     expect(out[0].query).toBe('postgres pooling best practices');
+  });
+
+  it('skips symlinked run directories that escape the output base', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'librarium-cleanup-outside-'));
+    try {
+      writeFileSync(join(outside, 'run.json'), JSON.stringify(makeManifest()));
+      symlinkSync(outside, join(baseDir, '100-linked'));
+
+      expect(discoverCandidates(baseDir, { all: true })).toEqual([]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });
 
@@ -208,6 +240,50 @@ describe('hasPendingAsync', () => {
   it('conservatively protects a corrupt authoritative manifest', () => {
     const dir = makeRun('100-corrupt', { 'run.json': '{not-json' });
     expect(hasPendingAsync(dir)).toBe(true);
+  });
+
+  it('keeps a pending manifest protected when a recovery output exists', () => {
+    const dir = makeRun('100-recovered-pending', {
+      'run.json': JSON.stringify(
+        makeManifest({
+          status: 'awaiting_async',
+          exitCode: null,
+          providers: [
+            {
+              id: 'provider-a',
+              tier: 'deep-research',
+              status: 'async-pending',
+              durationMs: 0,
+              wordCount: 0,
+              citationCount: 0,
+              outputFile: '',
+              metaFile: '',
+              task: { taskId: 'task-a', submittedAt: 1, status: 'completed' },
+            },
+          ],
+        }),
+      ),
+      'provider-a.md': 'recovered output',
+    });
+
+    expect(hasPendingAsync(dir)).toBe(true);
+    expect(discoverCandidates(baseDir, { all: true })[0]).toMatchObject({
+      pendingAsync: true,
+      query: 'postgres pooling best practices',
+    });
+  });
+
+  it('protects corrupt manifests and leaves their query unknown', () => {
+    const dir = makeRun('100-corrupt-candidate', {
+      'run.json': '{not-json',
+      'provider-a.md': 'untrusted recovery output',
+    });
+
+    expect(hasPendingAsync(dir)).toBe(true);
+    expect(discoverCandidates(baseDir, { all: true })[0]).toMatchObject({
+      pendingAsync: true,
+      query: null,
+    });
   });
 
   it('is false for a run dir with no async indicators', () => {
@@ -282,6 +358,26 @@ describe('unsafeBaseDirReason', () => {
 
   it('allows a normal output dir', () => {
     expect(unsafeBaseDirReason(baseDir)).toBeNull();
+  });
+
+  it('rejects a symbolic-link base before discovery or deletion', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'librarium-cleanup-target-'));
+    const linkedBase = `${baseDir}-link`;
+    try {
+      mkdirSync(join(outside, '100-run'));
+      symlinkSync(outside, linkedBase);
+
+      expect(unsafeBaseDirReason(linkedBase)).toMatch(/symbolic-link/);
+      expect(discoverCandidates(linkedBase, { all: true })).toEqual([]);
+      expect(isInsideBaseDir(linkedBase, join(linkedBase, '100-run'))).toBe(
+        false,
+      );
+    } finally {
+      try {
+        unlinkSync(linkedBase);
+      } catch {}
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/dispatcher-metering.test.ts
+++ b/tests/dispatcher-metering.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ESTIMATE_BUDGET_SKIP_REASON } from '../src/core/budget.js';
+import { providerArtifactFileNames } from '../src/node-run-artifacts.js';
 import type {
   Config,
   Provider,
@@ -114,6 +115,37 @@ describe('dispatcher: metering attachment', () => {
     const est = reports.find((r) => r.id === 'serpapi')?.metering?.estimate;
     expect(est?.estimatedCostUsd).toBe(0.03);
     expect(est?.costConfidence).toBe('configured');
+  });
+
+  it('matches Node artifact names for sanitized-ID collisions', async () => {
+    const providerIds = ['a:b', 'a?b'];
+    for (const id of providerIds) registerProvider(searchProvider(id));
+
+    const { reports } = await dispatch({
+      config: makeConfig({
+        'a:b': { apiKey: '', enabled: true },
+        'a?b': { apiKey: '', enabled: true },
+      }),
+      providerIds,
+      query: 'q',
+      mode: 'sync',
+      credentials: { env: {} },
+    });
+
+    const names = providerIds.map((id) => {
+      const report = reports.find((candidate) => candidate.id === id);
+      return {
+        id,
+        outputFile: report?.outputFile,
+        metaFile: report?.metaFile,
+      };
+    });
+
+    for (const name of names) {
+      expect(name).toMatchObject(providerArtifactFileNames(name.id));
+    }
+    expect(names[0]?.outputFile).not.toBe(names[1]?.outputFile);
+    expect(names[0]?.metaFile).not.toBe(names[1]?.metaFile);
   });
 });
 

--- a/tests/fixtures/commit-retrieved.ts
+++ b/tests/fixtures/commit-retrieved.ts
@@ -1,0 +1,31 @@
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+} from '../../src/node-run-artifacts.js';
+
+const [, , runDir, content] = process.argv;
+if (!runDir || content === undefined) {
+  throw new Error('Usage: commit-retrieved <run-dir> <content>');
+}
+
+const names = providerArtifactFileNames('provider-a');
+
+new RunArtifactRepository({ now: () => 10 }).commitRetrieved({
+  runDir,
+  providerId: 'provider-a',
+  taskId: 'task-a',
+  report: {
+    id: 'provider-a',
+    tier: 'deep-research',
+    status: 'success',
+    durationMs: 1,
+    wordCount: content.split(/\s+/).filter(Boolean).length,
+    citationCount: 1,
+    outputFile: names.outputFile,
+    metaFile: names.metaFile,
+  },
+  content,
+  meta: {
+    citations: [{ url: 'https://provider-a.test', provider: 'provider-a' }],
+  },
+});

--- a/tests/html-report.test.ts
+++ b/tests/html-report.test.ts
@@ -730,7 +730,10 @@ describe('writeHtmlReport', () => {
         provider: providerId,
         durationMs: 95_000,
         citationCount: 14,
-        citations: [],
+        citations: Array.from({ length: 14 }, (_, index) => ({
+          provider: providerId,
+          url: `https://example.test/html-${index}`,
+        })),
       }),
     );
 

--- a/tests/html-report.test.ts
+++ b/tests/html-report.test.ts
@@ -1,16 +1,23 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   answerBody,
-  enrichRetrievedReports,
   escapeHtml,
   generateHtmlReport,
   renderMarkdown,
   safeUrl,
   writeHtmlReport,
+  writeHtmlReportFromSnapshot,
 } from '../src/commands/html-report.js';
+import { RunArtifactRepository } from '../src/node-run-artifacts.js';
 import type {
   DeduplicatedSource,
   ProviderReport,
@@ -675,7 +682,7 @@ describe('writeHtmlReport', () => {
     writeFileSync(join(dir, 'sources.json'), JSON.stringify(SOURCES));
 
     const reportPath = writeHtmlReport(dir);
-    expect(reportPath).toBe(join(dir, 'report.html'));
+    expect(reportPath).toBe(join(realpathSync(dir), 'report.html'));
     const html = readFileSync(reportPath as string, 'utf-8');
     expect(html).toContain('Exa findings');
     expect(html).toContain('PgBouncer docs');
@@ -699,45 +706,47 @@ describe('writeHtmlReport', () => {
     expect(html).toContain('synthesized by openai / gpt-5-mini');
   });
 
-  it('fills in retrieved results for reports still marked async-pending', () => {
+  it('writes a recovery snapshot without changing durable pending state', () => {
+    const providerId = '__proto__';
     const manifest = makeManifest({
       providers: [
         makeReport({
-          id: 'openai-deep',
+          id: providerId,
           tier: 'deep-research',
           status: 'async-pending',
           outputFile: '',
           metaFile: '',
           durationMs: 0,
           citationCount: 0,
+          task: { taskId: 'opaque-task', submittedAt: 1, status: 'completed' },
         }),
       ],
     });
     writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
-    writeFileSync(join(dir, 'openai-deep.md'), '# Deep findings\n\nretrieved');
+    writeFileSync(join(dir, '__proto__.md'), '# Deep findings\n\nretrieved');
     writeFileSync(
-      join(dir, 'openai-deep.meta.json'),
-      JSON.stringify({ durationMs: 95_000, citationCount: 14 }),
+      join(dir, '__proto__.meta.json'),
+      JSON.stringify({
+        provider: providerId,
+        durationMs: 95_000,
+        citationCount: 14,
+        citations: [],
+      }),
     );
 
-    const reportPath = writeHtmlReport(dir) as string;
+    const before = readFileSync(join(dir, 'run.json'), 'utf-8');
+    const repository = new RunArtifactRepository();
+    const snapshot = repository.readSnapshot(dir, { view: 'recovery' });
+    expect(snapshot.manifest.providers[0]?.status).toBe('async-pending');
+    expect(snapshot.reports[0]?.status).toBe('success');
+    expect(Object.hasOwn(snapshot.providerArtifacts, providerId)).toBe(true);
+
+    const reportPath = writeHtmlReportFromSnapshot(snapshot, repository);
     const html = readFileSync(reportPath, 'utf-8');
     expect(html).toContain('Deep findings');
+    expect(html).toContain('<span class="pid">__proto__</span>');
     expect(html).toContain('14 sources');
     expect(html).not.toContain('Result not retrieved yet');
-  });
-});
-
-describe('enrichRetrievedReports', () => {
-  it('leaves pending reports untouched when no file exists', () => {
-    const reports = [
-      makeReport({
-        status: 'async-pending',
-        id: 'openai-deep',
-        outputFile: '',
-      }),
-    ];
-    const enriched = enrichRetrievedReports('/nonexistent-dir', reports);
-    expect(enriched[0]?.status).toBe('async-pending');
+    expect(readFileSync(join(dir, 'run.json'), 'utf-8')).toBe(before);
   });
 });

--- a/tests/jsonl-report.test.ts
+++ b/tests/jsonl-report.test.ts
@@ -1,11 +1,19 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   generateJsonlReport,
   writeJsonlReport,
+  writeJsonlReportFromSnapshot,
 } from '../src/commands/jsonl-report.js';
+import { RunArtifactRepository } from '../src/node-run-artifacts.js';
 import type {
   DeduplicatedSource,
   ProviderReport,
@@ -558,7 +566,7 @@ describe('writeJsonlReport', () => {
     writeFileSync(join(dir, 'sources.json'), JSON.stringify(SOURCES));
 
     const reportPath = writeJsonlReport(dir);
-    expect(reportPath).toBe(join(dir, 'results.jsonl'));
+    expect(reportPath).toBe(join(realpathSync(dir), 'results.jsonl'));
 
     const text = readFileSync(reportPath as string, 'utf-8');
     const lines = parseLines(text) as Array<Record<string, unknown>>;
@@ -597,31 +605,45 @@ describe('writeJsonlReport', () => {
     expect(answerLine?.content).toContain('Use PgBouncer');
   });
 
-  it('fills in retrieved results for reports still marked async-pending', () => {
+  it('writes a recovery snapshot without changing durable pending state', () => {
+    const providerId = 'constructor';
     const manifest = makeManifest({
       providers: [
         makeReport({
-          id: 'openai-deep',
+          id: providerId,
           tier: 'deep-research',
           status: 'async-pending',
           outputFile: '',
           metaFile: '',
           durationMs: 0,
           citationCount: 0,
+          task: { taskId: 'opaque-task', submittedAt: 1, status: 'completed' },
         }),
       ],
     });
     writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
     writeFileSync(
-      join(dir, 'openai-deep.md'),
+      join(dir, 'constructor.md'),
       '# Deep findings\n\nretrieved content',
     );
     writeFileSync(
-      join(dir, 'openai-deep.meta.json'),
-      JSON.stringify({ durationMs: 95_000, citationCount: 14 }),
+      join(dir, 'constructor.meta.json'),
+      JSON.stringify({
+        provider: providerId,
+        durationMs: 95_000,
+        citationCount: 14,
+        citations: [],
+      }),
     );
 
-    const reportPath = writeJsonlReport(dir) as string;
+    const before = readFileSync(join(dir, 'run.json'), 'utf-8');
+    const repository = new RunArtifactRepository();
+    const snapshot = repository.readSnapshot(dir, { view: 'recovery' });
+    expect(snapshot.manifest.providers[0]?.status).toBe('async-pending');
+    expect(snapshot.reports[0]?.status).toBe('success');
+    expect(Object.hasOwn(snapshot.providerArtifacts, providerId)).toBe(true);
+
+    const reportPath = writeJsonlReportFromSnapshot(snapshot, repository);
     const text = readFileSync(reportPath, 'utf-8');
     const lines = parseLines(text) as Array<Record<string, unknown>>;
     const resultLine = lines.find((l) => l.type === 'result') as Record<
@@ -629,8 +651,9 @@ describe('writeJsonlReport', () => {
       unknown
     >;
 
-    // The enriched report should show success and the content should be present
     expect(resultLine?.status).toBe('success');
+    expect(resultLine?.id).toBe(providerId);
     expect(resultLine?.content).toContain('Deep findings');
+    expect(readFileSync(join(dir, 'run.json'), 'utf-8')).toBe(before);
   });
 });

--- a/tests/jsonl-report.test.ts
+++ b/tests/jsonl-report.test.ts
@@ -632,7 +632,10 @@ describe('writeJsonlReport', () => {
         provider: providerId,
         durationMs: 95_000,
         citationCount: 14,
-        citations: [],
+        citations: Array.from({ length: 14 }, (_, index) => ({
+          provider: providerId,
+          url: `https://example.test/jsonl-${index}`,
+        })),
       }),
     );
 

--- a/tests/mcp-async-metering.test.ts
+++ b/tests/mcp-async-metering.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { providerArtifactFileNames } from '../src/node-run-artifacts.js';
 import type {
   AsyncPollResult,
   AsyncTaskHandle,
@@ -119,7 +120,10 @@ describe('MCP check_async retrieval persists metering', () => {
 
     // .meta.json carries metering.
     const meta = JSON.parse(
-      readFileSync(join(dir, 'perplexity-sonar-deep.meta.json'), 'utf-8'),
+      readFileSync(
+        join(dir, providerArtifactFileNames('perplexity-sonar-deep').metaFile),
+        'utf-8',
+      ),
     );
     expect(meta.metering.kind).toBe('native_cost');
     expect(meta.metering.actual).toEqual({
@@ -142,6 +146,17 @@ describe('MCP check_async retrieval persists metering', () => {
       status: 'completed',
       retrievedAt: expect.any(Number),
     });
+
+    // A later inspection must not present the durable historical retrieval as
+    // an ordinary completed-and-unretrieved task.
+    const secondPass = await checkAsyncTasks(dir, false);
+    expect(secondPass.tasks).toEqual([
+      expect.objectContaining({
+        taskId: 'task-1',
+        status: 'completed',
+        retrieved: true,
+      }),
+    ]);
   });
 
   it('does not recover tasks from a corrupt run.json', async () => {
@@ -259,13 +274,13 @@ describe('MCP check_async poll state persistence', () => {
     expect(result.tasks[0]).toMatchObject({
       status: 'cancelled',
       providerStatus: 'CANCELLED',
-      error: 'cancelled by provider',
+      error: 'provider.poll_failed',
     });
     const persisted = JSON.parse(readFileSync(join(dir, 'run.json'), 'utf8'));
     expect(persisted.providers[0].task).toMatchObject({
       status: 'cancelled',
       providerStatus: 'CANCELLED',
-      lastPollError: 'cancelled by provider',
+      lastPollError: 'provider.poll_failed',
     });
     expect(persisted.providers[0].task.completedAt).toEqual(expect.any(Number));
     expect(persisted.providers[0].task.lastPolledAt).toEqual(
@@ -322,13 +337,11 @@ describe('MCP check_async poll state persistence', () => {
     expect(result.tasks[0]).toMatchObject({
       status: 'running',
       providerStatus: 'MIGRATING',
-      error: 'Unknown remote status: MIGRATING',
     });
     const persisted = JSON.parse(readFileSync(join(dir, 'run.json'), 'utf8'));
     expect(persisted.providers[0].task).toMatchObject({
       status: 'running',
       providerStatus: 'MIGRATING',
-      lastPollError: 'Unknown remote status: MIGRATING',
     });
     expect(persisted.providers[0].task.completedAt).toBeUndefined();
   });
@@ -348,14 +361,13 @@ describe('MCP check_async poll state persistence', () => {
     expect(result.tasks[0]).toMatchObject({
       status: 'failed',
       providerStatus: 'unsupported_provider',
-      error: 'Provider openai-deep does not support polling after this upgrade',
+      error: 'provider.unavailable',
     });
     const persisted = JSON.parse(readFileSync(join(dir, 'run.json'), 'utf8'));
     expect(persisted.providers[0].task).toMatchObject({
       status: 'failed',
       providerStatus: 'unsupported_provider',
-      lastPollError:
-        'Provider openai-deep does not support polling after this upgrade',
+      lastPollError: 'provider.unavailable',
     });
     expect(persisted.providers[0].task.completedAt).toEqual(expect.any(Number));
   });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -171,6 +171,40 @@ describe('mcp tool surface', () => {
     ]);
     await server.close();
   });
+
+  it('passes the merged config to check_async', async () => {
+    const config = makeConfig();
+    const runDir = join(baseDir, 'check-async');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'run.json'),
+      JSON.stringify(makeManifest({ outputDir: runDir })),
+    );
+    const checkAsync = vi.fn().mockResolvedValue({
+      runDir,
+      polled: 0,
+      retrieved: 0,
+      tasks: [],
+    });
+    const { client, server } = await connect({
+      loadMergedConfig: () => config,
+      checkAsync,
+      initialize: vi.fn().mockResolvedValue({
+        warnings: [],
+        loadedCustomProviders: [],
+        skippedCustomProviders: [],
+      }),
+    });
+
+    const result = await client.callTool({
+      name: 'check_async',
+      arguments: { runDir },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(checkAsync).toHaveBeenCalledWith(runDir, false, config);
+    await server.close();
+  });
 });
 
 describe('research tool', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -32,6 +38,7 @@ import {
   truncateProviderContent,
   UNTRUSTED_CONTENT_WARNING,
 } from '../src/mcp/shaping.js';
+import { RunArtifactRepository } from '../src/node-run-artifacts.js';
 import { createRunDir } from '../src/node-run-directory.js';
 import type {
   Config,
@@ -439,6 +446,112 @@ describe('review fixes: path containment', () => {
     const result = readRunResults(dir);
     expect(result.results[0].error).toMatch(/outside the run directory/);
     expect(result.results[0].content).toBe('');
+  });
+
+  it('keeps safe provider content when only metadata is rejected', () => {
+    const dir = join(baseDir, 'unsafe-meta');
+    mkdirSync(dir, { recursive: true });
+    const manifest = makeManifest({
+      providers: [
+        report({
+          id: 'exa',
+          outputFile: 'exa.md',
+          metaFile: '../secret.json',
+        }),
+      ],
+    });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+    writeFileSync(join(dir, 'exa.md'), '# Safe provider content');
+
+    const result = readRunResults(dir);
+
+    expect(result?.results[0]?.content).toContain('# Safe provider content');
+    expect(result?.results[0]?.error).toBeUndefined();
+  });
+
+  it('reports every rejected provider output in one run', () => {
+    const dir = join(baseDir, 'multiple-unsafe-outputs');
+    mkdirSync(dir, { recursive: true });
+    const manifest = makeManifest({
+      providers: [
+        report({ id: 'exa', outputFile: '../exa.md', metaFile: '' }),
+        report({ id: 'brave', outputFile: '../brave.md', metaFile: '' }),
+      ],
+    });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+
+    const result = readRunResults(dir);
+
+    expect(result?.results).toHaveLength(2);
+    expect(result?.results.every((entry) => entry.error !== undefined)).toBe(
+      true,
+    );
+  });
+
+  it('projects a pending historical artifact as recovered MCP content', () => {
+    const dir = join(baseDir, 'recovered');
+    mkdirSync(dir, { recursive: true });
+    const manifest = makeManifest({
+      status: 'awaiting_async',
+      providers: [
+        report({
+          id: 'historical-provider',
+          status: 'async-pending',
+          outputFile: '',
+          metaFile: '',
+          task: {
+            taskId: 'task-1',
+            submittedAt: 1,
+            status: 'pending',
+          },
+        }),
+      ],
+    });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+    writeFileSync(join(dir, 'historical-provider.md'), '# Recovered');
+    const before = readFileSync(join(dir, 'run.json'), 'utf8');
+
+    const result = readRunResults(dir);
+
+    expect(result?.summary.providers[0]?.status).toBe('success');
+    expect(result?.results[0]?.status).toBe('success');
+    expect(result?.results[0]?.content).toContain('# Recovered');
+    expect(readFileSync(join(dir, 'run.json'), 'utf8')).toBe(before);
+  });
+
+  it('reads opaque provider ids without prototype lookup', () => {
+    const ids = ['__proto__', 'constructor', 'prototype'];
+    const dir = join(baseDir, 'opaque');
+    mkdirSync(dir, { recursive: true });
+    const manifest = makeManifest({
+      providers: ids.map((id) =>
+        report({ id, outputFile: `${id}.md`, metaFile: '' }),
+      ),
+    });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+    for (const id of ids) writeFileSync(join(dir, `${id}.md`), id);
+
+    const result = readRunResults(dir);
+
+    expect(result?.results.map((entry) => entry.content)).toEqual(
+      ids.map((id) => expect.stringContaining(id)),
+    );
+    expect(Object.prototype.polluted).toBeUndefined();
+  });
+
+  it('uses an injected artifact repository for run selection and snapshots', () => {
+    const dir = join(baseDir, 'injected');
+    mkdirSync(dir, { recursive: true });
+    const manifest = makeManifest({ outputDir: dir });
+    writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+    const repository = new RunArtifactRepository();
+    const resolveSpy = vi.spyOn(repository, 'resolveRunDirectory');
+    const snapshotSpy = vi.spyOn(repository, 'readSnapshot');
+
+    expect(resolveRunDir(baseDir, dir, repository)).toBe(dir);
+    expect(readRunResults(dir, undefined, repository)).not.toBeNull();
+    expect(resolveSpy).toHaveBeenCalledWith(baseDir, dir);
+    expect(snapshotSpy).toHaveBeenCalledWith(dir, { view: 'recovery' });
   });
 });
 

--- a/tests/node-run-artifacts.test.ts
+++ b/tests/node-run-artifacts.test.ts
@@ -165,6 +165,28 @@ describe('RunArtifactRepository', () => {
     expect(mismatched.providerArtifacts['provider-a']?.meta).toBeUndefined();
   });
 
+  it('derives recovered citation counts from validated citations', () => {
+    const dir = makeRun([pending('provider-a')]);
+    writeFileSync(join(dir, 'provider-a.md'), 'recovered content');
+    writeFileSync(
+      join(dir, 'provider-a.meta.json'),
+      JSON.stringify({
+        provider: 'provider-a',
+        citationCount: 99,
+        citations: [citation('provider-a')],
+      }),
+    );
+
+    const snapshot = new RunArtifactRepository().readSnapshot(dir, {
+      view: 'recovery',
+    });
+
+    expect(snapshot.providerArtifacts['provider-a']?.meta?.citationCount).toBe(
+      1,
+    );
+    expect(snapshot.reports[0]?.citationCount).toBe(1);
+  });
+
   it('preserves persisted source accounting and opaque provider keys in recovery', () => {
     const opaque = ['__proto__', 'constructor', 'prototype'];
     const dir = makeRun(

--- a/tests/node-run-artifacts.test.ts
+++ b/tests/node-run-artifacts.test.ts
@@ -1,0 +1,579 @@
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { buildSync } from 'esbuild';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createRunManifest,
+  type RunManifest,
+  RunManifestError,
+  readRunManifest,
+} from '../src/core/run-manifest.js';
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+  resolveContainedPath,
+  resolveRunDirectory,
+} from '../src/node-run-artifacts.js';
+import type { ProviderReport } from '../src/types.js';
+
+const runs: string[] = [];
+
+afterEach(() => {
+  for (const dir of runs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function makeRun(
+  providers: ProviderReport[],
+  overrides: Partial<RunManifest> = {},
+): string {
+  const dir = mkdtempSync(join(tmpdir(), 'librarium-artifacts-'));
+  runs.push(dir);
+  createRunManifest(dir, {
+    status: 'awaiting_async',
+    timestamp: 1,
+    slug: 'artifact-test',
+    query: 'artifact test',
+    mode: 'async',
+    outputDir: '/untrusted/from-manifest',
+    providers,
+    sources: { total: 0, unique: 0, file: 'sources.json' },
+    exitCode: null,
+    ...overrides,
+  });
+  return dir;
+}
+
+function pending(provider = 'provider-a', taskId = 'task-a'): ProviderReport {
+  return {
+    id: provider,
+    tier: 'deep-research',
+    status: 'async-pending',
+    durationMs: 0,
+    wordCount: 0,
+    citationCount: 0,
+    outputFile: '',
+    metaFile: '',
+    task: { taskId, submittedAt: 1, status: 'completed' },
+  };
+}
+
+function success(
+  provider: string,
+  taskId: string,
+  outputFile = `${provider}.md`,
+  metaFile = `${provider}.meta.json`,
+): ProviderReport {
+  const generated = providerArtifactFileNames(provider);
+  return {
+    id: provider,
+    tier: 'deep-research',
+    status: 'success',
+    durationMs: 10,
+    wordCount: 2,
+    citationCount: 1,
+    outputFile:
+      outputFile === `${provider}.md` ? generated.outputFile : outputFile,
+    metaFile:
+      metaFile === `${provider}.meta.json` ? generated.metaFile : metaFile,
+    task: { taskId, submittedAt: 1, status: 'completed' },
+  };
+}
+
+const citation = (
+  provider: string,
+  url = `https://${provider}.test`,
+): {
+  url: string;
+  provider: string;
+} => ({ url, provider });
+
+describe('RunArtifactRepository', () => {
+  it('keeps strict manifest errors separate from best-effort discovery', () => {
+    const dir = makeRun([]);
+    const repository = new RunArtifactRepository();
+    expect(repository.readManifest(dir).schemaVersion).toBe(2);
+
+    writeFileSync(join(dir, 'run.json'), '{not-json');
+    expect(() => repository.readManifest(dir)).toThrow(RunManifestError);
+    expect(repository.tryReadManifest(dir)).toBeNull();
+
+    const base = mkdtempSync(join(tmpdir(), 'librarium-discovery-'));
+    runs.push(base);
+    mkdirSync(join(base, 'malformed'));
+    writeFileSync(join(base, 'malformed', 'run.json'), '{not-json');
+    expect(repository.discoverRuns(base)).toEqual([]);
+  });
+
+  it('centralizes contained paths and rejects traversal and symlink escapes', () => {
+    const dir = makeRun([]);
+    expect(resolveContainedPath(dir, 'safe.md')).toBe(join(dir, 'safe.md'));
+    expect(() => resolveContainedPath(dir, '../outside.md')).toThrow();
+    expect(() => resolveContainedPath(dir, '/tmp/outside.md')).toThrow();
+
+    const outside = mkdtempSync(join(tmpdir(), 'librarium-outside-'));
+    runs.push(outside);
+    writeFileSync(join(outside, 'secret.md'), 'secret');
+    symlinkSync(join(outside, 'secret.md'), join(dir, 'escape.md'));
+    expect(() => resolveContainedPath(dir, 'escape.md')).toThrow(/Symlink/);
+    expect(resolveRunDirectory(dirname(dir), dir)).toBe(realpathSync(dir));
+  });
+
+  it('projects recovery without mutating the authoritative manifest or inventing facts', () => {
+    const dir = makeRun([pending('provider-a')]);
+    writeFileSync(join(dir, 'provider-a.md'), '# recovered\ntext');
+    const before = readFileSync(join(dir, 'run.json'), 'utf8');
+    const repository = new RunArtifactRepository();
+    const snapshot = repository.readSnapshot(dir, { view: 'recovery' });
+
+    expect(snapshot.manifest.providers[0]?.status).toBe('async-pending');
+    expect(snapshot.reports[0]).toMatchObject({
+      id: 'provider-a',
+      status: 'success',
+      outputFile: 'provider-a.md',
+      metaFile: '',
+      wordCount: 3,
+    });
+    expect(snapshot.providerArtifacts['provider-a']).toEqual({
+      content: '# recovered\ntext',
+      recovered: true,
+    });
+    expect(snapshot.manifest.providers[0]?.task?.retrievedAt).toBeUndefined();
+    expect(readFileSync(join(dir, 'run.json'), 'utf8')).toBe(before);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.manifest)).toBe(true);
+
+    writeFileSync(
+      join(dir, 'provider-a.meta.json'),
+      JSON.stringify({
+        provider: 'other-provider',
+        citations: [citation('other-provider')],
+      }),
+    );
+    const mismatched = repository.readSnapshot(dir, { view: 'recovery' });
+    expect(mismatched.providerArtifacts['provider-a']?.meta).toBeUndefined();
+  });
+
+  it('preserves persisted source accounting and opaque provider keys in recovery', () => {
+    const opaque = ['__proto__', 'constructor', 'prototype'];
+    const dir = makeRun(
+      opaque.map((provider) => pending(provider, `task-${provider}`)),
+      { sources: { total: 5, unique: 1, file: 'sources.json' } },
+    );
+    writeFileSync(join(dir, '__proto__.md'), 'recovered');
+    writeFileSync(
+      join(dir, '__proto__.meta.json'),
+      JSON.stringify({
+        provider: '__proto__',
+        citations: [
+          {
+            url: 'https://new.test',
+            provider: '__proto__',
+            title: 'kept',
+            raw_vendor_payload: { secret: true },
+          },
+        ],
+      }),
+    );
+    const persisted = [
+      {
+        url: 'https://persisted.test',
+        normalizedUrl: 'persisted.test',
+        providers: ['__proto__'],
+        citationCount: 5,
+      },
+    ];
+    writeFileSync(join(dir, 'sources.json'), JSON.stringify(persisted));
+
+    const snapshot = new RunArtifactRepository().readSnapshot(dir, {
+      view: 'recovery',
+    });
+    for (const provider of opaque) {
+      expect(Object.hasOwn(snapshot.providerArtifacts, provider)).toBe(true);
+      expect(Object.isFrozen(snapshot.providerArtifacts[provider])).toBe(true);
+    }
+    expect(Object.prototype.polluted).toBeUndefined();
+    expect(snapshot.sources).toEqual(persisted);
+    const protoArtifact = Object.getOwnPropertyDescriptor(
+      snapshot.providerArtifacts,
+      '__proto__',
+    )?.value as { meta?: { citations: unknown } } | undefined;
+    expect(protoArtifact?.meta?.citations).toEqual([
+      { url: 'https://new.test', provider: '__proto__', title: 'kept' },
+    ]);
+
+    const collisionDir = makeRun([pending('a:b'), pending('a?b')]);
+    writeFileSync(join(collisionDir, 'a_b.md'), 'ambiguous legacy output');
+    const collisionSnapshot = new RunArtifactRepository().readSnapshot(
+      collisionDir,
+      { view: 'recovery' },
+    );
+    expect(collisionSnapshot.reports.map((report) => report.status)).toEqual([
+      'async-pending',
+      'async-pending',
+    ]);
+    expect(providerArtifactFileNames('a:b').outputFile).not.toBe(
+      providerArtifactFileNames('a?b').outputFile,
+    );
+
+    const caseDir = makeRun([pending('A'), pending('a')]);
+    writeFileSync(join(caseDir, 'a.md'), 'case-ambiguous');
+    const caseSnapshot = new RunArtifactRepository().readSnapshot(caseDir, {
+      view: 'recovery',
+    });
+    expect(caseSnapshot.reports.map((report) => report.status)).toEqual([
+      'async-pending',
+      'async-pending',
+    ]);
+  });
+
+  it('keeps normal retrieved reports authoritative and reads narrow metadata', () => {
+    const report = success('provider-a', 'task-a');
+    const dir = makeRun([report], {
+      status: 'completed',
+      mode: 'async',
+      exitCode: 0,
+      sources: { total: 1, unique: 1, file: 'sources.json' },
+    });
+    writeFileSync(join(dir, report.outputFile), 'answer text');
+    writeFileSync(
+      join(dir, report.metaFile),
+      JSON.stringify({
+        provider: 'provider-a',
+        citations: [citation('provider-a')],
+      }),
+    );
+    writeFileSync(
+      join(dir, 'sources.json'),
+      JSON.stringify([
+        {
+          url: 'https://provider-a.test',
+          normalizedUrl: 'provider-a.test',
+          providers: ['provider-a'],
+          citationCount: 1,
+        },
+      ]),
+    );
+    const snapshot = new RunArtifactRepository().readSnapshot(dir);
+    expect(snapshot.reports).toEqual([report]);
+    expect(snapshot.providerArtifacts['provider-a']?.recovered).toBe(false);
+    expect(snapshot.sources).toHaveLength(1);
+    const repository = new RunArtifactRepository();
+    expect(repository.readProviderContent(dir, 'provider-a')).toBe(
+      'answer text',
+    );
+    expect(repository.readProviderMeta(dir, 'provider-a')).toMatchObject({
+      provider: 'provider-a',
+      citations: [citation('provider-a')],
+    });
+  });
+
+  it('writes output/meta ahead of a serialized commit and retries after commit failure', () => {
+    const dir = makeRun([pending('provider-a')]);
+    const report = success('provider-a', 'task-a');
+    const failing = new RunArtifactRepository({
+      mutateManifest: (manifestDir, mutate) => {
+        const current = readRunManifest(manifestDir);
+        const draft = structuredClone(current);
+        mutate(draft);
+        throw new Error('injected manifest commit failure');
+      },
+    });
+    const input = {
+      runDir: dir,
+      providerId: 'provider-a',
+      taskId: 'task-a',
+      report,
+      content: 'answer text',
+      meta: { citations: [citation('provider-a')] },
+      now: 10,
+    } as const;
+    expect(() => failing.commitRetrieved(input)).toThrow(
+      'injected manifest commit failure',
+    );
+    expect(
+      readRunManifest(dir).providers[0]?.task?.retrievedAt,
+    ).toBeUndefined();
+    expect(JSON.parse(readFileSync(join(dir, 'sources.json'), 'utf8'))).toEqual(
+      [
+        {
+          url: 'https://provider-a.test',
+          normalizedUrl: 'provider-a.test',
+          providers: ['provider-a'],
+          citationCount: 1,
+        },
+      ],
+    );
+
+    const committed = new RunArtifactRepository({
+      now: () => 10,
+    }).commitRetrieved(input);
+    expect(committed.manifest.providers[0]?.task?.retrievedAt).toBe(10);
+    expect(committed.manifest.sources).toEqual({
+      total: 1,
+      unique: 1,
+      file: 'sources.json',
+    });
+  });
+
+  it('rejects malformed commit inputs before write-ahead artifacts', () => {
+    const dir = makeRun([pending('provider-a')]);
+    const report = success(
+      'provider-a',
+      'task-a',
+      '../escape.md',
+      'provider-a.meta.json',
+    );
+    const repository = new RunArtifactRepository();
+    expect(() =>
+      repository.commitRetrieved({
+        runDir: dir,
+        providerId: 'provider-a',
+        taskId: 'task-a',
+        report,
+        content: 'should not write',
+        meta: { citations: [citation('provider-a')] },
+      }),
+    ).toThrow();
+    expect(existsSync(join(dir, 'escape.md'))).toBe(false);
+    expect(existsSync(join(dir, 'provider-a.meta.json'))).toBe(false);
+  });
+
+  it('rejects reserved names and declared-artifact collisions before writes', () => {
+    const dir = makeRun([pending('bad\nid', 'task-control')]);
+    const repository = new RunArtifactRepository();
+    expect(() =>
+      repository.commitRetrieved({
+        runDir: dir,
+        providerId: 'bad\nid',
+        taskId: 'task-control',
+        report: success('bad\nid', 'task-control'),
+        content: 'control collision',
+        meta: { citations: [citation('bad\nid')] },
+      }),
+    ).toThrow(/reserved|collide|generated/);
+    expect(
+      existsSync(join(dir, providerArtifactFileNames('bad\nid').outputFile)),
+    ).toBe(false);
+
+    const collisionDir = makeRun([
+      success(
+        'other',
+        'task-other',
+        providerArtifactFileNames('provider-b').outputFile,
+        'other-declared.meta.json',
+      ),
+      pending('provider-b', 'task-b'),
+    ]);
+    writeFileSync(
+      join(collisionDir, 'other-declared.meta.json'),
+      JSON.stringify({ provider: 'other', citations: [citation('other')] }),
+    );
+    expect(() =>
+      repository.commitRetrieved({
+        runDir: collisionDir,
+        providerId: 'provider-b',
+        taskId: 'task-b',
+        report: success('provider-b', 'task-b'),
+        content: 'collision text',
+        meta: { citations: [citation('provider-b')] },
+      }),
+    ).toThrow(/collide/);
+    expect(existsSync(join(collisionDir, 'provider-b.meta.json'))).toBe(false);
+  });
+
+  it('rejects contradictory or non-closed report facts before any write', () => {
+    const mutations: Array<(report: ProviderReport) => void> = [
+      (report) => {
+        report.durationMs = Number.NaN;
+      },
+      (report) => {
+        report.durationMs = Number.POSITIVE_INFINITY;
+      },
+      (report) => {
+        report.wordCount = -1;
+      },
+      (report) => {
+        report.citationCount = 2;
+      },
+      (report) => {
+        report.tier = 'unknown' as ProviderReport['tier'];
+      },
+      (report) => {
+        (report as ProviderReport & { raw_extra?: unknown }).raw_extra = {
+          secret: true,
+        };
+      },
+      (report) => {
+        report.usage = { raw: { secret: true } };
+      },
+    ];
+    for (const mutate of mutations) {
+      const dir = makeRun([pending('provider-a', 'task-a')]);
+      const report = success('provider-a', 'task-a');
+      mutate(report);
+      const names = providerArtifactFileNames('provider-a');
+      expect(() =>
+        new RunArtifactRepository().commitRetrieved({
+          runDir: dir,
+          providerId: 'provider-a',
+          taskId: 'task-a',
+          report,
+          content: 'answer text',
+          meta: { citations: [citation('provider-a')] },
+        }),
+      ).toThrow();
+      expect(existsSync(join(dir, names.outputFile))).toBe(false);
+      expect(existsSync(join(dir, names.metaFile))).toBe(false);
+      expect(readRunManifest(dir).revision).toBe(0);
+    }
+
+    const timestampValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -1,
+      1.5,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+    for (const now of timestampValues) {
+      const dir = makeRun([pending('provider-a', 'task-a')]);
+      const report = success('provider-a', 'task-a');
+      const names = providerArtifactFileNames('provider-a');
+      expect(() =>
+        new RunArtifactRepository().commitRetrieved({
+          runDir: dir,
+          providerId: 'provider-a',
+          taskId: 'task-a',
+          report,
+          content: 'answer text',
+          meta: { citations: [citation('provider-a')] },
+          now,
+        }),
+      ).toThrow(/timestamp/);
+      expect(existsSync(join(dir, names.outputFile))).toBe(false);
+      expect(readRunManifest(dir).revision).toBe(0);
+    }
+    const clockDir = makeRun([pending('provider-a', 'task-a')]);
+    const clockReport = success('provider-a', 'task-a');
+    expect(() =>
+      new RunArtifactRepository({ now: () => Number.NaN }).commitRetrieved({
+        runDir: clockDir,
+        providerId: 'provider-a',
+        taskId: 'task-a',
+        report: clockReport,
+        content: 'answer text',
+        meta: { citations: [citation('provider-a')] },
+      }),
+    ).toThrow(/timestamp/);
+    expect(readRunManifest(clockDir).revision).toBe(0);
+  });
+
+  it('fails closed when another declared provider metadata file is malformed', () => {
+    const providerA = success(
+      'provider-a',
+      'task-a',
+      'provider-a.md',
+      'provider-a.meta.json',
+    );
+    const dir = makeRun([providerA, pending('provider-b', 'task-b')]);
+    writeFileSync(join(dir, providerA.outputFile), 'a');
+    writeFileSync(join(dir, providerA.metaFile), '{malformed');
+    const report = success('provider-b', 'task-b');
+    const input = {
+      runDir: dir,
+      providerId: 'provider-b',
+      taskId: 'task-b',
+      report,
+      content: 'b answer',
+      meta: { citations: [citation('provider-b')] },
+      now: 10,
+    } as const;
+    expect(() => new RunArtifactRepository().commitRetrieved(input)).toThrow(
+      /malformed|unreadable/,
+    );
+    expect(
+      readRunManifest(dir).providers[1]?.task?.retrievedAt,
+    ).toBeUndefined();
+    expect(readFileSync(join(dir, report.outputFile), 'utf8')).toBe('b answer');
+    expect(readFileSync(join(dir, report.metaFile), 'utf8')).toContain(
+      'provider-b',
+    );
+
+    writeFileSync(
+      join(dir, providerA.metaFile),
+      JSON.stringify({
+        provider: 'provider-a',
+        citations: [citation('provider-a')],
+      }),
+    );
+    const committed = new RunArtifactRepository({
+      now: () => 10,
+    }).commitRetrieved(input);
+    expect(committed.manifest.providers[1]?.task?.retrievedAt).toBe(10);
+    expect(committed.manifest.sources).toMatchObject({ total: 2, unique: 2 });
+  });
+
+  it('serializes same-task commits so the winner owns a coherent artifact set', async () => {
+    const dir = makeRun([pending('provider-a', 'task-a')]);
+    const names = providerArtifactFileNames('provider-a');
+    const fixture = join(process.cwd(), 'tests/fixtures/commit-retrieved.ts');
+    const worker = join(dir, 'commit-worker.mjs');
+    buildSync({
+      entryPoints: [fixture],
+      outfile: worker,
+      bundle: true,
+      platform: 'node',
+      format: 'esm',
+      target: 'node22.12',
+    });
+    await Promise.all(
+      ['winner-a', 'winner-b'].map(
+        (content) =>
+          new Promise<void>((resolve, reject) => {
+            const child = spawn(process.execPath, [worker, dir, content], {
+              stdio: 'pipe',
+            });
+            let stderr = '';
+            child.stderr.on('data', (chunk) => {
+              stderr += String(chunk);
+            });
+            child.on('error', reject);
+            child.on('exit', (code) => {
+              if (code === 0) resolve();
+              else reject(new Error(`commit worker exited ${code}: ${stderr}`));
+            });
+          }),
+      ),
+    );
+    const manifest = readRunManifest(dir);
+    expect(manifest.revision).toBe(1);
+    expect(manifest.providers[0]?.task?.retrievedAt).toBeDefined();
+    const content = readFileSync(join(dir, names.outputFile), 'utf8');
+    expect(['winner-a', 'winner-b']).toContain(content);
+    const meta = JSON.parse(
+      readFileSync(join(dir, names.metaFile), 'utf8'),
+    ) as { citations: Array<{ url: string }> };
+    expect(meta.citations[0]?.url).toBe('https://provider-a.test');
+    expect(JSON.parse(readFileSync(join(dir, 'sources.json'), 'utf8'))).toEqual(
+      [
+        {
+          url: 'https://provider-a.test',
+          normalizedUrl: 'provider-a.test',
+          providers: ['provider-a'],
+          citationCount: 1,
+        },
+      ],
+    );
+  });
+});

--- a/tests/node-run-artifacts.test.ts
+++ b/tests/node-run-artifacts.test.ts
@@ -319,12 +319,23 @@ describe('RunArtifactRepository', () => {
     const committed = new RunArtifactRepository({
       now: () => 10,
     }).commitRetrieved(input);
-    expect(committed.manifest.providers[0]?.task?.retrievedAt).toBe(10);
-    expect(committed.manifest.sources).toEqual({
+    expect(committed.committed).toBe(true);
+    expect(committed.snapshot.manifest.providers[0]?.task?.retrievedAt).toBe(
+      10,
+    );
+    expect(committed.snapshot.manifest.sources).toEqual({
       total: 1,
       unique: 1,
       file: 'sources.json',
     });
+
+    const alreadyCommitted = new RunArtifactRepository({
+      now: () => 11,
+    }).commitRetrieved(input);
+    expect(alreadyCommitted.committed).toBe(false);
+    expect(alreadyCommitted.snapshot.manifest.revision).toBe(
+      committed.snapshot.manifest.revision,
+    );
   });
 
   it('rejects malformed commit inputs before write-ahead artifacts', () => {
@@ -520,8 +531,14 @@ describe('RunArtifactRepository', () => {
     const committed = new RunArtifactRepository({
       now: () => 10,
     }).commitRetrieved(input);
-    expect(committed.manifest.providers[1]?.task?.retrievedAt).toBe(10);
-    expect(committed.manifest.sources).toMatchObject({ total: 2, unique: 2 });
+    expect(committed.committed).toBe(true);
+    expect(committed.snapshot.manifest.providers[1]?.task?.retrievedAt).toBe(
+      10,
+    );
+    expect(committed.snapshot.manifest.sources).toMatchObject({
+      total: 2,
+      unique: 2,
+    });
   });
 
   it('serializes same-task commits so the winner owns a coherent artifact set', async () => {

--- a/tests/node-run-reconciliation-runtime.test.ts
+++ b/tests/node-run-reconciliation-runtime.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerProvider } from '../src/adapters/index.js';
+import { writeHtmlReportFromSnapshot } from '../src/commands/html-report.js';
+import { writeJsonlReportFromSnapshot } from '../src/commands/jsonl-report.js';
+import { createRunManifest } from '../src/core/run-manifest.js';
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+} from '../src/node-run-artifacts.js';
+import { createNodeRunReconciliationRuntime } from '../src/node-run-reconciliation-runtime.js';
+import {
+  ConfigSchema,
+  type Provider,
+  type ProviderReport,
+} from '../src/types.js';
+
+const runs: string[] = [];
+
+function pending(
+  id: string,
+  taskId: string,
+  taskStatus: 'pending' | 'completed',
+): ProviderReport {
+  return {
+    id,
+    tier: 'deep-research',
+    status: 'async-pending',
+    durationMs: 0,
+    wordCount: 0,
+    citationCount: 0,
+    outputFile: '',
+    metaFile: '',
+    task: { taskId, submittedAt: 1, status: taskStatus },
+  };
+}
+
+function backgroundProvider(
+  id: string,
+  pollStatus: 'pending' | 'completed',
+  content: string,
+): Provider {
+  const result = {
+    provider: id,
+    tier: 'deep-research' as const,
+    content,
+    citations: [
+      { provider: id, url: `https://${id}.test/source`, title: `${id} source` },
+    ],
+    durationMs: 9,
+  };
+  return {
+    id,
+    displayName: id,
+    tier: 'deep-research',
+    execution: 'background',
+    envVar: '',
+    execute: async () => result,
+    submit: async (query) => ({
+      provider: id,
+      taskId: `submitted-${id}`,
+      query,
+      submittedAt: 1,
+      status: 'pending',
+    }),
+    poll: async () => ({ status: pollStatus }),
+    retrieve: async () => result,
+  };
+}
+
+afterEach(() => {
+  for (const runDir of runs.splice(0)) {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+describe('Node reconciliation runtime presentation regeneration', () => {
+  it('matches direct recovery reports while keeping summary and lifecycle authoritative', async () => {
+    const recoveredId = 'runtime-recovery-pending';
+    const retrievedId = 'runtime-retrieved';
+    const recoveredContent = '# Recovered provider\nlegacy on-disk result';
+    const retrievedContent = '# Retrieved provider\nnew committed result';
+    registerProvider(
+      backgroundProvider(recoveredId, 'pending', recoveredContent),
+    );
+    registerProvider(
+      backgroundProvider(retrievedId, 'completed', retrievedContent),
+    );
+
+    const runDir = mkdtempSync(join(tmpdir(), 'librarium-runtime-regen-'));
+    runs.push(runDir);
+    createRunManifest(runDir, {
+      status: 'awaiting_async',
+      timestamp: 1,
+      slug: 'runtime-regeneration',
+      query: 'runtime regeneration query',
+      mode: 'async',
+      outputDir: '/untrusted/output',
+      providers: [
+        pending(recoveredId, 'recover-task', 'pending'),
+        pending(retrievedId, 'retrieve-task', 'completed'),
+      ],
+      sources: { total: 0, unique: 0, file: 'sources.json' },
+      exitCode: null,
+    });
+    writeFileSync(join(runDir, `${recoveredId}.md`), recoveredContent);
+    writeFileSync(
+      join(runDir, `${recoveredId}.meta.json`),
+      JSON.stringify({
+        provider: recoveredId,
+        durationMs: 7,
+        citationCount: 1,
+        citations: [
+          {
+            provider: recoveredId,
+            url: `https://${recoveredId}.test/source`,
+          },
+        ],
+      }),
+    );
+    writeFileSync(join(runDir, 'summary.md'), 'stale summary');
+    writeFileSync(join(runDir, 'report.html'), 'stale html');
+    writeFileSync(join(runDir, 'results.jsonl'), 'stale jsonl');
+
+    const config = ConfigSchema.parse({
+      version: 1,
+      defaults: {},
+      providers: {
+        [recoveredId]: { enabled: true },
+        [retrievedId]: { enabled: true },
+      },
+    });
+    const repository = new RunArtifactRepository();
+    const runtime = createNodeRunReconciliationRuntime(config, repository);
+
+    const result = await runtime.service.reconcileOnce(runDir, {
+      retrieve: true,
+    });
+
+    expect(result).toMatchObject({ retrieved: 1, regenerated: true });
+    const authoritative = repository.readManifest(runDir);
+    expect(authoritative).toMatchObject({
+      status: 'awaiting_async',
+      exitCode: null,
+      providers: [
+        { id: recoveredId, status: 'async-pending' },
+        { id: retrievedId, status: 'success' },
+      ],
+    });
+    expect(authoritative.providers[1]).toMatchObject(
+      providerArtifactFileNames(retrievedId),
+    );
+    const summary = readFileSync(join(runDir, 'summary.md'), 'utf8');
+    expect(summary).toContain(`### ${recoveredId} [PENDING]`);
+    expect(summary).toContain(`### ${retrievedId} [OK]`);
+
+    const regeneratedHtml = readFileSync(join(runDir, 'report.html'), 'utf8');
+    const regeneratedJsonl = readFileSync(
+      join(runDir, 'results.jsonl'),
+      'utf8',
+    );
+    expect(regeneratedHtml).toContain('2 succeeded, 0 failed, 0 async pending');
+    expect(regeneratedHtml).toContain('<h1>Recovered provider</h1>');
+    expect(regeneratedHtml).toContain('legacy on-disk result');
+    expect(regeneratedHtml).toContain('<h1>Retrieved provider</h1>');
+    expect(regeneratedHtml).toContain('new committed result');
+    expect(
+      regeneratedJsonl
+        .split('\n')
+        .map((line) => JSON.parse(line) as { type: string; status?: string })
+        .filter((line) => line.type === 'result')
+        .map((line) => line.status),
+    ).toEqual(['success', 'success']);
+
+    const manifestBeforeDirectReports = readFileSync(
+      join(runDir, 'run.json'),
+      'utf8',
+    );
+    const recovery = repository.readSnapshot(runDir, { view: 'recovery' });
+    writeHtmlReportFromSnapshot(recovery, repository);
+    writeJsonlReportFromSnapshot(recovery, repository);
+
+    expect(readFileSync(join(runDir, 'report.html'), 'utf8')).toBe(
+      regeneratedHtml,
+    );
+    expect(readFileSync(join(runDir, 'results.jsonl'), 'utf8')).toBe(
+      regeneratedJsonl,
+    );
+    expect(readFileSync(join(runDir, 'run.json'), 'utf8')).toBe(
+      manifestBeforeDirectReports,
+    );
+  });
+});

--- a/tests/node-run-reconciliation.test.ts
+++ b/tests/node-run-reconciliation.test.ts
@@ -97,6 +97,54 @@ function provider(
 }
 
 describe('RunReconciliationService', () => {
+  it('counts and regenerates only the service invocation that wins a concurrent retrieval commit', async () => {
+    const runDir = makeRun([
+      pending('brave-search', 'concurrent', 'completed'),
+    ]);
+    const repository = new RunArtifactRepository();
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered = 0;
+    let bothEntered!: () => void;
+    const both = new Promise<void>((resolve) => {
+      bothEntered = resolve;
+    });
+    const retrieve = vi.fn(async () => {
+      entered++;
+      if (entered === 2) bothEntered();
+      await released;
+      return successResult('brave-search');
+    });
+    const regenerate = vi.fn();
+    const service = () =>
+      new RunReconciliationService({
+        repository,
+        resolveBackgroundProvider: () =>
+          provider(async () => ({ status: 'completed' }), retrieve),
+        getProviderConfig: () => undefined,
+        now: () => 50,
+        regenerateDerivedArtifacts: regenerate,
+      });
+
+    const first = service().reconcileOnce(runDir, { retrieve: true });
+    const second = service().reconcileOnce(runDir, { retrieve: true });
+    await both;
+    release();
+    const results = await Promise.all([first, second]);
+
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.retrieved).sort()).toEqual([0, 1]);
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(
+      results
+        .flatMap((result) => result.tasks)
+        .filter((task) => task.retrievedThisPass),
+    ).toHaveLength(1);
+    expect(readRunManifest(runDir).providers[0]?.task?.retrievedAt).toBe(50);
+  });
+
   it('polls, rescans, and retrieves newly completed plus pre-existing tasks', async () => {
     const runDir = makeRun([
       pending('brave-search', 'new-task'),

--- a/tests/node-run-reconciliation.test.ts
+++ b/tests/node-run-reconciliation.test.ts
@@ -1,0 +1,454 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createRunManifest,
+  RunManifestError,
+  readRunManifest,
+} from '../src/core/run-manifest.js';
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+} from '../src/node-run-artifacts.js';
+import {
+  type ReconciliationBackgroundProvider,
+  RunReconciliationService,
+} from '../src/node-run-reconciliation.js';
+import type {
+  AsyncPollResult,
+  ProviderReport,
+  ProviderResult,
+} from '../src/types.js';
+
+const runs: string[] = [];
+
+afterEach(() => {
+  for (const run of runs.splice(0))
+    rmSync(run, { recursive: true, force: true });
+});
+
+function makeRun(providers: ProviderReport[]): string {
+  const runDir = mkdtempSync(join(tmpdir(), 'librarium-reconcile-'));
+  runs.push(runDir);
+  createRunManifest(runDir, {
+    status: 'awaiting_async',
+    timestamp: 1,
+    slug: 'reconcile-test',
+    query: 'test query',
+    mode: 'async',
+    outputDir: '/untrusted/manifest-output',
+    providers,
+    sources: { total: 0, unique: 0, file: 'sources.json' },
+    exitCode: null,
+  });
+  return runDir;
+}
+
+function pending(
+  provider: string,
+  taskId: string,
+  status: 'pending' | 'completed' = 'pending',
+): ProviderReport {
+  return {
+    id: provider,
+    tier: 'deep-research',
+    status: 'async-pending',
+    durationMs: 0,
+    wordCount: 0,
+    citationCount: 0,
+    outputFile: '',
+    metaFile: '',
+    task: { taskId, submittedAt: 1, status },
+  };
+}
+
+function successResult(
+  provider: string,
+  text = `# ${provider}\nresult`,
+): ProviderResult {
+  return {
+    provider,
+    tier: 'raw-search',
+    content: text,
+    citations: [
+      { provider, url: `https://${provider}.test/source`, title: 'Source' },
+    ],
+    durationMs: 12,
+    tokenUsage: { input: 2, output: 3 },
+  };
+}
+
+function provider(
+  poll: (
+    handle: Parameters<ReconciliationBackgroundProvider['poll']>[0],
+  ) => Promise<AsyncPollResult>,
+  retrieve: (
+    handle: Parameters<ReconciliationBackgroundProvider['retrieve']>[0],
+  ) => Promise<ProviderResult>,
+): ReconciliationBackgroundProvider {
+  return { execution: 'background', poll, retrieve };
+}
+
+describe('RunReconciliationService', () => {
+  it('polls, rescans, and retrieves newly completed plus pre-existing tasks', async () => {
+    const runDir = makeRun([
+      pending('brave-search', 'new-task'),
+      pending('searchapi', 'old-task', 'completed'),
+    ]);
+    const polls: string[] = [];
+    const retrieves: string[] = [];
+    const configs: string[] = [];
+    const providers = new Map<string, ReconciliationBackgroundProvider>([
+      [
+        'brave-search',
+        provider(
+          async (handle) => {
+            polls.push(handle.taskId);
+            return { status: 'completed', rawStatus: 'DONE' };
+          },
+          async (handle) => {
+            retrieves.push(handle.taskId);
+            return successResult('brave-search');
+          },
+        ),
+      ],
+      [
+        'searchapi',
+        provider(
+          async () => ({ status: 'running' }),
+          async (handle) => {
+            retrieves.push(handle.taskId);
+            return successResult('searchapi');
+          },
+        ),
+      ],
+    ]);
+    let now = 100;
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: (id) => providers.get(id),
+      getProviderConfig: (id) => {
+        configs.push(id);
+        return id === 'brave-search'
+          ? { options: { perRequestUsd: 0.09 } }
+          : { options: { perRequestUsd: 0.07 } };
+      },
+      now: () => now++,
+    });
+
+    const result = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(polls).toEqual(['new-task']);
+    expect(retrieves).toEqual(['new-task', 'old-task']);
+    expect(configs).toEqual(['brave-search', 'searchapi']);
+    expect(result.polled).toBe(1);
+    expect(result.retrieved).toBe(2);
+    expect(result.tasks.map((task) => task.status)).toEqual([
+      'retrieved',
+      'retrieved',
+    ]);
+    expect(result.tasks).toEqual(result.tasks);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.tasks)).toBe(true);
+
+    const manifest = readRunManifest(runDir);
+    expect(
+      manifest.providers.every(
+        (report) => report.task?.retrievedAt !== undefined,
+      ),
+    ).toBe(true);
+    expect(manifest.providers[0]?.metering?.estimate?.estimatedCostUsd).toBe(
+      0.09,
+    );
+    expect(manifest.providers[1]?.metering?.estimate?.estimatedCostUsd).toBe(
+      0.07,
+    );
+    expect(manifest.sources.total).toBe(2);
+  });
+
+  it('persists transport errors while keeping a task retryable', async () => {
+    const runDir = makeRun([pending('brave-search', 'retry')]);
+    let shouldFail = true;
+    const poll = vi.fn(async () => {
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('temporary transport failure\nwith stack-like text');
+      }
+      return { status: 'completed' as const };
+    });
+    const retrieve = vi.fn(async () => successResult('brave-search'));
+    let now = 10;
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: () => provider(poll, retrieve),
+      getProviderConfig: () => undefined,
+      now: () => now++,
+    });
+
+    const first = await service.reconcileOnce(runDir);
+    expect(first.tasks[0]).toMatchObject({
+      status: 'pending',
+      error: 'provider.poll_failed',
+    });
+    expect(readRunManifest(runDir).providers[0]?.task).toMatchObject({
+      status: 'pending',
+      lastPollError: 'provider.poll_failed',
+    });
+    const second = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(second.retrieved).toBe(1);
+    expect(retrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write for provider retrieval errors and allows retry', async () => {
+    const runDir = makeRun([
+      pending('brave-search', 'error-task', 'completed'),
+    ]);
+    const providerResult: ProviderResult = {
+      ...successResult('brave-search'),
+      error: 'remote provider failed',
+    };
+    let result = providerResult;
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: () =>
+        provider(
+          async () => ({ status: 'completed' }),
+          async () => result,
+        ),
+      getProviderConfig: () => undefined,
+      now: () => 20,
+    });
+    const before = readFileSync(join(runDir, 'run.json'), 'utf8');
+    const first = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(first.tasks[0]).toMatchObject({ status: 'error', retrieved: false });
+    expect(readFileSync(join(runDir, 'run.json'), 'utf8')).toBe(before);
+    expect(
+      existsSync(
+        join(runDir, providerArtifactFileNames('brave-search').outputFile),
+      ),
+    ).toBe(false);
+
+    result = successResult('brave-search');
+    const second = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(second.retrieved).toBe(1);
+  });
+
+  it('terminalizes unsupported providers without invoking a resolver-owned provider', async () => {
+    const runDir = makeRun([pending('retired-provider', 'unsupported')]);
+    const resolver = vi.fn(() => undefined);
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: resolver,
+      getProviderConfig: () => undefined,
+      now: () => 30,
+    });
+    const result = await service.reconcileOnce(runDir);
+    expect(resolver).toHaveBeenCalledWith('retired-provider');
+    expect(result.tasks[0]).toMatchObject({
+      status: 'unsupported',
+      error: 'provider.unavailable',
+    });
+    expect(readRunManifest(runDir).providers[0]).toMatchObject({
+      status: 'error',
+      error: 'provider.unavailable',
+      task: { status: 'failed', providerStatus: 'unsupported_provider' },
+    });
+  });
+
+  it('fails a pre-existing completed task once when its provider is unavailable', async () => {
+    const runDir = makeRun([
+      pending('retired-provider', 'completed-unsupported', 'completed'),
+    ]);
+    const repository = new RunArtifactRepository();
+    const resolver = vi.fn(() => undefined);
+    const service = new RunReconciliationService({
+      repository,
+      resolveBackgroundProvider: resolver,
+      getProviderConfig: () => undefined,
+      now: () => 31,
+    });
+    const first = await service.reconcileOnce(runDir, { retrieve: true });
+    const manifest = readRunManifest(runDir);
+    expect(first.tasks[0]).toMatchObject({
+      status: 'unsupported',
+      error: 'provider.unavailable',
+    });
+    expect(manifest.providers[0]).toMatchObject({
+      status: 'error',
+      error: 'provider.unavailable',
+      task: {
+        status: 'failed',
+        completedAt: 31,
+        lastPollError: 'provider.unavailable',
+      },
+    });
+    const revision = manifest.revision;
+    const second = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(second.tasks[0]?.status).toBe('failed');
+    expect(readRunManifest(runDir).revision).toBe(revision);
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls regeneration once with pre-existing derived artifact flags and reports failures without rollback', async () => {
+    const runDir = makeRun([pending('brave-search', 'regen', 'completed')]);
+    writeFileSync(join(runDir, 'summary.md'), 'old summary');
+    writeFileSync(join(runDir, 'report.html'), 'old html');
+    const regenerate = vi.fn(async () => {
+      throw new Error('renderer unavailable');
+    });
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: () =>
+        provider(
+          async () => ({ status: 'completed' }),
+          async () => successResult('brave-search'),
+        ),
+      getProviderConfig: () => undefined,
+      now: () => 40,
+      regenerateDerivedArtifacts: regenerate,
+    });
+    const result = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(regenerate.mock.calls[0]?.[0]).toMatchObject({
+      refreshSummary: true,
+      refreshHtml: true,
+      refreshJsonl: false,
+    });
+    expect(result).toMatchObject({
+      retrieved: 1,
+      regenerated: false,
+      regenerationError: 'artifact.regeneration_failed',
+    });
+    expect(readRunManifest(runDir).providers[0]?.task?.retrievedAt).toBe(40);
+  });
+
+  it('continues after one provider result failure and keeps output deterministic', async () => {
+    const runDir = makeRun([
+      pending('bad-provider', 'bad', 'completed'),
+      pending('good-provider', 'good', 'completed'),
+    ]);
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: (id) =>
+        provider(
+          async () => ({ status: 'completed' }),
+          async () =>
+            id === 'bad-provider'
+              ? ({
+                  ...successResult(id),
+                  provider: 'wrong-provider',
+                } as ProviderResult)
+              : successResult(id),
+        ),
+      getProviderConfig: () => undefined,
+      now: () => 50,
+    });
+    const result = await service.reconcileOnce(runDir, { retrieve: true });
+    expect(result.retrieved).toBe(1);
+    expect(result.tasks).toMatchObject([
+      { provider: 'bad-provider', status: 'error', retrieved: false },
+      { provider: 'good-provider', status: 'retrieved', retrieved: true },
+    ]);
+    expect(
+      readRunManifest(runDir).providers[0]?.task?.retrievedAt,
+    ).toBeUndefined();
+    expect(readRunManifest(runDir).providers[1]?.task?.retrievedAt).toBe(50);
+  });
+
+  it('rejects an invalid injected timestamp before any poll mutation', async () => {
+    const runDir = makeRun([pending('brave-search', 'bad-clock')]);
+    const poll = vi.fn(async () => ({ status: 'completed' as const }));
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: () =>
+        provider(poll, async () => successResult('brave-search')),
+      getProviderConfig: () => undefined,
+      now: () => Number.NaN,
+    });
+    const before = readFileSync(join(runDir, 'run.json'), 'utf8');
+    const result = await service.reconcileOnce(runDir);
+    expect(result.tasks[0]).toMatchObject({
+      status: 'pending',
+      error: 'provider.poll_failed',
+    });
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(readFileSync(join(runDir, 'run.json'), 'utf8')).toBe(before);
+  });
+
+  it('strictly rejects duplicate provider identities before resolver or clock effects', async () => {
+    const runDir = makeRun([
+      pending('duplicate-provider', 'one'),
+      pending('duplicate-provider', 'two'),
+    ]);
+    const resolver = vi.fn(() => undefined);
+    const now = vi.fn(() => 99);
+    const service = new RunReconciliationService({
+      repository: new RunArtifactRepository(),
+      resolveBackgroundProvider: resolver,
+      getProviderConfig: () => undefined,
+      now,
+    });
+    await expect(service.reconcileOnce(runDir)).rejects.toBeInstanceOf(
+      RunManifestError,
+    );
+    expect(resolver).not.toHaveBeenCalled();
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it('strictly rejects duplicate provider/task identities before retrieval', async () => {
+    const runDir = makeRun([
+      pending('duplicate-provider', 'same'),
+      pending('duplicate-provider', 'same'),
+    ]);
+    const repository = new RunArtifactRepository();
+    expect(() => repository.readManifest(runDir)).toThrow(RunManifestError);
+  });
+
+  it('keeps poll task state monotonic and does not bump revision for stale updates', () => {
+    const runDir = makeRun([pending('monotonic-provider', 'monotonic')]);
+    const repository = new RunArtifactRepository();
+    repository.updateTask(
+      runDir,
+      'monotonic-provider',
+      'monotonic',
+      { status: 'running', lastPolledAt: 10 },
+      10,
+    );
+    const running = readRunManifest(runDir);
+    expect(running.providers[0]?.task?.status).toBe('running');
+    repository.updateTask(
+      runDir,
+      'monotonic-provider',
+      'monotonic',
+      { status: 'pending', lastPolledAt: 1 },
+      11,
+    );
+    const afterRegression = readRunManifest(runDir);
+    expect(afterRegression.providers[0]?.task?.status).toBe('running');
+    expect(afterRegression.revision).toBe(running.revision);
+    repository.updateTask(
+      runDir,
+      'monotonic-provider',
+      'monotonic',
+      { status: 'completed', completedAt: 12 },
+      12,
+    );
+    const completed = readRunManifest(runDir);
+    repository.updateTask(
+      runDir,
+      'monotonic-provider',
+      'monotonic',
+      { status: 'running', lastPollError: 'ignored' },
+      13,
+    );
+    const afterTerminal = readRunManifest(runDir);
+    expect(afterTerminal.providers[0]?.task?.status).toBe('completed');
+    expect(afterTerminal.revision).toBe(completed.revision);
+  });
+});

--- a/tests/research-run.test.ts
+++ b/tests/research-run.test.ts
@@ -15,6 +15,10 @@ import {
   type RunManifestStore,
 } from '../src/core/research-run.js';
 import { readRunManifest } from '../src/core/run-manifest.js';
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+} from '../src/node-run-artifacts.js';
 import type {
   AsyncTaskHandle,
   Config,
@@ -162,10 +166,24 @@ describe('executeResearchRun', () => {
       status: 'completed',
       exitCode: 0,
     });
-    expect(readFileSync(join(outputDir, 'embedded.md'), 'utf8')).toBe(
-      'Embedded result',
-    );
-    expect(existsSync(join(outputDir, 'embedded.meta.json'))).toBe(true);
+    const artifactNames = providerArtifactFileNames(provider.id);
+    expect(
+      readFileSync(join(outputDir, artifactNames.outputFile), 'utf8'),
+    ).toBe('Embedded result');
+    expect(existsSync(join(outputDir, artifactNames.metaFile))).toBe(true);
+    expect(result.manifest.providers[0]).toMatchObject(artifactNames);
+    expect(
+      events
+        .filter(
+          (
+            event,
+          ): event is Extract<
+            ResearchRunEvent,
+            { type: 'dispatch-progress' }
+          > => event.type === 'dispatch-progress',
+        )
+        .find((event) => event.progress.report)?.progress.report,
+    ).toMatchObject(artifactNames);
     expect(existsSync(join(outputDir, 'sources.json'))).toBe(true);
     expect(existsSync(join(outputDir, 'summary.md'))).toBe(true);
     expect(existsSync(join(outputDir, 'prompt.md'))).toBe(true);
@@ -216,6 +234,63 @@ describe('executeResearchRun', () => {
       type: 'post-dispatch-warning',
       message: 'hook exploded',
     });
+  });
+
+  it('persists initial execution through one repository in write-ahead order', async () => {
+    const outputDir = join(
+      tmpdir(),
+      `librarium-repository-${crypto.randomUUID()}`,
+    );
+    dirs.push(outputDir);
+    const provider = new EmbeddedProvider();
+    const repository = new RunArtifactRepository();
+    const create = vi.spyOn(repository, 'create');
+    const prompt = vi.spyOn(repository, 'writePrompt');
+    const upsert = vi.spyOn(repository, 'upsertProviderReport');
+    const content = vi.spyOn(repository, 'writeProviderContent');
+    const meta = vi.spyOn(repository, 'writeProviderMeta');
+    const sources = vi.spyOn(repository, 'writeSources');
+    const mutate = vi.spyOn(repository, 'mutate');
+    const summary = vi.spyOn(repository, 'writeSummary');
+
+    await executeResearchRun(
+      {
+        query: 'repository ordering',
+        config: { ...config, defaults: { ...config.defaults, outputDir } },
+        providerIds: [provider.id],
+        outputDir,
+        slug: 'repository-ordering',
+      },
+      {
+        repository,
+        providerRegistry: {
+          getProvider: () => provider,
+          getAllProviders: () => [provider],
+        },
+        httpClient: async () => ({
+          status: 200,
+          statusText: 'OK',
+          data: { answer: 'Persisted once' },
+          headers: {},
+          durationMs: 1,
+        }),
+      },
+    );
+
+    const calledBefore = (
+      earlier: ReturnType<typeof vi.spyOn>,
+      later: ReturnType<typeof vi.spyOn>,
+    ) =>
+      expect(earlier.mock.invocationCallOrder[0]).toBeLessThan(
+        later.mock.invocationCallOrder[0] ?? 0,
+      );
+    calledBefore(create, prompt);
+    calledBefore(prompt, upsert);
+    calledBefore(upsert, content);
+    calledBefore(content, meta);
+    calledBefore(meta, sources);
+    calledBefore(sources, mutate);
+    calledBefore(mutate, summary);
   });
 
   it('isolates rejecting async observers', async () => {

--- a/tests/run-artifact-cross-transport.test.ts
+++ b/tests/run-artifact-cross-transport.test.ts
@@ -1,0 +1,383 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shapeBrowseRunSnapshot } from '../src/commands/browse-data.js';
+import { writeHtmlReportFromSnapshot } from '../src/commands/html-report.js';
+import { writeJsonlReportFromSnapshot } from '../src/commands/jsonl-report.js';
+import {
+  CONTENT_DELIMITER_BEGIN,
+  CONTENT_DELIMITER_END,
+  shapeRunResultsSnapshot,
+} from '../src/mcp/shaping.js';
+import { projectRunArtifactSnapshot } from '../src/node-run-artifact-presentation.js';
+import { RunArtifactRepository } from '../src/node-run-artifacts.js';
+import {
+  type DerivedArtifactRegeneratorInput,
+  type ReconciliationBackgroundProvider,
+  RunReconciliationService,
+} from '../src/node-run-reconciliation.js';
+import type { ProviderReport, RunManifest } from '../src/types.js';
+
+const fixtureDir = fileURLToPath(
+  new URL('./fixtures/v1/artifacts/', import.meta.url),
+);
+const temporaryRuns: string[] = [];
+
+function readFixture(name: string): { raw: string; manifest: RunManifest } {
+  const raw = readFileSync(join(fixtureDir, name), 'utf8');
+  return { raw, manifest: JSON.parse(raw) as RunManifest };
+}
+
+function makeRun(manifest: RunManifest): string {
+  const runDir = mkdtempSync(join(tmpdir(), 'librarium-cross-transport-'));
+  temporaryRuns.push(runDir);
+  writeFileSync(join(runDir, 'run.json'), JSON.stringify(manifest, null, 2));
+  return runDir;
+}
+
+function normalizedDurableFacts(manifest: Readonly<RunManifest>): unknown {
+  return {
+    schemaVersion: manifest.schemaVersion,
+    status: manifest.status,
+    query: manifest.query,
+    mode: manifest.mode,
+    providers: manifest.providers.map((report) => ({
+      id: report.id,
+      tier: report.tier,
+      status: report.status,
+      durationMs: report.durationMs,
+      wordCount: report.wordCount,
+      citationCount: report.citationCount,
+      outputFile: report.outputFile ? '<provider-output>' : '',
+      metaFile: report.metaFile ? '<provider-meta>' : '',
+      task: report.task
+        ? {
+            taskId: report.task.taskId,
+            status: report.task.status,
+            providerStatus: report.task.providerStatus,
+            submittedAt: '<timestamp>',
+            ...(report.task.lastPolledAt === undefined
+              ? {}
+              : { lastPolledAt: '<timestamp>' }),
+            ...(report.task.completedAt === undefined
+              ? {}
+              : { completedAt: '<timestamp>' }),
+            ...(report.task.retrievedAt === undefined
+              ? {}
+              : { retrievedAt: '<timestamp>' }),
+          }
+        : undefined,
+    })),
+    sources: manifest.sources,
+    exitCode: manifest.exitCode,
+  };
+}
+
+function providerFacts(
+  report: Readonly<ProviderReport>,
+  content: string,
+  sources: { readonly total: number; readonly unique: number },
+): unknown {
+  return {
+    id: report.id,
+    tier: report.tier,
+    status: report.status,
+    durationMs: report.durationMs,
+    wordCount: report.wordCount,
+    citationCount: report.citationCount,
+    content,
+    sources,
+  };
+}
+
+afterEach(() => {
+  for (const runDir of temporaryRuns.splice(0)) {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+describe('run artifact cross-transport projection', () => {
+  it('keeps reconciliation and every presentation transport on one durable result', async () => {
+    const pendingFixture = readFixture('background-pending-run.json');
+    const retrievedFixture = readFixture('background-retrieved-run.json');
+    const runDir = makeRun(pendingFixture.manifest);
+    writeFileSync(join(runDir, 'summary.md'), 'stale summary');
+    writeFileSync(join(runDir, 'report.html'), 'stale html');
+
+    const providerId = pendingFixture.manifest.providers[0]?.id;
+    expect(providerId).toBe('perplexity-sonar-deep');
+    const content = Array.from(
+      { length: 42 },
+      (_, index) => `retrieved-word-${index + 1}`,
+    ).join(' ');
+    expect(content.split(/\s+/)).toHaveLength(42);
+    const citations = [
+      {
+        provider: providerId as string,
+        url: 'https://example.test/first',
+        title: 'First source',
+      },
+      {
+        provider: providerId as string,
+        url: 'https://example.test/second',
+        title: 'Second source',
+      },
+    ];
+    const backgroundProvider: ReconciliationBackgroundProvider = {
+      execution: 'background',
+      poll: async () => ({ status: 'completed', rawStatus: 'COMPLETED' }),
+      retrieve: async () => ({
+        provider: providerId as string,
+        tier: 'deep-research',
+        content,
+        citations,
+        durationMs: 0,
+      }),
+    };
+    const repository = new RunArtifactRepository();
+    const commit = vi.spyOn(repository, 'commitRetrieved');
+    const regeneration = vi.fn(
+      async (input: DerivedArtifactRegeneratorInput) => {
+        if (input.refreshSummary) {
+          repository.writeSummary(input.runDir, '# refreshed summary');
+        }
+        if (input.refreshHtml) {
+          writeHtmlReportFromSnapshot(input.snapshot, repository);
+        }
+        if (input.refreshJsonl) {
+          writeJsonlReportFromSnapshot(input.snapshot, repository);
+        }
+      },
+    );
+    const times = [1_700_000_001_000, 1_700_000_003_000];
+    const service = new RunReconciliationService({
+      repository,
+      resolveBackgroundProvider: (id) =>
+        id === providerId ? backgroundProvider : undefined,
+      getProviderConfig: () => undefined,
+      now: () => times.shift() ?? 1_700_000_003_000,
+      regenerateDerivedArtifacts: regeneration,
+    });
+
+    const first = await service.reconcileOnce(runDir, { retrieve: true });
+    const repeated = await service.reconcileOnce(runDir, { retrieve: true });
+
+    expect(first).toMatchObject({ retrieved: 1, regenerated: true });
+    expect(repeated).toMatchObject({ retrieved: 0, regenerated: false });
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(commit.mock.results[0]?.value).toMatchObject({ committed: true });
+    expect(regeneration).toHaveBeenCalledTimes(1);
+    expect(regeneration.mock.calls[0]?.[0]).toMatchObject({
+      refreshSummary: true,
+      refreshHtml: true,
+      refreshJsonl: false,
+    });
+    expect(readFileSync(join(runDir, 'summary.md'), 'utf8')).toBe(
+      '# refreshed summary',
+    );
+    expect(readFileSync(join(runDir, 'report.html'), 'utf8')).toContain(
+      content,
+    );
+    expect(existsSync(join(runDir, 'results.jsonl'))).toBe(false);
+
+    const durableBeforePresentation = readFileSync(
+      join(runDir, 'run.json'),
+      'utf8',
+    );
+    const snapshot = repository.readSnapshot(runDir, { view: 'recovery' });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(normalizedDurableFacts(snapshot.manifest)).toEqual(
+      normalizedDurableFacts(retrievedFixture.manifest),
+    );
+
+    const report = snapshot.reports[0];
+    expect(report).toBeDefined();
+    const artifact = snapshot.providerArtifacts[providerId as string];
+    expect(artifact?.content).toBe(content);
+    const expectedFacts = providerFacts(
+      report as Readonly<ProviderReport>,
+      content,
+      { total: 2, unique: 2 },
+    );
+
+    const browse = shapeBrowseRunSnapshot(snapshot);
+    const browseProvider = browse.providers[0];
+    expect(
+      providerFacts(
+        browseProvider?.report as Readonly<ProviderReport>,
+        browseProvider?.content ?? '',
+        browse.sources,
+      ),
+    ).toEqual(expectedFacts);
+
+    const mcp = shapeRunResultsSnapshot(snapshot);
+    const mcpProvider = mcp.summary.providers[0];
+    const mcpResult = mcp.results[0];
+    expect(mcpResult?.content.startsWith(CONTENT_DELIMITER_BEGIN)).toBe(true);
+    expect(mcpResult?.content.endsWith(CONTENT_DELIMITER_END)).toBe(true);
+    const unwrappedMcpContent = mcpResult?.content
+      .slice(CONTENT_DELIMITER_BEGIN.length, -CONTENT_DELIMITER_END.length)
+      .trim();
+    expect(
+      providerFacts(
+        mcpProvider as Readonly<ProviderReport>,
+        unwrappedMcpContent ?? '',
+        mcp.summary.sources,
+      ),
+    ).toEqual(expectedFacts);
+
+    const htmlPath = writeHtmlReportFromSnapshot(snapshot, repository);
+    const html = readFileSync(htmlPath, 'utf8');
+    expect(html).toContain('1 succeeded, 0 failed, 0 async pending');
+    expect(html).toContain('2 unique sources after dedupe (2 total citations)');
+    expect(html).toContain(content);
+
+    const jsonlPath = writeJsonlReportFromSnapshot(snapshot, repository);
+    const jsonl = readFileSync(jsonlPath, 'utf8')
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const runLine = jsonl.find((line) => line.type === 'run');
+    const resultLine = jsonl.find((line) => line.type === 'result');
+    expect(runLine).toMatchObject({
+      succeeded: 1,
+      failed: 0,
+      pending: 0,
+      uniqueSources: 2,
+      totalCitations: 2,
+    });
+    expect(resultLine).toMatchObject({
+      id: providerId,
+      tier: 'deep-research',
+      status: 'success',
+      durationMs: 0,
+      citationCount: 2,
+      content,
+    });
+
+    expect(readFileSync(join(runDir, 'run.json'), 'utf8')).toBe(
+      durableBeforePresentation,
+    );
+    expect(
+      readFileSync(join(fixtureDir, 'background-pending-run.json'), 'utf8'),
+    ).toBe(pendingFixture.raw);
+    expect(
+      readFileSync(join(fixtureDir, 'background-retrieved-run.json'), 'utf8'),
+    ).toBe(retrievedFixture.raw);
+  });
+
+  it('preserves an own provider content entry named __proto__', () => {
+    const fixture = readFixture('background-retrieved-run.json');
+    const manifest = structuredClone(fixture.manifest);
+    const report = manifest.providers[0];
+    expect(report).toBeDefined();
+    if (!report) return;
+    report.outputFile = '__proto__';
+    report.metaFile = '';
+    const runDir = makeRun(manifest);
+    writeFileSync(join(runDir, '__proto__'), 'prototype-safe content');
+    const snapshot = new RunArtifactRepository().readSnapshot(runDir, {
+      view: 'recovery',
+    });
+
+    const presentation = projectRunArtifactSnapshot(snapshot);
+
+    expect(Object.hasOwn(presentation.providerContents, '__proto__')).toBe(
+      true,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(
+        presentation.providerContents,
+        '__proto__',
+      )?.value,
+    ).toBe('prototype-safe content');
+    expect(Object.getPrototypeOf(presentation.providerContents)).toBe(
+      Object.prototype,
+    );
+  });
+
+  it('does not inherit content for a missing constructor artifact', () => {
+    const fixture = readFixture('background-retrieved-run.json');
+    const manifest = structuredClone(fixture.manifest);
+    const report = manifest.providers[0];
+    expect(report).toBeDefined();
+    if (!report) return;
+    report.outputFile = 'constructor';
+    report.metaFile = '';
+    const runDir = makeRun(manifest);
+    const repository = new RunArtifactRepository();
+    const snapshot = repository.readSnapshot(runDir, { view: 'recovery' });
+
+    const html = readFileSync(
+      writeHtmlReportFromSnapshot(snapshot, repository),
+      'utf8',
+    );
+    const jsonl = readFileSync(
+      writeJsonlReportFromSnapshot(snapshot, repository),
+      'utf8',
+    )
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(html).toContain('No output file found for this provider');
+    expect(jsonl.find((line) => line.type === 'result')).toMatchObject({
+      content: null,
+    });
+  });
+
+  it('uses one persisted-source summary across presentation transports', () => {
+    const fixture = readFixture('background-retrieved-run.json');
+    const manifest = structuredClone(fixture.manifest);
+    manifest.sources = { total: 0, unique: 0, file: 'sources.json' };
+    const runDir = makeRun(manifest);
+    const repository = new RunArtifactRepository();
+    repository.writeSources(runDir, [
+      {
+        url: 'https://example.test/first',
+        normalizedUrl: 'https://example.test/first',
+        providers: ['perplexity-sonar-deep'],
+        citationCount: 2,
+      },
+      {
+        url: 'https://example.test/second',
+        normalizedUrl: 'https://example.test/second',
+        providers: ['perplexity-sonar-deep'],
+        citationCount: 1,
+      },
+    ]);
+    const snapshot = repository.readSnapshot(runDir, { view: 'recovery' });
+
+    const browse = shapeBrowseRunSnapshot(snapshot);
+    const mcp = shapeRunResultsSnapshot(snapshot);
+    const html = readFileSync(
+      writeHtmlReportFromSnapshot(snapshot, repository),
+      'utf8',
+    );
+    const jsonlRun = JSON.parse(
+      readFileSync(
+        writeJsonlReportFromSnapshot(snapshot, repository),
+        'utf8',
+      ).split('\n')[0] as string,
+    ) as Record<string, unknown>;
+
+    expect(snapshot.manifest.sources).toEqual({
+      total: 0,
+      unique: 0,
+      file: 'sources.json',
+    });
+    expect(browse.sources).toEqual({ total: 3, unique: 2 });
+    expect(mcp.summary.sources).toEqual({ total: 3, unique: 2 });
+    expect(html).toContain('2 unique sources after dedupe (3 total citations)');
+    expect(jsonlRun).toMatchObject({
+      uniqueSources: 2,
+      totalCitations: 3,
+    });
+  });
+});

--- a/tests/run-artifact-cross-transport.test.ts
+++ b/tests/run-artifact-cross-transport.test.ts
@@ -18,7 +18,10 @@ import {
   shapeRunResultsSnapshot,
 } from '../src/mcp/shaping.js';
 import { projectRunArtifactSnapshot } from '../src/node-run-artifact-presentation.js';
-import { RunArtifactRepository } from '../src/node-run-artifacts.js';
+import {
+  providerArtifactFileNames,
+  RunArtifactRepository,
+} from '../src/node-run-artifacts.js';
 import {
   type DerivedArtifactRegeneratorInput,
   type ReconciliationBackgroundProvider,
@@ -200,6 +203,9 @@ describe('run artifact cross-transport projection', () => {
 
     const report = snapshot.reports[0];
     expect(report).toBeDefined();
+    expect(report).toMatchObject(
+      providerArtifactFileNames(providerId as string),
+    );
     const artifact = snapshot.providerArtifacts[providerId as string];
     expect(artifact?.content).toBe(content);
     const expectedFacts = providerFacts(

--- a/tests/run-manifest.test.ts
+++ b/tests/run-manifest.test.ts
@@ -1,9 +1,9 @@
 import { spawn } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildSync } from 'esbuild';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   applyRunLifecycle,
   createRunManifest,
@@ -19,6 +19,33 @@ import {
 import type { ProviderReport } from '../src/types.js';
 
 let dir: string;
+
+const fsFault = vi.hoisted(() => ({
+  code: undefined as string | undefined,
+  remaining: 0,
+  syscall: 'open',
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => {
+      if (
+        fsFault.remaining > 0 &&
+        args[1] === 'wx' &&
+        String(args[0]).endsWith('run.json.lock')
+      ) {
+        fsFault.remaining -= 1;
+        throw Object.assign(new Error(`injected ${fsFault.code}`), {
+          code: fsFault.code,
+          syscall: fsFault.syscall,
+        });
+      }
+      return actual.openSync(...args);
+    },
+  };
+});
 
 const pendingReport: ProviderReport = {
   id: 'openai-research',
@@ -36,7 +63,13 @@ beforeEach(() => {
   mkdirSync(dir, { recursive: true });
 });
 
-afterEach(() => rmSync(dir, { recursive: true, force: true }));
+afterEach(() => {
+  fsFault.code = undefined;
+  fsFault.remaining = 0;
+  fsFault.syscall = 'open';
+  vi.restoreAllMocks();
+  rmSync(dir, { recursive: true, force: true });
+});
 
 function create(): void {
   createRunManifest(dir, {
@@ -72,6 +105,41 @@ describe('run manifest v2 store', () => {
       RunManifestRevisionError,
     );
   });
+
+  it.each([1, 5])(
+    'retries %i transient Windows lock permission errors',
+    (failures) => {
+      create();
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+      fsFault.code = 'EPERM';
+      fsFault.remaining = failures;
+
+      expect(
+        mutateRunManifest(dir, (manifest) => (manifest.query = 'updated')),
+      ).toMatchObject({ revision: 1, query: 'updated' });
+      expect(existsSync(join(dir, 'run.json.lock'))).toBe(false);
+    },
+  );
+
+  it.each([
+    ['darwin', 'EPERM', 'open', 1],
+    ['win32', 'EPERM', 'write', 1],
+    ['win32', 'EPERM', 'open', 6],
+    ['win32', 'ENOENT', 'open', 1],
+  ] as const)(
+    'does not retry %s lock errors with code %s from %s after %i failures',
+    (platform, code, syscall, failures) => {
+      create();
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(platform);
+      fsFault.code = code;
+      fsFault.remaining = failures;
+      fsFault.syscall = syscall;
+
+      expect(() => mutateRunManifest(dir, () => {})).toThrow(
+        `injected ${code}`,
+      );
+    },
+  );
 
   it('serializes mutations across processes without losing revisions', async () => {
     create();

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -72,6 +72,7 @@ vi.mock('../src/core/config.js', () => ({
 
 import { registerStatusCommand } from '../src/commands/status.js';
 import { loadAsyncTasks, saveAsyncTasks } from '../src/core/async-manager.js';
+import { providerArtifactFileNames } from '../src/node-run-artifacts.js';
 
 function program(): Command {
   const command = new Command();
@@ -161,9 +162,12 @@ describe('status command', () => {
     await program().parseAsync(['node', 'test', 'status', '--retrieve']);
 
     expect(state.retrieve).toHaveBeenCalledTimes(1);
-    expect(readFileSync(join(dir, 'status-command-mock.md'), 'utf8')).toBe(
-      'Completed research.',
-    );
+    expect(
+      readFileSync(
+        join(dir, providerArtifactFileNames('status-command-mock').outputFile),
+        'utf8',
+      ),
+    ).toBe('Completed research.');
     expect(loadAsyncTasks(dir)).toEqual([]);
   });
 
@@ -180,7 +184,11 @@ describe('status command', () => {
 
     expect(state.poll).not.toHaveBeenCalled();
     expect(state.retrieve).toHaveBeenCalledTimes(1);
-    expect(existsSync(join(dir, 'status-command-mock.md'))).toBe(true);
+    expect(
+      existsSync(
+        join(dir, providerArtifactFileNames('status-command-mock').outputFile),
+      ),
+    ).toBe(true);
     expect(loadAsyncTasks(dir)).toEqual([]);
   });
 
@@ -196,7 +204,21 @@ describe('status command', () => {
     expect(state.retrieve).toHaveBeenCalledTimes(2);
     expect(loadAsyncTasks(firstDir)).toEqual([]);
     expect(loadAsyncTasks(secondDir)).toEqual([]);
-    expect(existsSync(join(firstDir, 'status-command-mock.md'))).toBe(true);
-    expect(existsSync(join(secondDir, 'status-command-mock.md'))).toBe(true);
+    expect(
+      existsSync(
+        join(
+          firstDir,
+          providerArtifactFileNames('status-command-mock').outputFile,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(
+          secondDir,
+          providerArtifactFileNames('status-command-mock').outputFile,
+        ),
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/usage-data.test.ts
+++ b/tests/usage-data.test.ts
@@ -26,7 +26,7 @@ function writeManifest(
   baseDir: string,
   timestampSeconds: number,
   providers: ProviderReport[],
-): void {
+): string {
   const dir = join(
     baseDir,
     `${timestampSeconds}-slug-${randomUUID().slice(0, 6)}`,
@@ -46,6 +46,7 @@ function writeManifest(
     exitCode: 0,
   };
   writeFileSync(join(dir, 'run.json'), JSON.stringify(manifest));
+  return dir;
 }
 
 describe('aggregateUsage', () => {
@@ -143,6 +144,27 @@ describe('aggregateUsage', () => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, 'run.json'), '{ not valid json');
     expect(aggregateUsage(baseDir).runCount).toBe(0);
+  });
+
+  it('uses only authoritative manifest usage, never recovered metadata', () => {
+    const dir = writeManifest(baseDir, nowSec, [
+      report('exa', { costUsd: 0.01, totalTokens: 10 }),
+    ]);
+    writeFileSync(
+      join(dir, 'exa.meta.json'),
+      JSON.stringify({
+        provider: 'exa',
+        usage: { costUsd: 999, totalTokens: 999_999 },
+        citations: [],
+      }),
+    );
+
+    const aggregate = aggregateUsage(baseDir);
+    expect(aggregate.totalCostUsd).toBeCloseTo(0.01);
+    expect(aggregate.providers[0]).toMatchObject({
+      provider: 'exa',
+      totalTokens: 10,
+    });
   });
 
   it('aggregates estimated cost separately from reported cost', () => {

--- a/tests/workers/adapters.test.ts
+++ b/tests/workers/adapters.test.ts
@@ -92,6 +92,12 @@ describe('internal adapters in workerd', () => {
 
     expect(result.asyncTasks).toEqual([]);
     expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]).toMatchObject({
+      outputFile:
+        'provider-worker-mock--d31b38595ef057e4742a7edf5bdb8342f5070092f6c5739eaab6d5f54d9687ed.md',
+      metaFile:
+        'provider-worker-mock--d31b38595ef057e4742a7edf5bdb8342f5070092f6c5739eaab6d5f54d9687ed.meta.json',
+    });
     expect(result.results[0]).toMatchObject({
       provider: 'worker-mock',
       status: 'success',


### PR DESCRIPTION
## Summary

Consolidates Librarium's durable run state behind one Node-only artifact repository and one reconciliation service shared by the CLI and MCP. Retrieval, recovery views, report regeneration, metering, and cleanup now use consistent persistence and safety rules without exposing Node-only behavior through the Worker-safe package entries.

## What's New

- Add a contained, immutable run-artifact repository with strict manifest reads, canonical hashed provider filenames, concurrent retrieval commits, and authoritative versus recovery snapshots.
- Share one reconciliation service across CLI status and MCP `check_async`, including polling, retrieval, configured metering, sanitized task-local failures, and conditional derived-artifact regeneration.
- Route initial run persistence through the repository while preserving accepted-handle write-ahead ordering and conservative failure state.
- Generate HTML, JSONL, MCP, and browse results from the same recovery presentation model; keep usage and cleanup authoritative and conservative.
- Harden path containment, symbolic-link cleanup boundaries, prototype-like artifact identities, stale task transitions, citation/source coherence, and cross-process retrieval races.
- Add a frozen cross-transport fixture and focused concurrency, security, recovery, presentation, and Worker-safe filename coverage.

## Design Decisions

**Recovery is a view, not a repair:** Historical on-disk provider artifacts can be presented as recovered without mutating `run.json`, inventing usage, or changing cleanup/accounting authority.

**Derived artifacts stay opt-in:** Retrieval always refreshes the existing summary and refreshes HTML/JSONL only when those files already exist. Regeneration failures are reported but never roll back a persisted provider result.

**The boundary remains internal:** Repository and reconciliation services are Node-only implementation details. Root and `librarium/core` exports remain Worker-safe.

## Compatibility

- Existing async-pending manifests and legacy sanitized provider artifact names remain readable through the recovery projection.
- CLI and MCP now produce equivalent retrieved content, metadata, sources, metering, and derived reports.
- No shared terminal response schema, provider contract, package export, or public library API is changed.

## Test Plan

- [x] 116 focused reconciliation/artifact/report/MCP tests across 7 files
- [x] 1,555 unit tests across 92 files
- [x] 24 Worker tests across 7 files
- [x] 11 integration tests across 2 files
- [x] 5 PTY tests across 4 files
- [x] TypeScript typecheck and Biome lint across 335 files
- [x] Production build and declarations
- [x] Packed consumer: inventory, exact exports, declarations, Worker-safe graph, side effects, and CLI
- [x] Independent architecture, security, regression, and targeted post-fix review consensus

No paid provider calls, publishing, deployment, or release actions were performed.
