### PR TITLE
feat(core): support truthful model targets

### DIFF
--- a/src/adapters/gemini-grounded.ts
+++ b/src/adapters/gemini-grounded.ts
@@ -6,6 +6,7 @@ import type {
   ProviderTier,
   ProviderUsage,
 } from '../types.js';
+import type { BaseProviderOptions } from './base.js';
 import { BaseProvider } from './base.js';
 
 interface GeminiGroundedPart {
@@ -51,6 +52,12 @@ const GEMINI_GROUNDED_MODEL = getBuiltinProviderDefaultModel('gemini-grounded');
 export class GeminiGroundedProvider extends BaseProvider {
   readonly id = 'gemini-grounded';
   readonly tier: ProviderTier = 'ai-grounded';
+  private readonly model: string;
+
+  constructor(options: BaseProviderOptions & { model?: string } = {}) {
+    super(options);
+    this.model = options.model?.trim() || GEMINI_GROUNDED_MODEL;
+  }
 
   async execute(
     query: string,
@@ -61,7 +68,7 @@ export class GeminiGroundedProvider extends BaseProvider {
 
     try {
       const response = await this.request<GeminiGroundedResponse>(
-        `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_GROUNDED_MODEL}:generateContent?key=${apiKey}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${apiKey}`,
         {
           method: 'POST',
           body: {
@@ -113,7 +120,7 @@ export class GeminiGroundedProvider extends BaseProvider {
         content,
         citations,
         durationMs,
-        model: GEMINI_GROUNDED_MODEL,
+        model: this.model,
         tokenUsage: {
           input: data.usageMetadata?.promptTokenCount,
           output: data.usageMetadata?.candidatesTokenCount,

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -6,15 +6,38 @@ import {
 import type { HttpClient, HttpStreamClient } from '../core/http-client.js';
 import { getMeteringKind } from '../core/metering.js';
 import {
+  adapterProfileBindings,
+  buildProfileBindings,
+  TargetSelectionError,
+} from '../core/profile-bindings.js';
+import { BUILTIN_PROVIDER_CATALOG } from '../core/provider-profiles.js';
+import {
   providerCredentialRef,
   providerHasCredential,
 } from '../core/provider-selection.js';
-import type { Config, Provider, ProviderMeta, ProviderTier } from '../types.js';
+import type {
+  Config,
+  Provider,
+  ProviderConfig,
+  ProviderMeta,
+  ProviderTier,
+} from '../types.js';
 import { ProviderBase } from './base.js';
 import {
   BUILTIN_PROVIDER_DESCRIPTORS,
   type BuiltInProviderDescriptor,
 } from './provider-descriptors.js';
+
+const builtinDeclarations = new Map(
+  BUILTIN_PROVIDER_CATALOG.flatMap((entry) =>
+    entry.profiles.map(
+      (profile) =>
+        [`${entry.provider_id}/${profile.profile_id}`, profile] as const,
+    ),
+  ),
+);
+const builtinProfileBindings = buildProfileBindings(builtinDeclarations);
+const builtinAdapterBindings = adapterProfileBindings();
 
 const providers = new Map<string, Provider>();
 
@@ -117,7 +140,10 @@ export function getProvidersByTier(tier: ProviderTier): Provider[] {
  * Get provider metadata for display (ls command)
  */
 export function getProviderMeta(
-  config: Record<string, { apiKey?: string; enabled?: boolean }>,
+  config: Record<
+    string,
+    Pick<ProviderConfig, 'apiKey' | 'enabled' | 'model' | 'options'>
+  >,
   credentials: CredentialContext = {},
 ): ProviderMeta[] {
   return getAllProviders().map((p) => {
@@ -130,6 +156,27 @@ export function getProviderMeta(
     const hasApiKey = requiresApiKey
       ? providerHasCredential(p, providerConfig, credentials)
       : true;
+    const identity = builtinAdapterBindings.get(p.id);
+    const binding = identity
+      ? builtinProfileBindings.get(
+          `${identity.provider_id}/${identity.profile_id}`,
+        )
+      : undefined;
+    let target;
+    try {
+      target = binding?.resolve({
+        model: providerConfig?.model,
+        options: providerConfig?.options ?? {},
+      }).profile.identity.target;
+    } catch {
+      // Invalid configuration is reported by preflight. Display the declared
+      // target rather than inventing a configured or provider-reported value.
+      target = identity
+        ? builtinDeclarations.get(
+            `${identity.provider_id}/${identity.profile_id}`,
+          )?.target
+        : undefined;
+    }
     return {
       id: p.id,
       displayName: p.displayName,
@@ -145,6 +192,7 @@ export function getProviderMeta(
           ? credentialInfo.source
           : 'missing'
         : 'literal',
+      ...(target !== undefined && { target }),
     };
   });
 }
@@ -165,6 +213,24 @@ export async function initializeProviders(
 
   for (const descriptor of BUILTIN_PROVIDER_DESCRIPTORS) {
     const configured = providerConfig[descriptor.id];
+    const identity = builtinAdapterBindings.get(descriptor.id);
+    const binding = identity
+      ? builtinProfileBindings.get(
+          `${identity.provider_id}/${identity.profile_id}`,
+        )
+      : undefined;
+    try {
+      binding?.validateModel(configured?.model);
+    } catch (error) {
+      const detail =
+        error instanceof TargetSelectionError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      warnings.push(`Skipping ${descriptor.id}: ${detail}`);
+      continue;
+    }
     const options = descriptor.optionsSchema.safeParse(
       configured?.options ?? {},
     );

--- a/src/adapters/openrouter-online.ts
+++ b/src/adapters/openrouter-online.ts
@@ -6,6 +6,7 @@ import type {
   ProviderTier,
   ProviderUsage,
 } from '../types.js';
+import type { BaseProviderOptions } from './base.js';
 import { BaseProvider } from './base.js';
 
 interface OpenRouterAnnotation {
@@ -55,6 +56,12 @@ const OPENROUTER_ONLINE_MODEL =
 export class OpenRouterOnlineProvider extends BaseProvider {
   readonly id = 'openrouter-online';
   readonly tier: ProviderTier = 'ai-grounded';
+  private readonly model: string;
+
+  constructor(options: BaseProviderOptions & { model?: string } = {}) {
+    super(options);
+    this.model = options.model?.trim() || OPENROUTER_ONLINE_MODEL;
+  }
 
   async execute(
     query: string,
@@ -74,7 +81,7 @@ export class OpenRouterOnlineProvider extends BaseProvider {
             'X-Title': 'librarium',
           },
           body: {
-            model: OPENROUTER_ONLINE_MODEL,
+            model: this.model,
             messages: [{ role: 'user', content: query }],
             tools: [{ type: 'openrouter:web_search' }],
           },
@@ -115,7 +122,7 @@ export class OpenRouterOnlineProvider extends BaseProvider {
         content: message.content?.trim() ?? '',
         citations: this.extractCitations(message.annotations),
         durationMs,
-        model: data.model ?? OPENROUTER_ONLINE_MODEL,
+        model: data.model ?? this.model,
         tokenUsage: {
           input: data.usage?.prompt_tokens,
           output: data.usage?.completion_tokens,

--- a/src/adapters/perplexity-agent-base.ts
+++ b/src/adapters/perplexity-agent-base.ts
@@ -6,6 +6,7 @@ import type {
   ProviderResult,
   ProviderUsage,
 } from '../types.js';
+import type { BaseProviderOptions } from './base.js';
 import { BackgroundBaseProvider } from './base.js';
 
 interface AgentAnnotation {
@@ -59,7 +60,14 @@ const AGENT_API_URL = 'https://api.perplexity.ai/v1/agent';
 export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider {
   abstract readonly preset: string;
 
+  private readonly underlyingModel?: string;
+
   private storedResults = new Map<string, ProviderResult>();
+
+  constructor(options: BaseProviderOptions & { model?: string } = {}) {
+    super(options);
+    this.underlyingModel = options.model?.trim() || undefined;
+  }
 
   async execute(
     query: string,
@@ -74,6 +82,9 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         headers: { Authorization: `Bearer ${apiKey}` },
         body: {
           preset: this.preset,
+          ...(this.underlyingModel !== undefined && {
+            model: this.underlyingModel,
+          }),
           input: query,
         },
         timeout: options.timeout * 1000,
@@ -114,7 +125,7 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         content,
         citations,
         durationMs,
-        model: data.model ?? this.preset,
+        ...(data.model !== undefined && { model: data.model }),
         tokenUsage: {
           input: data.usage?.input_tokens,
           output: data.usage?.output_tokens,
@@ -181,6 +192,9 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         headers: { Authorization: `Bearer ${apiKey}` },
         body: {
           preset: this.preset,
+          ...(this.underlyingModel !== undefined && {
+            model: this.underlyingModel,
+          }),
           input: 'ping',
         },
         timeout: 15000,

--- a/src/adapters/provider-descriptors.ts
+++ b/src/adapters/provider-descriptors.ts
@@ -62,9 +62,15 @@ function model(
   context: BuiltInProviderFactoryContext,
 ): string | undefined {
   return (
-    context.providerConfig?.model ??
-    getBuiltinProviderDefinition(id)?.defaultModel
+    configuredModel(context) ?? getBuiltinProviderDefinition(id)?.defaultModel
   );
+}
+
+/** Blank legacy values mean no override, matching binding resolution. */
+function configuredModel(
+  context: BuiltInProviderFactoryContext,
+): string | undefined {
+  return context.providerConfig?.model?.trim() || undefined;
 }
 
 function webSearch(context: BuiltInProviderFactoryContext): boolean {
@@ -109,12 +115,14 @@ function perplexitySearchOptions(
 
 const factories: Record<string, ProviderFactory> = {
   'perplexity-sonar-deep': () => new PerplexitySonarDeepProvider(),
-  'perplexity-deep-research': () => new PerplexityDeepResearchProvider(),
-  'perplexity-advanced-deep': () => new PerplexityAdvancedDeepProvider(),
+  'perplexity-deep-research': (context) =>
+    new PerplexityDeepResearchProvider({ model: configuredModel(context) }),
+  'perplexity-advanced-deep': (context) =>
+    new PerplexityAdvancedDeepProvider({ model: configuredModel(context) }),
   'openai-research': ({ providerConfig }) =>
     new OpenAIResearchProvider({
       model:
-        providerConfig?.model ??
+        configuredModel({ providerConfig }) ??
         getBuiltinProviderDefinition('openai-research')?.defaultModel,
       maxToolCalls: option(providerConfig, 'maxToolCalls'),
       reasoningEffort: option(providerConfig, 'reasoningEffort'),
@@ -123,9 +131,13 @@ const factories: Record<string, ProviderFactory> = {
   'gemini-deep': (context) =>
     new GeminiDeepProvider({ model: model('gemini-deep', context) }),
   'perplexity-sonar-pro': () => new PerplexitySonarProProvider(),
-  'gemini-grounded': () => new GeminiGroundedProvider(),
+  'gemini-grounded': (context) =>
+    new GeminiGroundedProvider({ model: model('gemini-grounded', context) }),
   grok: (context) => new GrokProvider({ model: model('grok', context) }),
-  'openrouter-online': () => new OpenRouterOnlineProvider(),
+  'openrouter-online': (context) =>
+    new OpenRouterOnlineProvider({
+      model: model('openrouter-online', context),
+    }),
   'brave-answers': () => new BraveAnswersProvider(),
   exa: () => new ExaProvider(),
   'you-research': () => new YouResearchProvider(),

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -66,6 +66,10 @@ export function registerLsCommand(program: Command): void {
           'Config file'.length,
           'Missing'.length,
         );
+        const targetWidth = Math.max(
+          'Target'.length,
+          ...meta.map((p) => targetLabel(p.target).length),
+        );
         const color = isColorEnabled(process.stdout);
 
         // Table header
@@ -78,6 +82,7 @@ export function registerLsCommand(program: Command): void {
           'Enabled'.padEnd(enabledWidth),
           'API Key'.padEnd(apiKeyWidth),
           'Credential'.padEnd(credentialSourceWidth),
+          'Target'.padEnd(targetWidth),
         ].join('  ');
 
         console.log(`\n${header}`);
@@ -110,6 +115,7 @@ export function registerLsCommand(program: Command): void {
             enabled.padEnd(enabledWidth),
             apiKey.padEnd(apiKeyWidth),
             credentialSource.padEnd(credentialSourceWidth),
+            targetLabel(p.target).padEnd(targetWidth),
           ].join('  ');
           console.log(configured ? row : dimText(row, color));
         }
@@ -133,4 +139,26 @@ export function registerLsCommand(program: Command): void {
         process.exitCode = 1;
       }
     });
+}
+
+function targetLabel(
+  target:
+    | {
+        primary: { model_selection: string; kind?: string; target_id?: string };
+        underlying?: {
+          model_selection: string;
+          kind?: string;
+          target_id?: string;
+        };
+      }
+    | undefined,
+): string {
+  if (!target) return 'Custom';
+  const slotLabel = (slot: typeof target.primary): string =>
+    slot.target_id ?? slot.kind ?? slot.model_selection;
+  const primary = slotLabel(target.primary);
+  const underlying = target.underlying
+    ? slotLabel(target.underlying)
+    : undefined;
+  return underlying ? `${primary} + ${underlying}` : primary;
 }

--- a/src/contracts/domain/identity.ts
+++ b/src/contracts/domain/identity.ts
@@ -86,11 +86,13 @@ export const ProfileTargetSchema = z
     }
     if (
       underlying.model_selection !== 'configurable' &&
-      underlying.model_selection !== 'fixed'
+      underlying.model_selection !== 'fixed' &&
+      underlying.model_selection !== 'provider_managed'
     ) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Underlying targets must be separately configurable or fixed',
+        message:
+          'Underlying targets must be configurable, fixed, or provider-managed',
         path: ['underlying', 'model_selection'],
       });
     }

--- a/src/contracts/examples.ts
+++ b/src/contracts/examples.ts
@@ -84,6 +84,37 @@ export const durableResearchProfile: ExecutionProfile = {
   resumability: 'durable',
 };
 
+/**
+ * A real preset-backed profile: Librarium fixes the Agent API preset while the
+ * provider owns the underlying model until a supported model is configured.
+ */
+export const perplexityPresetResearchProfile: ExecutionProfile = {
+  identity: {
+    provider_id: 'perplexity-deep-research',
+    profile_id: 'research',
+    target: {
+      primary: {
+        model_selection: 'fixed',
+        kind: 'preset',
+        target_id: 'deep-research',
+      },
+      underlying: {
+        model_selection: 'provider_managed',
+        kind: 'model',
+      },
+    },
+  },
+  result_kind: 'research_report',
+  grounding_policy: 'required',
+  observation_mode: 'api_output',
+  corpora: ['web'],
+  retrieval_method: 'research_agent',
+  access_mode: 'direct',
+  operator_id: 'perplexity',
+  invocation: 'background',
+  resumability: 'process_local',
+};
+
 export const searchResultsProfile: ExecutionProfile = {
   identity: {
     provider_id: 'brave-search',
@@ -195,6 +226,18 @@ export const representativeRequest = {
         retrieval_methods: ['research_agent'],
       },
       primary: durableResearchProfile,
+    },
+    {
+      slot_id: 'slot-perplexity-preset',
+      position: 2,
+      requirements: {
+        result_kind: 'research_report',
+        grounding_policy: 'required',
+        observation_mode: 'api_output',
+        corpora: ['web'],
+        retrieval_methods: ['research_agent'],
+      },
+      primary: perplexityPresetResearchProfile,
     },
   ],
   fallback_reserve: [

--- a/src/core/config-v2.ts
+++ b/src/core/config-v2.ts
@@ -8,6 +8,7 @@ import {
   adapterProfileBinding,
   adapterProfileBindings,
   buildProfileBindings,
+  TargetSelectionError,
 } from './profile-bindings.js';
 import { BUILTIN_PROVIDER_CATALOG } from './provider-profiles.js';
 import {
@@ -1428,21 +1429,27 @@ function semanticIssues(config: LibrariumConfigV2): {
     const binding = bindings.get(
       `${bindingIdentity.provider_id}/${bindingIdentity.profile_id}`,
     );
-    const declaration = declarations.get(
-      `${bindingIdentity.provider_id}/${bindingIdentity.profile_id}`,
-    );
-    if (
-      provider.model !== undefined &&
-      declaration?.target.primary.model_selection !== 'configurable'
-    ) {
+    let modelValid = true;
+    try {
+      binding?.validateModel(provider.model);
+    } catch (error) {
+      modelValid = false;
+      const diagnostic =
+        error instanceof TargetSelectionError
+          ? error
+          : new TargetSelectionError(
+              'config_model_invalid',
+              error instanceof Error ? error.message : 'Invalid model.',
+            );
       issues.push(
         issue(
-          'config_model_not_configurable',
+          diagnostic.code,
           pointer(['providers', id, 'model']),
-          'This provider profile does not support selecting a different model.',
+          diagnostic.message,
         ),
       );
     }
+    if (!modelValid) continue;
     try {
       const resolved = binding?.resolve({
         model: provider.model,

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -13,6 +13,8 @@ import {
   type AdapterProfileBinding,
   adapterProfileBinding,
   adapterProfileBindings,
+  buildProfileBindings,
+  TargetSelectionError,
 } from './profile-bindings.js';
 import {
   buildProviderCatalog,
@@ -820,6 +822,53 @@ function fallbackReserve(
   return { reserve, reserveOnlyAdapterIds, notices, issues };
 }
 
+/**
+ * v1 keeps retired aliases until #2439, but model selection itself follows the
+ * same exact binding policy as native v2 before any factory can run.
+ */
+function modelSelectionIssues(
+  providerConfigs: Readonly<Record<string, ProviderConfig>>,
+  catalog: readonly ProviderCatalogEntry[],
+): PreparationIssue[] {
+  const declarations = new Map(
+    catalog.flatMap((entry) =>
+      entry.profiles.map(
+        (profile) =>
+          [`${entry.provider_id}/${profile.profile_id}`, profile] as const,
+      ),
+    ),
+  );
+  const bindings = buildProfileBindings(declarations);
+  const adapterBindings = adapterProfileBindings();
+  const issues: PreparationIssue[] = [];
+
+  for (const [adapterId, provider] of Object.entries(providerConfigs)) {
+    const identity = adapterBindings.get(adapterId);
+    if (!identity) continue;
+    const binding = bindings.get(
+      `${identity.provider_id}/${identity.profile_id}`,
+    );
+    try {
+      binding?.validateModel(provider.model);
+    } catch (error) {
+      const diagnostic =
+        error instanceof TargetSelectionError
+          ? error
+          : new TargetSelectionError(
+              'config_model_invalid',
+              error instanceof Error ? error.message : 'Invalid model.',
+            );
+      issues.push({
+        code: diagnostic.code,
+        phase: 'migration',
+        path: `/providers/${escapePointerSegment(adapterId)}/model`,
+        message: diagnostic.message,
+      });
+    }
+  }
+  return issues;
+}
+
 function sameProfile(
   left: Pick<AdapterProfileBinding, 'provider_id' | 'profile_id'>,
   right: Pick<AdapterProfileBinding, 'provider_id' | 'profile_id'>,
@@ -1088,6 +1137,10 @@ export function mapConfiguration(
     ...custom.issues,
     ...canonicalGroups.issues,
     ...fallback.issues,
+    ...modelSelectionIssues(
+      providerConfigs,
+      options.catalog ?? BUILTIN_PROVIDER_CATALOG,
+    ),
   ];
   const deadlineMigration = deadlineMigrationContext(
     config,

--- a/src/core/profile-bindings.ts
+++ b/src/core/profile-bindings.ts
@@ -43,6 +43,8 @@ export interface ProfileBinding {
   readonly adapter_id: string;
   readonly binding_id: string;
   readonly options_schema: z.ZodTypeAny;
+  /** Validates a top-level v1/v2 model override before adapter construction. */
+  validateModel(model?: string): void;
   resolve(config?: ProfileBindingConfig): {
     readonly profile: ExecutionProfile;
     readonly estimate?: NetworkFreeEstimate;
@@ -50,6 +52,84 @@ export interface ProfileBinding {
 }
 
 export class ProfileBindingError extends Error {}
+
+/** A stable, path-independent diagnostic from the shared target policy. */
+export class TargetSelectionError extends ProfileBindingError {
+  constructor(
+    readonly code:
+      | 'config_model_not_configurable'
+      | 'config_model_not_allowed'
+      | 'config_model_invalid',
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Exact reviewed models which preserve each provider's dedicated tool contract.
+ *
+ * These lists are intentionally small. A provider may add a model only after a
+ * reviewed compatibility change; a prefix or family match would silently turn
+ * an unsupported configuration into a paid request.
+ */
+const MODEL_OVERRIDE_ALLOWLISTS: Readonly<Record<string, ReadonlySet<string>>> =
+  {
+    'gemini-grounded': new Set(['gemini-2.5-flash', 'gemini-2.5-pro']),
+    'openrouter-online': new Set(['openai/gpt-4o-mini', 'openai/gpt-4o']),
+  };
+
+function normalizedConfiguredModel(
+  model: string | undefined,
+): string | undefined {
+  const normalized = model?.trim();
+  return normalized || undefined;
+}
+
+/**
+ * Apply the one model-selection policy shared by catalog resolution and both
+ * configuration ingress paths. It deliberately validates only a selected
+ * model. Omission and whitespace preserve the declared/provider-owned target.
+ */
+function validateConfiguredModel(
+  profile: ExecutionProfile,
+  adapterId: string,
+  model: string | undefined,
+): void {
+  const configured = normalizedConfiguredModel(model);
+  if (!configured) return;
+
+  const target = profile.identity.target;
+  const slot =
+    target.primary.model_selection === 'configurable'
+      ? target.primary
+      : target.primary.kind !== 'model' &&
+          target.underlying?.model_selection === 'provider_managed'
+        ? target.underlying
+        : undefined;
+  if (!slot) {
+    throw new TargetSelectionError(
+      'config_model_not_configurable',
+      'This provider profile does not support selecting a different model.',
+    );
+  }
+
+  const parsed = OpaqueIdSchema.safeParse(configured);
+  if (!parsed.success) {
+    throw new TargetSelectionError(
+      'config_model_invalid',
+      parsed.error.issues[0]?.message ?? 'Invalid model identifier.',
+    );
+  }
+
+  const allowlist = MODEL_OVERRIDE_ALLOWLISTS[adapterId];
+  if (allowlist && !allowlist.has(parsed.data)) {
+    throw new TargetSelectionError(
+      'config_model_not_allowed',
+      `The configured model is not supported by ${adapterId}; choose a reviewed compatible model.`,
+    );
+  }
+}
 
 /**
  * Only exact, plan-priced metering yields a cost estimate.
@@ -138,19 +218,35 @@ function bindingEstimate(adapterId: string): NetworkFreeEstimate | undefined {
  */
 function configuredTargetProjection(
   profile: ExecutionProfile,
+  adapterId: string,
   configuredModel: string | undefined,
 ): ExecutionProfile {
-  const primary = profile.identity.target.primary;
-  if (primary.model_selection !== 'configurable') return profile;
+  validateConfiguredModel(profile, adapterId, configuredModel);
+  const targetId = normalizedConfiguredModel(configuredModel);
+  if (!targetId) return profile;
 
-  const targetId = configuredModel?.trim();
-  if (!targetId || targetId === primary.target_id) return profile;
+  const target = profile.identity.target;
+  const primary = target.primary;
+  if (primary.model_selection === 'configurable') {
+    if (targetId === primary.target_id) return profile;
+    return {
+      ...profile,
+      identity: {
+        ...profile.identity,
+        target: {
+          ...target,
+          primary: { ...primary, target_id: targetId },
+        },
+      },
+    };
+  }
 
-  const validated = OpaqueIdSchema.safeParse(targetId);
-  if (!validated.success) {
-    throw new ProfileBindingError(
-      `model: ${validated.error.issues[0]?.message ?? 'Invalid target identifier'}`,
-    );
+  const underlying = target.underlying;
+  if (
+    primary.kind === 'model' ||
+    underlying?.model_selection !== 'provider_managed'
+  ) {
+    return profile;
   }
 
   return {
@@ -158,8 +254,12 @@ function configuredTargetProjection(
     identity: {
       ...profile.identity,
       target: {
-        ...profile.identity.target,
-        primary: { ...primary, target_id: validated.data },
+        ...target,
+        underlying: {
+          model_selection: 'configurable',
+          kind: 'model',
+          target_id: targetId,
+        },
       },
     },
   };
@@ -180,6 +280,9 @@ function bind(input: BindingInput): ProfileBinding {
       input.binding_id ??
       `${input.provider_id}.${input.declaration.profile_id}.${input.adapter_id}`,
     options_schema: optionsSchema,
+    validateModel(model?: string) {
+      validateConfiguredModel(declared, input.adapter_id, model);
+    },
     resolve(config?: ProfileBindingConfig) {
       const parsed = optionsSchema.safeParse(config?.options ?? {});
       if (!parsed.success) {
@@ -198,7 +301,11 @@ function bind(input: BindingInput): ProfileBinding {
         : declared;
       // The configured identifier is applied last so an options-driven strategy
       // change (web search off, widened corpora) never discards it.
-      const profile = configuredTargetProjection(projected, config?.model);
+      const profile = configuredTargetProjection(
+        projected,
+        input.adapter_id,
+        config?.model,
+      );
       return { profile, ...(estimate && { estimate }) };
     },
   });

--- a/src/core/provider-profiles.ts
+++ b/src/core/provider-profiles.ts
@@ -99,6 +99,14 @@ function providerManagedTarget(
   };
 }
 
+/** A fixed provider preset may expose a separately selected underlying model. */
+function fixedPresetWithUnderlyingModel(preset: string): ProfileTarget {
+  return {
+    primary: { model_selection: 'fixed', kind: 'preset', target_id: preset },
+    underlying: { model_selection: 'provider_managed', kind: 'model' },
+  };
+}
+
 interface ProfileInput {
   readonly profile_id: string;
   readonly selection_order: number;
@@ -390,7 +398,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
       declare({
         profile_id: 'grounded',
         selection_order: 220,
-        target: fixedTarget('model', 'gemini-2.5-flash'),
+        target: configurableTarget('model', 'gemini-2.5-flash'),
         result_kind: 'grounded_answer',
         grounding_policy: 'required',
         corpora: ['web'],
@@ -490,7 +498,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
       declare({
         profile_id: 'research',
         selection_order: 110,
-        target: fixedTarget('preset', 'deep-research'),
+        target: fixedPresetWithUnderlyingModel('deep-research'),
         result_kind: 'research_report',
         grounding_policy: 'required',
         corpora: ['web'],
@@ -525,7 +533,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
       declare({
         profile_id: 'research',
         selection_order: 120,
-        target: fixedTarget('preset', 'advanced-deep-research'),
+        target: fixedPresetWithUnderlyingModel('advanced-deep-research'),
         result_kind: 'research_report',
         grounding_policy: 'required',
         corpora: ['web'],
@@ -616,7 +624,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
       declare({
         profile_id: 'grounded',
         selection_order: 260,
-        target: fixedTarget('model', 'openai/gpt-4o-mini'),
+        target: configurableTarget('model', 'openai/gpt-4o-mini'),
         result_kind: 'grounded_answer',
         grounding_policy: 'required',
         corpora: ['web'],

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -252,6 +252,7 @@ export function createMcpServer(deps: McpServerDeps = {}): McpServer {
             keyConfigured: p.hasApiKey,
             credentialSource: p.credentialSource,
             configured: p.configured !== false,
+            target: p.target,
           })),
         });
       } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { OpaqueIdSchema } from './contracts/common.js';
 import {
   type ExecutionProfile,
   ExecutionProfileSchema,
+  type ProfileTarget,
 } from './contracts/domain/index.js';
 
 // Provider tiers
@@ -239,6 +240,8 @@ export interface ProviderMeta {
   configured?: boolean;
   /** How this provider is metered/priced (from the metering registry). */
   meteringKind?: MeteringKind;
+  /** Configured execution target, not a provider-reported runtime observation. */
+  target?: ProfileTarget;
 }
 
 // Config for a single provider

--- a/tests/adapters/grounded-providers.test.ts
+++ b/tests/adapters/grounded-providers.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { GeminiGroundedProvider } from '../../src/adapters/gemini-grounded.js';
 import { OpenRouterOnlineProvider } from '../../src/adapters/openrouter-online.js';
+import { PerplexityAdvancedDeepProvider } from '../../src/adapters/perplexity-advanced-deep.js';
+import { PerplexityDeepResearchProvider } from '../../src/adapters/perplexity-deep-research.js';
 
 function jsonResponse(status: number, data: unknown): Response {
   return {
@@ -182,5 +184,95 @@ describe('grounded providers', () => {
     expect(result.content).toBe('');
     expect(result.citations).toEqual([]);
     expect(result.error).toContain('annotations');
+  });
+
+  it.each([
+    [
+      'Gemini grounded',
+      new GeminiGroundedProvider({
+        credentials: { env: { GEMINI_API_KEY: 'gemini-key' } },
+        model: 'gemini-2.5-pro',
+      }),
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=gemini-key',
+    ],
+    [
+      'OpenRouter online',
+      new OpenRouterOnlineProvider({
+        credentials: { env: { OPENROUTER_API_KEY: 'openrouter-key' } },
+        model: 'openai/gpt-4o',
+      }),
+      'https://openrouter.ai/api/v1/chat/completions',
+    ],
+  ] as const)(
+    'threads a configured compatible model through %s',
+    async (_name, provider, expectedUrl) => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        jsonResponse(200, {
+          candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+          choices: [
+            {
+              message: {
+                content: 'ok',
+                annotations: [],
+              },
+            },
+          ],
+        }),
+      );
+      globalThis.fetch = fetchMock;
+
+      await provider.execute('configured target', { timeout: 10 });
+      const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(expectedUrl);
+      const body = JSON.parse(options.body as string) as { model?: string };
+      expect(body.model).toBe(
+        provider.id === 'gemini-grounded' ? undefined : 'openai/gpt-4o',
+      );
+    },
+  );
+
+  it.each([
+    [PerplexityDeepResearchProvider, 'deep-research'],
+    [PerplexityAdvancedDeepProvider, 'advanced-deep-research'],
+  ] as const)(
+    'keeps the %s preset separate from an optional model and omits an unreported model',
+    async (Provider, preset) => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(200, { id: 'agent-1', status: 'completed', output: [] }),
+        );
+      globalThis.fetch = fetchMock;
+      const provider = new Provider({
+        credentials: { env: { PERPLEXITY_API_KEY: 'perplexity-key' } },
+        model: 'sonar-pro',
+      });
+
+      const result = await provider.execute('deep query', { timeout: 10 });
+      expect(result).not.toHaveProperty('model');
+      const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(JSON.parse(options.body as string)).toEqual({
+        preset,
+        model: 'sonar-pro',
+        input: 'deep query',
+      });
+    },
+  );
+
+  it('threads the configured Perplexity model through its credential check request', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(200, {}));
+    globalThis.fetch = fetchMock;
+    const provider = new PerplexityDeepResearchProvider({
+      credentials: { env: { PERPLEXITY_API_KEY: 'perplexity-key' } },
+      model: 'sonar-pro',
+    });
+
+    await expect(provider.test()).resolves.toEqual({ ok: true });
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(options.body as string)).toEqual({
+      preset: 'deep-research',
+      model: 'sonar-pro',
+      input: 'ping',
+    });
   });
 });

--- a/tests/config-v2.test.ts
+++ b/tests/config-v2.test.ts
@@ -887,6 +887,35 @@ describe('public v2 configuration migration', () => {
     ]);
   });
 
+  it('uses model diagnostics at the exact model path for fixed and allowlisted targets', () => {
+    const result = validateConfigV2(
+      v2({
+        providers: {
+          exa: { enabled: true, model: 'not-supported' },
+          'gemini-grounded': { enabled: true, model: 'gemini-3.6-flash' },
+          'openrouter-online': { enabled: true, model: 'openai/gpt-4o' },
+        },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'config_model_not_configurable',
+          path: '/providers/exa/model',
+        }),
+        expect.objectContaining({
+          code: 'config_model_not_allowed',
+          path: '/providers/gemini-grounded/model',
+        }),
+      ]),
+    );
+    expect(result.issues).not.toContainEqual(
+      expect.objectContaining({ path: '/providers/openrouter-online/model' }),
+    );
+  });
+
   it('rejects non-JSON options and invalid explicit request deadlines', () => {
     const badJson = validateConfigV2(
       v2({

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -1241,4 +1241,32 @@ describe('configuration mapping', () => {
       ['configuration_fallback_unknown_adapter', '/providers/exa/fallback'],
     ]);
   });
+
+  it('uses the shared model selection diagnostics before v1 factory construction', () => {
+    const mapped = map(
+      config({
+        providers: {
+          exa: { enabled: true, model: 'not-supported' },
+          'gemini-grounded': { enabled: true, model: 'gemini-3.6-flash' },
+          'openrouter-online': { enabled: true, model: 'openai/gpt-4o' },
+        },
+      }),
+      { requestDeadlineMs: 2_000_000 },
+    );
+    expect(mapped.preflight.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'config_model_not_configurable',
+          path: '/providers/exa/model',
+        }),
+        expect.objectContaining({
+          code: 'config_model_not_allowed',
+          path: '/providers/gemini-grounded/model',
+        }),
+      ]),
+    );
+    expect(mapped.preflight.issues).not.toContainEqual(
+      expect.objectContaining({ path: '/providers/openrouter-online/model' }),
+    );
+  });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -179,6 +179,49 @@ describe('mcp tool surface', () => {
     await server.close();
   });
 
+  it('lists configured targets without claiming provider-observed models', async () => {
+    await initializeProviders({
+      providers: { 'perplexity-deep-research': { model: 'sonar-pro' } },
+    });
+    const { client, server } = await connect({
+      loadMergedConfig: () => ({
+        ...makeConfig(),
+        providers: {
+          'perplexity-deep-research': { enabled: true, model: 'sonar-pro' },
+        },
+      }),
+      initialize: vi.fn().mockResolvedValue({
+        warnings: [],
+        loadedCustomProviders: [],
+        skippedCustomProviders: [],
+      }),
+    });
+    const response = await client.callTool({
+      name: 'list_providers',
+      arguments: {},
+    });
+    const payload = JSON.parse(
+      (response.content as { text: string }[])[0].text,
+    );
+    const provider = payload.providers.find(
+      (entry: { id: string }) => entry.id === 'perplexity-deep-research',
+    );
+    expect(provider.target).toEqual({
+      primary: {
+        model_selection: 'fixed',
+        kind: 'preset',
+        target_id: 'deep-research',
+      },
+      underlying: {
+        model_selection: 'configurable',
+        kind: 'model',
+        target_id: 'sonar-pro',
+      },
+    });
+    expect(provider).not.toHaveProperty('model');
+    await server.close();
+  });
+
   it('passes the merged config to check_async', async () => {
     const config = makeConfig();
     const runDir = join(baseDir, 'check-async');

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -3,6 +3,7 @@ import {
   type ExecutionProfile,
   ExecutionProfileSchema,
 } from '../src/contracts/domain/index.js';
+import { perplexityPresetResearchProfile } from '../src/contracts/examples.js';
 import { fallbackCompatibilityIssues } from '../src/contracts/interchange/compatibility.js';
 import type { CredentialContext } from '../src/core/credentials.js';
 import {
@@ -1132,14 +1133,19 @@ describe('provider catalog -- target selection', () => {
       },
     });
     expect(
-      built.get('perplexity-deep-research', 'research')?.profile.identity
-        .target,
+      built.get('perplexity-deep-research', 'research')?.profile.identity.target
+        .primary,
     ).toEqual({
-      primary: {
-        model_selection: 'fixed',
-        kind: 'preset',
-        target_id: 'deep-research',
-      },
+      model_selection: 'fixed',
+      kind: 'preset',
+      target_id: 'deep-research',
+    });
+    expect(
+      built.get('perplexity-deep-research', 'research')?.profile.identity.target
+        .underlying,
+    ).toEqual({
+      model_selection: 'provider_managed',
+      kind: 'model',
     });
   });
 
@@ -1147,7 +1153,9 @@ describe('provider catalog -- target selection', () => {
     for (const [providerId, profileId] of [
       ['openai-research', 'research'],
       ['gemini-deep', 'research'],
+      ['gemini-grounded', 'grounded'],
       ['grok', 'web'],
+      ['openrouter', 'grounded'],
       ['claude', 'chat'],
       ['openai-chat', 'chat'],
       ['gemini-chat', 'chat'],
@@ -1805,7 +1813,21 @@ const CONFIGURABLE_TARGET_MATRIX = [
 ] as const;
 
 describe('provider catalog -- configured target fidelity', () => {
-  it('exposes exactly the seven adapter-backed configurable targets', () => {
+  it('keeps a real contract fixture for a provider-managed underlying model', () => {
+    expect(
+      ExecutionProfileSchema.safeParse(perplexityPresetResearchProfile).success,
+    ).toBe(true);
+    expect(perplexityPresetResearchProfile.identity.target).toEqual({
+      primary: {
+        model_selection: 'fixed',
+        kind: 'preset',
+        target_id: 'deep-research',
+      },
+      underlying: { model_selection: 'provider_managed', kind: 'model' },
+    });
+  });
+
+  it('preserves the seven existing configurable primary targets', () => {
     const configurable = catalog()
       .resolved.filter(
         (item) =>
@@ -1817,12 +1839,19 @@ describe('provider catalog -- configured target fidelity', () => {
           `${item.profile.identity.provider_id}/${item.declaration.profile_id}`,
       );
 
-    expect(configurable).toEqual(
-      CONFIGURABLE_TARGET_MATRIX.map(
-        ([providerId, profileId]) => `${providerId}/${profileId}`,
-      ),
+    const existing = CONFIGURABLE_TARGET_MATRIX.map(
+      ([providerId, profileId]) => `${providerId}/${profileId}`,
     );
-    expect(configurable).toHaveLength(7);
+    expect(configurable.filter((key) => existing.includes(key))).toEqual(
+      existing,
+    );
+    expect(configurable).toHaveLength(9);
+    expect(configurable).toEqual(
+      expect.arrayContaining([
+        'gemini-grounded/grounded',
+        'openrouter/grounded',
+      ]),
+    );
   });
 
   it('resolves every configurable target to the configured identifier', () => {
@@ -1897,11 +1926,11 @@ describe('provider catalog -- configured target fidelity', () => {
     );
   });
 
-  it('never makes a fixed, provider-managed, or not-applicable target configurable', () => {
+  it('keeps dedicated, provider-managed, and raw targets truthful', () => {
     const built = buildProviderCatalog({
       providerConfigs: enabledConfigs({
         'brave-answers': { model: 'ignored-model' },
-        'openrouter-online': { model: 'ignored-model' },
+        'openrouter-online': { model: 'not-reviewed' },
         'kagi-fastgpt': { model: 'ignored-preset' },
         'you-research': { model: 'ignored-model' },
         'searchapi-chatgpt': { model: 'ignored-model' },
@@ -1914,12 +1943,8 @@ describe('provider catalog -- configured target fidelity', () => {
       built.get('brave-answers', 'grounded')?.profile.identity.target.primary,
     ).toEqual({ model_selection: 'fixed', kind: 'model', target_id: 'brave' });
     expect(
-      built.get('openrouter', 'grounded')?.profile.identity.target.primary,
-    ).toEqual({
-      model_selection: 'fixed',
-      kind: 'model',
-      target_id: 'openai/gpt-4o-mini',
-    });
+      built.get('openrouter', 'grounded')?.availability.configuration_valid,
+    ).toBe(false);
     expect(
       built.get('kagi-fastgpt', 'grounded')?.profile.identity.target.primary,
     ).toEqual({
@@ -1937,6 +1962,53 @@ describe('provider catalog -- configured target fidelity', () => {
     expect(built.get('exa', 'search')?.profile.identity.target.primary).toEqual(
       { model_selection: 'not_applicable' },
     );
+  });
+
+  it('resolves configured models for Gemini and OpenRouter only from exact reviewed allowlists', () => {
+    for (const [adapterId, providerId, profileId, model] of [
+      ['gemini-grounded', 'gemini-grounded', 'grounded', 'gemini-2.5-pro'],
+      ['openrouter-online', 'openrouter', 'grounded', 'openai/gpt-4o'],
+    ] as const) {
+      const resolved = buildProviderCatalog({
+        providerConfigs: enabledConfigs({ [adapterId]: { model } }),
+        credentials: allCredentials(),
+      }).get(providerId, profileId);
+      expect(resolved?.profile.identity.target.primary).toMatchObject({
+        model_selection: 'configurable',
+        target_id: model,
+      });
+      expect(resolved?.availability.configuration_valid).toBe(true);
+    }
+  });
+
+  it('keeps a fixed Perplexity preset with provider-managed or configured underlying model', () => {
+    const unresolved = catalog().get('perplexity-deep-research', 'research');
+    expect(unresolved?.profile.identity.target).toEqual({
+      primary: {
+        model_selection: 'fixed',
+        kind: 'preset',
+        target_id: 'deep-research',
+      },
+      underlying: { model_selection: 'provider_managed', kind: 'model' },
+    });
+    const configured = buildProviderCatalog({
+      providerConfigs: enabledConfigs({
+        'perplexity-deep-research': { model: 'sonar-pro' },
+      }),
+      credentials: allCredentials(),
+    }).get('perplexity-deep-research', 'research');
+    expect(configured?.profile.identity.target).toEqual({
+      primary: {
+        model_selection: 'fixed',
+        kind: 'preset',
+        target_id: 'deep-research',
+      },
+      underlying: {
+        model_selection: 'configurable',
+        kind: 'model',
+        target_id: 'sonar-pro',
+      },
+    });
   });
 
   it('rejects a configured identifier the contract cannot carry', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -390,6 +390,49 @@ describe('registry', () => {
     expect((gemini as { model?: string }).model).toBe('gemini-2.5-pro');
   });
 
+  it('skips unsupported target overrides before adapter factory work or fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const pastedSecret = 'sk-live-do-not-log';
+    const result = await initializeProviders({
+      providers: {
+        'gemini-grounded': { model: pastedSecret },
+        'openrouter-online': { model: 'openai/gpt-4o' },
+      },
+    });
+
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining('Skipping gemini-grounded'),
+    );
+    expect(getProvider('gemini-grounded')).toBeUndefined();
+    expect(getProvider('openrouter-online')).toBeDefined();
+    expect(result.warnings.join('\n')).not.toContain(pastedSecret);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports configured target selection without claiming an observed model', async () => {
+    await initializeProviders({
+      providers: {
+        'perplexity-deep-research': { model: 'sonar-pro' },
+      },
+    });
+    const meta = getProviderMeta({
+      'perplexity-deep-research': { enabled: true, model: 'sonar-pro' },
+    }).find((provider) => provider.id === 'perplexity-deep-research');
+    expect(meta?.target).toEqual({
+      primary: {
+        model_selection: 'fixed',
+        kind: 'preset',
+        target_id: 'deep-research',
+      },
+      underlying: {
+        model_selection: 'configurable',
+        kind: 'model',
+        target_id: 'sonar-pro',
+      },
+    });
+  });
+
   it('applies OpenAI research model and research options config', async () => {
     await initializeProviders({
       providers: {


### PR DESCRIPTION
## Summary

Make configured provider targets truthful and enforce supported model selection before adapter construction or network work. Gemini Grounded and OpenRouter Online now honor reviewed compatible models, while Perplexity Agent presets remain fixed and carry an optional, separately identified underlying model.

## What's New

- Apply one target-selection policy across catalog resolution, v1 mapping, native v2 validation, registry initialization, and provider metadata.
- Thread compatible Gemini Grounded and OpenRouter Online models into request payloads.
- Preserve Perplexity Deep and Advanced Deep preset identity while forwarding an optional underlying model, and stop inventing a model when the provider omits one.
- Expose configured target metadata through CLI and MCP provider listings without claiming provider-observed runtime identity.
- Reject unsupported overrides before factory or fetch work, with diagnostics that do not echo configured values.

## Compatibility Notes

- Existing configurable providers retain their current model behavior.
- Dedicated product endpoints, provider-managed surfaces, and model-inapplicable retrieval providers retain their catalog semantics.
- No live or paid provider validation was run; that remains a separate release-validation gate.

## Test Plan

- [x] Focused adapter, config, catalog, registry, MCP, and contract tests: 266 passed after review fixes
- [x] Full unit suite: 1,574 passed
- [x] Worker suite: 24 passed
- [x] Integration suite: 11 passed
- [x] Typecheck, Biome lint, build and declarations
- [x] Contract regeneration is byte-identical
- [x] Packed consumer inventory, exports, declarations, Worker graph, side effects, and CLI
- [x] Independent security, architecture, and regression review: final GO
