### PR TITLE
feat(core): retire legacy provider aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking retired provider IDs:** `perplexity-sonar` now requires
+  `perplexity-sonar-pro`; `perplexity-deep` now requires
+  `perplexity-sonar-deep`; and `openai-deep` and `openai-deep-o3` now require
+  `openai-research`. Current CLI, MCP, and native v2 configuration reject the
+  retired IDs. The v1 migrator still converts them without rewriting source
+  files. Completed historical artifacts retain their recorded IDs and
+  filenames, while pending retired handles cannot poll or retrieve through a
+  replacement provider.
 - **Breaking v2 configuration boundary:** strict versioned v1/v2 inputs now
   normalize through one pure snake-case v2 representation before code loading
   or network work. Legacy mixed mode becomes async with a notice; authored

--- a/README.md
+++ b/README.md
@@ -242,23 +242,15 @@ These provider IDs were renamed as their upstream products changed:
 - `openai-deep` -> `openai-research`
 - `openai-deep-o3` -> `openai-research`
 
-For backward compatibility, librarium still accepts legacy IDs in:
+These IDs are retired from current Librarium 2.0 selection. Use their
+replacement IDs in CLI, MCP, and native v2 configuration. The v1 config
+migrator still converts old IDs without rewriting the source file. If more
+than one historical OpenAI key is present, it selects `openai-research` first,
+then `openai-deep-o3`, then `openai-deep`, regardless of JSON key order.
 
-- `run --providers`
-- provider config keys in `~/.config/librarium/config.json`
-- custom group members
-- `fallback` targets
-
-Legacy IDs are normalized to canonical IDs and emit a warning. If both OpenAI
-legacy IDs are configured, they collapse to one `openai-research` request;
-an explicit canonical configuration wins, otherwise the former
-`openai-deep-o3` configuration wins. Config files are not rewritten
-automatically. Output files and `run.json` always use canonical IDs.
-
-Pending OpenAI tasks submitted under the retired providers are not guaranteed
-to remain retrievable after upgrading. Completed report files already written
-to disk are unaffected. The OpenAI legacy aliases are deprecated and will be
-removed in Librarium 2.0.
+Completed historical runs remain readable with their recorded provider IDs and
+filenames. Pending historical handles for retired IDs cannot resume, poll, or
+retrieve through a replacement provider.
 
 You can also add **custom providers** (npm modules or local scripts) via config. See [Custom Providers](#custom-providers).
 
@@ -376,7 +368,12 @@ librarium run "AI agent architectures" --group deep --mode sync
 librarium run "Node.js 22 features" --group fast
 ```
 
-The `--providers` flag accepts canonical IDs, legacy aliases, or display names (case- and punctuation-insensitive, so `"Exa Search"`, `exa-search`, and `EXA SEARCH` all resolve to `exa`). Display names are a CLI input convenience only. If a name is ambiguous or unrecognized, the run stops with the matching candidates or a short list of suggestions. Config files (provider keys, custom groups, fallback targets) still require canonical IDs or legacy aliases.
+The `--providers` flag accepts canonical IDs or display names (case- and
+punctuation-insensitive, so `"Exa Search"`, `exa-search`, and `EXA SEARCH` all
+resolve to `exa`). Display names are a CLI input convenience only. If a name is
+ambiguous or unrecognized, the run stops with matching candidates or a short
+list of suggestions. Current configuration requires canonical IDs; only the v1
+migrator accepts retired IDs.
 
 In an interactive terminal, `run` shows a live per-provider results table. Every row appears at fan-out with a spinner and ticking elapsed time, then resolves in place as results arrive:
 

--- a/src/adapters/openai-deep-base.ts
+++ b/src/adapters/openai-deep-base.ts
@@ -1,7 +1,0 @@
-import { OpenAIResearchProvider } from './openai-research.js';
-
-/**
- * @deprecated Extend OpenAIResearchProvider instead. This compatibility class
- * uses the canonical openai-research id and current model behavior.
- */
-export abstract class OpenAIDeepBaseProvider extends OpenAIResearchProvider {}

--- a/src/adapters/openai-deep-o3.ts
+++ b/src/adapters/openai-deep-o3.ts
@@ -1,7 +1,0 @@
-import { OpenAIResearchProvider } from './openai-research.js';
-
-/**
- * @deprecated Use OpenAIResearchProvider. This wrapper no longer dispatches
- * o3-deep-research; it behaves as the canonical openai-research provider.
- */
-export class OpenAIDeepO3Provider extends OpenAIResearchProvider {}

--- a/src/adapters/openai-deep.ts
+++ b/src/adapters/openai-deep.ts
@@ -1,7 +1,0 @@
-import { OpenAIResearchProvider } from './openai-research.js';
-
-/**
- * @deprecated Use OpenAIResearchProvider. This wrapper no longer dispatches
- * o4-mini-deep-research; it behaves as the canonical openai-research provider.
- */
-export class OpenAIDeepProvider extends OpenAIResearchProvider {}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -27,6 +27,7 @@ import { generateSlug, resolveOutputDir } from '../core/prompt-builder.js';
 import {
   ProviderSelectionError,
   resolveProviderSelection,
+  retiredProviderSelectionIssues,
 } from '../core/provider-selection.js';
 import { executeResearchRun } from '../core/research-run.js';
 import { createNodeCredentialContext } from '../node-credentials.js';
@@ -221,6 +222,16 @@ export async function executeRun(
       prettyStream.write(`${line}\n`);
       if (wasSpinning) spinner.start();
     };
+    const retiredProviderIssues = retiredProviderSelectionIssues(
+      opts.providers,
+    );
+    if (retiredProviderIssues.length > 0) {
+      spinner.fail(
+        retiredProviderIssues.map((issue) => issue.message).join(' '),
+      );
+      process.exitCode = 2;
+      return { exitCode: 2 };
+    }
     try {
       const globalConfig = loadConfig();
       const projectConfig = loadProjectConfig(process.cwd());

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ import {
   BUILTIN_PROVIDER_DEFINITIONS,
   BUILTIN_PROVIDER_DEFINITIONS_IN_REGISTRATION_ORDER,
 } from './core/provider-descriptor.js';
+import { retiredProviderReplacement } from './core/retired-provider-ids.js';
 
 export const VERSION =
   typeof __VERSION__ !== 'undefined' ? __VERSION__ : '0.1.0';
@@ -174,13 +175,14 @@ export function suggestProviders(
 export type ProviderTokenResolution =
   | { kind: 'id'; token: string; id: string }
   | { kind: 'alias'; token: string; id: string }
+  | { kind: 'retired'; token: string; replacement: string }
   | { kind: 'name'; token: string; id: string }
   | { kind: 'ambiguous'; token: string; candidates: ProviderNameEntry[] }
   | { kind: 'unknown'; token: string; suggestions: ProviderNameEntry[] };
 
 /**
  * Resolve a single token to a canonical provider id, accepting (in order):
- * exact canonical id, legacy alias, then case/punctuation-insensitive display
+ * exact canonical id, a rejected retired id, active alias, then case/punctuation-insensitive display
  * name. Returns a structured outcome so callers can warn (alias), error
  * (ambiguous / unknown), or proceed (id / name).
  *
@@ -193,18 +195,25 @@ export function resolveProviderToken(
   const trimmed = token.trim();
   const knownIds = new Set(providers.map((p) => p.id));
 
-  // 1. Exact canonical id.
+  // 1. Retired ids guide the caller but never resolve to an executable id,
+  // even if a compromised provider index includes the old spelling.
+  const replacement = retiredProviderReplacement(trimmed);
+  if (replacement !== undefined) {
+    return { kind: 'retired', token: trimmed, replacement };
+  }
+
+  // 2. Exact canonical id.
   if (knownIds.has(trimmed)) {
     return { kind: 'id', token: trimmed, id: trimmed };
   }
 
-  // 2. Legacy alias (existing behavior; emits a deprecation warning).
+  // 3. Active alias (emits a deprecation warning).
   const aliased = PROVIDER_ID_ALIASES[trimmed];
   if (aliased !== undefined) {
     return { kind: 'alias', token: trimmed, id: aliased };
   }
 
-  // 3. Case-insensitive display-name match with normalization.
+  // 4. Case-insensitive display-name match with normalization.
   const normalizedToken = normalizeProviderName(trimmed);
   const nameMatches = providers.filter(
     (provider) =>
@@ -217,7 +226,7 @@ export function resolveProviderToken(
     return { kind: 'ambiguous', token: trimmed, candidates: nameMatches };
   }
 
-  // 4. Nothing matched.
+  // 5. Nothing matched.
   return {
     kind: 'unknown',
     token: trimmed,
@@ -237,9 +246,9 @@ export interface ProviderTokensResult {
 
 /**
  * Resolve a list of human-friendly provider tokens (canonical ids, legacy
- * aliases, or display names) to canonical ids. Display-name matches are a
- * supported input form and emit no warning; legacy aliases warn; ambiguous or
- * unknown tokens produce errors. Edge-safe pure string logic.
+ * active aliases, or display names) to canonical ids. Display-name matches are
+ * a supported input form and emit no warning; ambiguous or unknown tokens
+ * produce errors. Edge-safe pure string logic.
  */
 export function resolveProviderTokens(
   tokens: string[],
@@ -269,6 +278,11 @@ export function resolveProviderTokens(
           `Provider ID "${outcome.token}" is deprecated; using "${outcome.id}"`,
         );
         push(outcome.id);
+        break;
+      case 'retired':
+        errors.push(
+          `Provider "${outcome.token}" was removed; use "${outcome.replacement}".`,
+        );
         break;
       case 'ambiguous': {
         const candidateList = outcome.candidates

--- a/src/core/config-v2.ts
+++ b/src/core/config-v2.ts
@@ -20,8 +20,8 @@ import {
 } from './research-request.js';
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 import {
-  isRetiredProviderId,
-  migrateRetiredProviderId,
+  isRetiredProviderToken,
+  migrateRetiredProviderToken,
   retiredProviderGuidance,
   retiredProviderMigrationPriority,
 } from './retired-provider-ids.js';
@@ -696,7 +696,7 @@ function unsafeDictionaryIssues(
   return issues;
 }
 
-const canonicalLegacyId = migrateRetiredProviderId;
+const canonicalLegacyId = migrateRetiredProviderToken;
 const legacyAliasPriority = retiredProviderMigrationPriority;
 
 function legacySource(
@@ -1110,7 +1110,7 @@ function migrateGroups(
     const members: string[] = [];
     const seen = new Set<string>();
     for (const [index, member] of definition.members.entries()) {
-      if (!definition.legacy && isRetiredProviderId(member)) {
+      if (!definition.legacy && isRetiredProviderToken(member)) {
         issues.push(
           issue(
             'config_group_member_alias_removed',
@@ -1168,7 +1168,7 @@ function nativeGroups(
     const exact: string[] = [];
     const seen = new Set<string>();
     for (const [index, member] of members.entries()) {
-      if (isRetiredProviderId(member)) {
+      if (isRetiredProviderToken(member)) {
         issues.push(
           issue(
             'config_group_member_alias_removed',
@@ -1407,7 +1407,7 @@ function semanticIssues(config: LibrariumConfigV2): {
 
   for (const [id, provider] of Object.entries(config.providers)) {
     const bindingIdentity = builtinBindings.get(id);
-    if (isRetiredProviderId(id)) {
+    if (isRetiredProviderToken(id)) {
       issues.push(
         issue(
           'config_provider_alias_removed',
@@ -1475,7 +1475,7 @@ function semanticIssues(config: LibrariumConfigV2): {
   for (const [id, provider] of Object.entries(config.providers)) {
     const fallback = provider.fallback;
     if (!fallback) continue;
-    if (isRetiredProviderId(fallback)) {
+    if (isRetiredProviderToken(fallback)) {
       issues.push(
         issue(
           'config_fallback_alias_removed',

--- a/src/core/config-v2.ts
+++ b/src/core/config-v2.ts
@@ -19,6 +19,12 @@ import {
   RESEARCH_REQUEST_LIMITS,
 } from './research-request.js';
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
+import {
+  isRetiredProviderId,
+  migrateRetiredProviderId,
+  retiredProviderGuidance,
+  retiredProviderMigrationPriority,
+} from './retired-provider-ids.js';
 import { exactUsdBudgets } from './transport-normalization.js';
 
 export type JsonValue =
@@ -690,33 +696,8 @@ function unsafeDictionaryIssues(
   return issues;
 }
 
-function canonicalLegacyId(id: string): string {
-  switch (id) {
-    case 'perplexity-sonar':
-      return 'perplexity-sonar-pro';
-    case 'perplexity-deep':
-      return 'perplexity-sonar-deep';
-    case 'openai-deep':
-    case 'openai-deep-o3':
-      return 'openai-research';
-    default:
-      return id;
-  }
-}
-
-const LEGACY_PROVIDER_ALIASES: ReadonlySet<string> = new Set([
-  'perplexity-sonar',
-  'perplexity-deep',
-  'openai-deep',
-  'openai-deep-o3',
-]);
-
-function legacyAliasPriority(id: string, canonical: string): number {
-  if (id === canonical) return 0;
-  if (id === 'openai-deep-o3') return 1;
-  if (id === 'openai-deep') return 2;
-  return 1;
-}
+const canonicalLegacyId = migrateRetiredProviderId;
+const legacyAliasPriority = retiredProviderMigrationPriority;
 
 function legacySource(
   source: z.infer<typeof LegacySourceSchema>,
@@ -1129,6 +1110,16 @@ function migrateGroups(
     const members: string[] = [];
     const seen = new Set<string>();
     for (const [index, member] of definition.members.entries()) {
+      if (!definition.legacy && isRetiredProviderId(member)) {
+        issues.push(
+          issue(
+            'config_group_member_alias_removed',
+            pointer(['groups', name, index]),
+            `Native v2 groups do not accept retired provider aliases. ${retiredProviderGuidance(member)}`,
+          ),
+        );
+        continue;
+      }
       const exact = exactGroupMember(
         member,
         definition.legacy,
@@ -1177,6 +1168,16 @@ function nativeGroups(
     const exact: string[] = [];
     const seen = new Set<string>();
     for (const [index, member] of members.entries()) {
+      if (isRetiredProviderId(member)) {
+        issues.push(
+          issue(
+            'config_group_member_alias_removed',
+            pointer(['groups', name, index]),
+            `Native v2 groups do not accept retired provider aliases. ${retiredProviderGuidance(member)}`,
+          ),
+        );
+        continue;
+      }
       const resolved = exactGroupMember(
         member,
         false,
@@ -1406,12 +1407,12 @@ function semanticIssues(config: LibrariumConfigV2): {
 
   for (const [id, provider] of Object.entries(config.providers)) {
     const bindingIdentity = builtinBindings.get(id);
-    if (LEGACY_PROVIDER_ALIASES.has(id)) {
+    if (isRetiredProviderId(id)) {
       issues.push(
         issue(
           'config_provider_alias_removed',
           pointer(['providers', id]),
-          'Native v2 config does not accept retired provider aliases; use the canonical adapter id.',
+          `Native v2 config does not accept retired provider aliases. ${retiredProviderGuidance(id)}`,
         ),
       );
       continue;
@@ -1474,6 +1475,16 @@ function semanticIssues(config: LibrariumConfigV2): {
   for (const [id, provider] of Object.entries(config.providers)) {
     const fallback = provider.fallback;
     if (!fallback) continue;
+    if (isRetiredProviderId(fallback)) {
+      issues.push(
+        issue(
+          'config_fallback_alias_removed',
+          pointer(['providers', id, 'fallback']),
+          `Native v2 config does not accept retired fallback aliases. ${retiredProviderGuidance(fallback)}`,
+        ),
+      );
+      continue;
+    }
     if (!provider.enabled) {
       notices.push(
         notice(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,7 @@ import { ConfigSchema, ProjectConfigSchema } from '../types.js';
 import type { EnvRecord } from './credentials.js';
 import { hasCredential, resolveCredential } from './credentials.js';
 import { safeWriteFile } from './fs-utils.js';
+import { migrateRetiredProviderId } from './retired-provider-ids.js';
 
 export const CONFIG_DIR = resolve(homedir(), '.config', 'librarium');
 export const CONFIG_FILE = resolve(CONFIG_DIR, 'config.json');
@@ -368,25 +369,16 @@ function migrateLegacyProviderIds(config: Config): string[] {
   // Both retired OpenAI deep-research entries map to one canonical provider.
   // A canonical entry wins over either alias; when only aliases exist, the
   // former o3 entry wins deterministically regardless of JSON key order.
-  const openAiResearchConfigs = [
-    'openai-deep',
+  const selectedOpenAiResearchId = [
+    'openai-research',
     'openai-deep-o3',
-    'openai-research',
-  ].filter((id) => config.providers[id] !== undefined);
-  const selectedOpenAiResearchId = openAiResearchConfigs.includes(
-    'openai-research',
-  )
-    ? 'openai-research'
-    : openAiResearchConfigs.includes('openai-deep-o3')
-      ? 'openai-deep-o3'
-      : openAiResearchConfigs.includes('openai-deep')
-        ? 'openai-deep'
-        : undefined;
+    'openai-deep',
+  ].find((id) => config.providers[id] !== undefined);
 
   for (const [id, providerConfig] of Object.entries(config.providers)) {
-    const canonicalId = resolveProviderId(id);
+    const canonicalId = migrateRetiredProviderId(resolveProviderId(id));
     const normalizedFallback = providerConfig.fallback
-      ? resolveProviderId(providerConfig.fallback)
+      ? migrateRetiredProviderId(resolveProviderId(providerConfig.fallback))
       : undefined;
 
     if (canonicalId !== id) {
@@ -432,14 +424,18 @@ function migrateLegacyProviderIds(config: Config): string[] {
 
   for (const [groupName, members] of Object.entries(config.groups)) {
     for (const member of members) {
-      const canonicalMember = resolveProviderId(member);
+      const canonicalMember = migrateRetiredProviderId(
+        resolveProviderId(member),
+      );
       if (canonicalMember !== member) {
         warnings.push(
           `Group "${groupName}" member "${member}" is deprecated; using "${canonicalMember}"`,
         );
       }
     }
-    config.groups[groupName] = resolveProviderIds(members);
+    config.groups[groupName] = resolveProviderIds(
+      members.map(migrateRetiredProviderId),
+    );
   }
 
   return warnings;
@@ -509,7 +505,9 @@ function captureStoredDefaultGroupRosters(
     if (storedMembers) {
       // Canonicalize aliases without deduplication so additions and duplicate
       // members cannot accidentally collapse into a recognized snapshot.
-      captured[groupName] = storedMembers.map(resolveProviderId);
+      captured[groupName] = storedMembers.map((id) =>
+        migrateRetiredProviderId(resolveProviderId(id)),
+      );
     }
   }
   return captured;

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -37,6 +37,10 @@ import {
   RESEARCH_REQUEST_LIMITS,
 } from './research-request.js';
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
+import {
+  migrateRetiredProviderId,
+  retiredProviderReplacement,
+} from './retired-provider-ids.js';
 import type {
   CanonicalTransportDefaults,
   ConfigurationTransportInput,
@@ -107,6 +111,11 @@ export type ConfigurationProfileTokenResolution =
       };
     }
   | {
+      readonly kind: 'retired';
+      readonly token: string;
+      readonly replacement: string;
+    }
+  | {
       readonly kind: 'ambiguous';
       readonly token: string;
       readonly candidates: readonly CatalogProfileTarget[];
@@ -116,6 +125,11 @@ export type ConfigurationProfileTokenResolution =
       readonly token: string;
       readonly suggestions: readonly string[];
     };
+
+export interface ConfigurationProfileTokenOptions {
+  /** Only the retained v1 configuration migration may canonicalize tombstones. */
+  readonly migrateRetired?: boolean;
+}
 
 const PROVIDER_NAME_ENTRIES: readonly ProviderNameEntry[] =
   BUILTIN_PROVIDER_DEFINITIONS.map((definition) => ({
@@ -161,19 +175,31 @@ function escapePointerSegment(segment: string): string {
 }
 
 function canonicalProviderId(id: string): string {
-  return Object.hasOwn(PROVIDER_ID_ALIASES, id) ? PROVIDER_ID_ALIASES[id]! : id;
+  return migrateRetiredProviderId(
+    Object.hasOwn(PROVIDER_ID_ALIASES, id) ? PROVIDER_ID_ALIASES[id]! : id,
+  );
 }
 
 /**
- * Purely resolve a legacy provider/display/qualified token to one exact
- * catalog identity. An unqualified provider with more than one profile is
- * deliberately ambiguous; callers must preserve the exact strategy.
+ * Resolve a current provider/display/qualified token to one exact catalog
+ * identity. Only the explicit v1 migration option accepts a retired id.
  */
 export function resolveConfigurationProfileToken(
   token: string,
   customProfiles: readonly CustomCatalogProfile[] = [],
+  options: ConfigurationProfileTokenOptions = {},
 ): ConfigurationProfileTokenResolution {
-  const trimmed = token.trim();
+  const sourceToken = token.trim();
+  const [providerToken, ...profileParts] = sourceToken.split('/');
+  const replacement = providerToken
+    ? retiredProviderReplacement(providerToken)
+    : undefined;
+  if (replacement !== undefined && !options.migrateRetired) {
+    return { kind: 'retired', token: sourceToken, replacement };
+  }
+  const trimmed = replacement
+    ? [replacement, ...profileParts].join('/')
+    : sourceToken;
   const qualified = trimmed.split('/');
   if (qualified.length === 2 && qualified[0] && qualified[1]) {
     const target = {
@@ -193,7 +219,14 @@ export function resolveConfigurationProfileToken(
   }
 
   const direct = adapterProfileBinding(trimmed);
-  if (direct) return exactToken(trimmed, direct);
+  if (direct)
+    return exactToken(
+      sourceToken,
+      direct,
+      replacement
+        ? { from: sourceToken, adapter_id: direct.adapter_id }
+        : undefined,
+    );
 
   const directCustom = customProfiles.find(
     (profile) => profile.adapter_id === trimmed,
@@ -254,6 +287,13 @@ export function resolveConfigurationProfileToken(
       kind: 'ambiguous',
       token: trimmed,
       candidates: exactTargetsForProviderEntries(provider.candidates),
+    };
+  }
+  if (provider.kind === 'retired') {
+    return {
+      kind: 'unknown',
+      token: sourceToken,
+      suggestions: [provider.replacement],
     };
   }
   const matches = [
@@ -504,18 +544,11 @@ function canonicalizeProviderConfigs(
 } {
   const providerConfigs = safeRecord<ProviderConfig>();
   const notices: PreparationNotice[] = [];
-  const openAiCandidates = [
-    'openai-deep',
-    'openai-deep-o3',
+  const selectedOpenAi = [
     'openai-research',
-  ].filter((id) => ownValue(providers, id) !== undefined);
-  const selectedOpenAi = openAiCandidates.includes('openai-research')
-    ? 'openai-research'
-    : openAiCandidates.includes('openai-deep-o3')
-      ? 'openai-deep-o3'
-      : openAiCandidates.includes('openai-deep')
-        ? 'openai-deep'
-        : undefined;
+    'openai-deep-o3',
+    'openai-deep',
+  ].find((id) => ownValue(providers, id) !== undefined);
 
   for (const [id, config] of Object.entries(providers)) {
     const adapterId = canonicalProviderId(id);
@@ -628,6 +661,7 @@ function canonicalizeGroups(
       const resolution = resolveConfigurationProfileToken(
         member,
         customProfiles,
+        { migrateRetired: true },
       );
       if (resolution.kind === 'unknown') {
         issues.push({
@@ -646,6 +680,16 @@ function canonicalizeGroups(
           path,
           message:
             'The group member resolves to multiple profiles. Use a qualified "provider/profile" reference.',
+        });
+        continue;
+      }
+      if (resolution.kind === 'retired') {
+        issues.push({
+          code: 'configuration_group_member_unknown',
+          phase: 'migration',
+          path,
+          message:
+            'The group member does not resolve to an implemented exact provider profile.',
         });
         continue;
       }

--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -39,7 +39,7 @@ import {
 import { RESERVED_BUILTIN_PROVIDER_IDS } from './reserved-provider-ids.js';
 import {
   migrateRetiredProviderId,
-  retiredProviderReplacement,
+  retiredProviderTokenReplacement,
 } from './retired-provider-ids.js';
 import type {
   CanonicalTransportDefaults,
@@ -190,16 +190,11 @@ export function resolveConfigurationProfileToken(
   options: ConfigurationProfileTokenOptions = {},
 ): ConfigurationProfileTokenResolution {
   const sourceToken = token.trim();
-  const [providerToken, ...profileParts] = sourceToken.split('/');
-  const replacement = providerToken
-    ? retiredProviderReplacement(providerToken)
-    : undefined;
+  const replacement = retiredProviderTokenReplacement(sourceToken);
   if (replacement !== undefined && !options.migrateRetired) {
     return { kind: 'retired', token: sourceToken, replacement };
   }
-  const trimmed = replacement
-    ? [replacement, ...profileParts].join('/')
-    : sourceToken;
+  const trimmed = replacement ?? sourceToken;
   const qualified = trimmed.split('/');
   if (qualified.length === 2 && qualified[0] && qualified[1]) {
     const target = {
@@ -209,9 +204,16 @@ export function resolveConfigurationProfileToken(
     const known = [
       ...adapterProfileBindings().values(),
       ...customProfiles.map(customProfileBinding),
-    ].some((binding) => sameProfile(binding, target));
+    ].find((binding) => sameProfile(binding, target));
     return known
-      ? { kind: 'exact', token: trimmed, target }
+      ? {
+          kind: 'exact',
+          token: sourceToken,
+          target,
+          ...(replacement && {
+            alias: { from: sourceToken, adapter_id: known.adapter_id },
+          }),
+        }
       : { kind: 'unknown', token: trimmed, suggestions: [] };
   }
   if (qualified.length !== 1) {

--- a/src/core/provider-descriptor.ts
+++ b/src/core/provider-descriptor.ts
@@ -166,7 +166,7 @@ export const BUILTIN_PROVIDER_DEFINITIONS = [
   define({
     id: 'perplexity-sonar-pro',
     registrationOrder: 6,
-    aliases: ['perplexity-sonar'],
+    aliases: [],
     tier: 'ai-grounded',
     envVar: 'PERPLEXITY_API_KEY',
     defaultModel: 'sonar-pro',
@@ -223,7 +223,7 @@ export const BUILTIN_PROVIDER_DEFINITIONS = [
   define({
     id: 'openai-research',
     registrationOrder: 4,
-    aliases: ['openai-deep', 'openai-deep-o3'],
+    aliases: [],
     tier: 'deep-research',
     envVar: 'OPENAI_API_KEY',
     defaultModel: 'gpt-5.6-sol',
@@ -277,7 +277,7 @@ export const BUILTIN_PROVIDER_DEFINITIONS = [
   define({
     id: 'perplexity-sonar-deep',
     registrationOrder: 1,
-    aliases: ['perplexity-deep'],
+    aliases: [],
     tier: 'deep-research',
     envVar: 'PERPLEXITY_API_KEY',
     defaultModel: 'sonar-deep-research',

--- a/src/core/provider-profiles.ts
+++ b/src/core/provider-profiles.ts
@@ -230,7 +230,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
   {
     provider_id: 'perplexity-sonar-pro',
     order: 20,
-    aliases: ['perplexity-sonar'],
+    aliases: [],
     display: {
       family: 'Perplexity',
       name: 'Perplexity Sonar Pro',
@@ -347,7 +347,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
   {
     provider_id: 'openai-research',
     order: 110,
-    aliases: ['openai-deep', 'openai-deep-o3'],
+    aliases: [],
     display: {
       family: 'OpenAI',
       name: 'OpenAI Research',
@@ -448,7 +448,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
   {
     provider_id: 'perplexity-sonar-deep',
     order: 130,
-    aliases: ['perplexity-deep'],
+    aliases: [],
     display: {
       family: 'Perplexity',
       name: 'Perplexity Sonar Deep Research',

--- a/src/core/provider-selection.ts
+++ b/src/core/provider-selection.ts
@@ -6,8 +6,46 @@ import {
 import type { Config, Provider } from '../types.js';
 import type { CredentialContext } from './credentials.js';
 import { hasCredential } from './credentials.js';
+import { retiredProviderGuidance } from './retired-provider-ids.js';
 
 export class ProviderSelectionError extends Error {}
+
+export interface RetiredProviderSelectionIssue {
+  readonly code: 'provider_token_retired';
+  readonly path: string;
+  readonly message: string;
+}
+
+/**
+ * Pure transport preflight for current CLI/MCP provider selections. v1 config
+ * migration uses a separate compatibility path and must not call this helper.
+ */
+export function retiredProviderSelectionIssues(
+  tokens: readonly string[] | undefined,
+): readonly RetiredProviderSelectionIssue[] {
+  if (tokens === undefined) return [];
+  const issues: RetiredProviderSelectionIssue[] = [];
+  for (const [index, token] of tokens.entries()) {
+    const guidance = retiredProviderGuidance(token.trim());
+    if (!guidance) continue;
+    issues.push({
+      code: 'provider_token_retired',
+      path: `/providers/${index}`,
+      message: guidance,
+    });
+  }
+  return issues;
+}
+
+export function assertNoRetiredProviderSelectionTokens(
+  tokens: readonly string[] | undefined,
+): void {
+  const issues = retiredProviderSelectionIssues(tokens);
+  if (issues.length === 0) return;
+  throw new ProviderSelectionError(
+    issues.map((issue) => issue.message).join(' '),
+  );
+}
 
 export interface ProviderSelectionArgs {
   providers?: string[];

--- a/src/core/reserved-provider-ids.ts
+++ b/src/core/reserved-provider-ids.ts
@@ -1,6 +1,7 @@
 import { PROVIDER_ID_ALIASES } from '../constants.js';
 import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
 import { BUILTIN_PROVIDER_CATALOG } from './provider-profiles.js';
+import { RETIRED_PROVIDER_REPLACEMENTS } from './retired-provider-ids.js';
 
 /**
  * Every current, planned, adapter, and retired built-in spelling is reserved.
@@ -11,4 +12,5 @@ export const RESERVED_BUILTIN_PROVIDER_IDS: ReadonlySet<string> = new Set([
   ...BUILTIN_PROVIDER_CATALOG.map(({ provider_id }) => provider_id),
   ...BUILTIN_PROVIDER_DEFINITIONS.map(({ id }) => id),
   ...Object.keys(PROVIDER_ID_ALIASES),
+  ...Object.keys(RETIRED_PROVIDER_REPLACEMENTS),
 ]);

--- a/src/core/retired-provider-ids.ts
+++ b/src/core/retired-provider-ids.ts
@@ -24,9 +24,36 @@ export function isRetiredProviderId(id: string): id is RetiredProviderId {
   return retiredProviderReplacement(id) !== undefined;
 }
 
+/**
+ * Replaces only the provider-id segment of a provider/profile token.
+ *
+ * Qualified profile selectors remain exact during v1 migration and native-v2
+ * diagnostics, so their suffix must never be discarded.
+ */
+export function retiredProviderTokenReplacement(
+  token: string,
+): string | undefined {
+  const [providerId, ...suffix] = token.split('/');
+  const replacement = providerId
+    ? retiredProviderReplacement(providerId)
+    : undefined;
+  return replacement === undefined
+    ? undefined
+    : [replacement, ...suffix].join('/');
+}
+
+export function isRetiredProviderToken(token: string): boolean {
+  return retiredProviderTokenReplacement(token) !== undefined;
+}
+
 /** v1-only canonicalization. Current selectors must not call this helper. */
 export function migrateRetiredProviderId(id: string): string {
   return retiredProviderReplacement(id) ?? id;
+}
+
+/** v1-only canonicalization that preserves a qualified profile suffix. */
+export function migrateRetiredProviderToken(token: string): string {
+  return retiredProviderTokenReplacement(token) ?? token;
 }
 
 /** Canonical > openai-deep-o3 > openai-deep, independent of input order. */
@@ -40,9 +67,9 @@ export function retiredProviderMigrationPriority(
   return 1;
 }
 
-export function retiredProviderGuidance(id: string): string | undefined {
-  const replacement = retiredProviderReplacement(id);
+export function retiredProviderGuidance(token: string): string | undefined {
+  const replacement = retiredProviderTokenReplacement(token);
   return replacement
-    ? `Provider "${id}" was removed; use "${replacement}".`
+    ? `Provider "${token}" was removed; use "${replacement}".`
     : undefined;
 }

--- a/src/core/retired-provider-ids.ts
+++ b/src/core/retired-provider-ids.ts
@@ -1,0 +1,48 @@
+/**
+ * Provider ids that Librarium no longer accepts for current execution.
+ *
+ * This immutable tombstone is deliberately separate from active provider
+ * aliases. It exists only for v1 migration, native-v2 rejection guidance, and
+ * reservation of the old identities for custom providers.
+ */
+export const RETIRED_PROVIDER_REPLACEMENTS = Object.freeze({
+  'perplexity-sonar': 'perplexity-sonar-pro',
+  'perplexity-deep': 'perplexity-sonar-deep',
+  'openai-deep': 'openai-research',
+  'openai-deep-o3': 'openai-research',
+} as const);
+
+export type RetiredProviderId = keyof typeof RETIRED_PROVIDER_REPLACEMENTS;
+
+export function retiredProviderReplacement(id: string): string | undefined {
+  return Object.hasOwn(RETIRED_PROVIDER_REPLACEMENTS, id)
+    ? RETIRED_PROVIDER_REPLACEMENTS[id as RetiredProviderId]
+    : undefined;
+}
+
+export function isRetiredProviderId(id: string): id is RetiredProviderId {
+  return retiredProviderReplacement(id) !== undefined;
+}
+
+/** v1-only canonicalization. Current selectors must not call this helper. */
+export function migrateRetiredProviderId(id: string): string {
+  return retiredProviderReplacement(id) ?? id;
+}
+
+/** Canonical > openai-deep-o3 > openai-deep, independent of input order. */
+export function retiredProviderMigrationPriority(
+  id: string,
+  canonical: string,
+): number {
+  if (id === canonical) return 0;
+  if (id === 'openai-deep-o3') return 1;
+  if (id === 'openai-deep') return 2;
+  return 1;
+}
+
+export function retiredProviderGuidance(id: string): string | undefined {
+  const replacement = retiredProviderReplacement(id);
+  return replacement
+    ? `Provider "${id}" was removed; use "${replacement}".`
+    : undefined;
+}

--- a/src/core/shadow-compilation.ts
+++ b/src/core/shadow-compilation.ts
@@ -117,6 +117,15 @@ function resolveProviderTokens(
       continue;
     }
     const resolution = resolveConfigurationProfileToken(token, customProfiles);
+    if (resolution.kind === 'retired') {
+      issues.push({
+        code: 'shadow_provider_token_retired',
+        phase: 'transport',
+        path,
+        message: `Provider "${resolution.token}" was removed; use "${resolution.replacement}".`,
+      });
+      continue;
+    }
     if (resolution.kind === 'unknown') {
       issues.push({
         code: 'shadow_provider_token_unknown',

--- a/src/mcp/research.ts
+++ b/src/mcp/research.ts
@@ -8,6 +8,7 @@ import { loadConfig, loadProjectConfig, mergeConfigs } from '../core/config.js';
 import type { CredentialContext } from '../core/credentials.js';
 import { generateSlug } from '../core/prompt-builder.js';
 import {
+  assertNoRetiredProviderSelectionTokens,
   ProviderSelectionError,
   resolveProviderSelection as resolveProviderSelectionCore,
 } from '../core/provider-selection.js';
@@ -75,8 +76,8 @@ function defaultLoadMergedConfig(cliFlags: Partial<Defaults>): Config {
  * Distinguishes undefined (use defaults) from provided-but-empty: an
  * explicitly-passed empty `providers` array or an empty/whitespace `group`
  * is a caller mistake, not a fallthrough to the default enabled set. Provider
- * tokens are resolved against the registry (canonical ids, legacy aliases, and
- * display names); ANY unresolved token is a hard error listing the unknowns.
+ * tokens are resolved against the registry (canonical ids and display names);
+ * ANY unresolved token is a hard error listing the unknowns.
  */
 export function resolveProviderSelection(
   config: Config,
@@ -99,6 +100,8 @@ export async function runResearchSilent(
 ): Promise<SilentRunResult> {
   const onWarn =
     deps.onWarn ?? ((message: string) => process.stderr.write(`${message}\n`));
+
+  assertNoRetiredProviderSelectionTokens(args.providers);
 
   const cliFlags: Partial<Defaults> = {};
   if (args.mode) cliFlags.mode = args.mode;

--- a/tests/adapters/openai-research.test.ts
+++ b/tests/adapters/openai-research.test.ts
@@ -4,8 +4,6 @@ import {
   initializeProviders,
   registerProvider,
 } from '../../src/adapters/index.js';
-import { OpenAIDeepProvider } from '../../src/adapters/openai-deep.js';
-import { OpenAIDeepO3Provider } from '../../src/adapters/openai-deep-o3.js';
 import { OpenAIResearchProvider } from '../../src/adapters/openai-research.js';
 import {
   type AcceptedTaskPersistenceError,
@@ -57,13 +55,6 @@ describe('OpenAIResearchProvider', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  it('keeps deprecated class exports on canonical provider behavior', () => {
-    expect(new OpenAIDeepProvider().id).toBe('openai-research');
-    expect(new OpenAIDeepProvider().model).toBe('gpt-5.6-sol');
-    expect(new OpenAIDeepO3Provider().id).toBe('openai-research');
-    expect(new OpenAIDeepO3Provider().model).toBe('gpt-5.6-sol');
   });
 
   it('submits the canonical async Responses API request', async () => {

--- a/tests/config-v2.test.ts
+++ b/tests/config-v2.test.ts
@@ -267,6 +267,33 @@ describe('public v2 configuration migration', () => {
     }
   });
 
+  it('migrates qualified retired v1 group members without dropping profiles', () => {
+    const members = [
+      'perplexity-sonar/grounded',
+      'perplexity-deep/research',
+      'openai-deep/research',
+      'openai-deep-o3/research',
+    ];
+    const result = migrateConfig({
+      global: v1({ groups: { legacy: members } }),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.groups['custom:legacy']).toEqual([
+      'perplexity-sonar-pro/grounded',
+      'perplexity-sonar-deep/research',
+      'openai-research/research',
+    ]);
+    for (const member of members) {
+      expect(result.notices).toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_provider_alias_migrated',
+          message: expect.stringContaining(`"${member}"`),
+        }),
+      );
+    }
+  });
+
   it('makes canonical provider ids win every alias collision independent of JSON order', () => {
     for (const providers of [
       {
@@ -934,6 +961,35 @@ describe('public v2 configuration migration', () => {
         }),
       );
       expect(migrated.issues).not.toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_member_unknown',
+          path: '/groups/custom:retired/0',
+        }),
+      );
+    }
+  });
+
+  it('rejects qualified retired native group members with full replacements', () => {
+    const replacements = {
+      'perplexity-sonar/grounded': 'perplexity-sonar-pro/grounded',
+      'perplexity-deep/research': 'perplexity-sonar-deep/research',
+      'openai-deep/research': 'openai-research/research',
+      'openai-deep-o3/research': 'openai-research/research',
+    } as const;
+    for (const [alias, replacement] of Object.entries(replacements)) {
+      const result = validateConfigV2(
+        v2({ groups: { 'custom:retired': [alias] } }),
+      );
+      expect(result.ok, alias).toBe(false);
+      if (result.ok) continue;
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_member_alias_removed',
+          path: '/groups/custom:retired/0',
+          message: expect.stringContaining(`use "${replacement}"`),
+        }),
+      );
+      expect(result.issues).not.toContainEqual(
         expect.objectContaining({
           code: 'config_group_member_unknown',
           path: '/groups/custom:retired/0',

--- a/tests/config-v2.test.ts
+++ b/tests/config-v2.test.ts
@@ -614,6 +614,28 @@ describe('public v2 configuration migration', () => {
     }
   });
 
+  it.each([
+    'perplexity-sonar',
+    'perplexity-deep',
+    'openai-deep',
+    'openai-deep-o3',
+  ])('reserves retired custom-provider key %s', (retired) => {
+    const result = validateConfigV2(
+      v2({
+        custom_providers: { [retired]: customSource('acme-provider') },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual({
+      code: 'config_custom_provider_id_reserved',
+      phase: 'migration',
+      path: `/custom_providers/${retired}`,
+      message:
+        'Custom providers cannot claim a current, planned, alias, or retired built-in id.',
+    });
+  });
+
   it('rejects duplicate custom provider/profile identities deterministically', () => {
     const first = customSource('shared-provider');
     const second = customSource('shared-provider');
@@ -857,6 +879,66 @@ describe('public v2 configuration migration', () => {
           expect.objectContaining({ code: 'config_provider_alias_removed' }),
         );
       }
+    }
+  });
+
+  it('rejects retired native provider, fallback, and group ids with replacement guidance', () => {
+    const replacements = {
+      'perplexity-sonar': 'perplexity-sonar-pro',
+      'perplexity-deep': 'perplexity-sonar-deep',
+      'openai-deep': 'openai-research',
+      'openai-deep-o3': 'openai-research',
+    } as const;
+    for (const [alias, replacement] of Object.entries(replacements)) {
+      const result = validateConfigV2(
+        v2({
+          providers: {
+            'openai-research': { enabled: true, fallback: alias },
+            [alias]: { enabled: false },
+          },
+          groups: { 'custom:retired': [alias] },
+        }),
+      );
+      expect(result.ok, alias).toBe(false);
+      if (result.ok) continue;
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'config_provider_alias_removed',
+            path: `/providers/${alias}`,
+            message: expect.stringContaining(`use "${replacement}"`),
+          }),
+          expect.objectContaining({
+            code: 'config_fallback_alias_removed',
+            path: '/providers/openai-research/fallback',
+            message: expect.stringContaining(`use "${replacement}"`),
+          }),
+          expect.objectContaining({
+            code: 'config_group_member_alias_removed',
+            path: '/groups/custom:retired/0',
+            message: expect.stringContaining(`use "${replacement}"`),
+          }),
+        ]),
+      );
+
+      const migrated = migrateConfig({
+        global: v2({ groups: { 'custom:retired': [alias] } }),
+      });
+      expect(migrated.ok, `${alias} migration`).toBe(false);
+      if (migrated.ok) continue;
+      expect(migrated.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_member_alias_removed',
+          path: '/groups/custom:retired/0',
+          message: expect.stringContaining(`use "${replacement}"`),
+        }),
+      );
+      expect(migrated.issues).not.toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_member_unknown',
+          path: '/groups/custom:retired/0',
+        }),
+      );
     }
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -205,6 +205,51 @@ describe('loadConfig', () => {
     ]);
   });
 
+  it('normalizes retired v1 fallback ids without restoring active aliases', () => {
+    const configPath = join(tmpDir, 'retired-fallbacks.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        version: 1,
+        defaults: {
+          outputDir: './agents/librarium',
+          maxParallel: 1,
+          timeout: 30,
+          asyncTimeout: 1800,
+          asyncPollInterval: 10,
+          mode: 'sync',
+        },
+        providers: {
+          'openai-deep': {
+            enabled: true,
+            fallback: 'openai-deep-o3',
+          },
+          'perplexity-sonar': {
+            enabled: true,
+            fallback: 'perplexity-deep',
+          },
+        },
+        groups: {},
+      }),
+    );
+
+    const config = loadConfig(configPath);
+    expect(config.providers['openai-research']?.fallback).toBe(
+      'openai-research',
+    );
+    expect(config.providers['perplexity-sonar-pro']?.fallback).toBe(
+      'perplexity-sonar-deep',
+    );
+    for (const retired of [
+      'perplexity-sonar',
+      'perplexity-deep',
+      'openai-deep',
+      'openai-deep-o3',
+    ]) {
+      expect(config.providers[retired]).toBeUndefined();
+    }
+  });
+
   it('migrates only exact stored prior comprehensive and all rosters', () => {
     const configPath = join(tmpDir, 'config.json');
     writeFileSync(

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -437,6 +437,30 @@ describe('configuration mapping', () => {
     });
   });
 
+  it.each([
+    ['perplexity-sonar/grounded', 'perplexity-sonar-pro/grounded'],
+    ['perplexity-deep/research', 'perplexity-sonar-deep/research'],
+    ['openai-deep/research', 'openai-research/research'],
+    ['openai-deep-o3/research', 'openai-research/research'],
+  ])('preserves qualified retired suffixes for %s', (token, replacement) => {
+    expect(resolveConfigurationProfileToken(token)).toEqual({
+      kind: 'retired',
+      token,
+      replacement,
+    });
+    expect(
+      resolveConfigurationProfileToken(token, [], { migrateRetired: true }),
+    ).toMatchObject({
+      kind: 'exact',
+      token,
+      target: {
+        provider_id: replacement.split('/')[0],
+        profile_id: replacement.split('/')[1],
+      },
+      alias: { from: token },
+    });
+  });
+
   it('resolves active aliases, display names, and qualified profiles without collapsing OpenRouter', () => {
     expect(
       resolveConfigurationProfileToken('OpenRouter Online Search'),

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -222,19 +222,26 @@ describe('configuration mapping', () => {
     },
   );
 
-  it.each([...PLANNED_PROVIDER_IDS, 'openai-deep'])(
+  it.each([
+    ...PLANNED_PROVIDER_IDS,
+    'perplexity-sonar',
+    'perplexity-deep',
+    'openai-deep',
+    'openai-deep-o3',
+  ])(
     'rejects custom metadata claiming reserved provider identity %s',
     (providerId) => {
       const mapped = map(customIdentityConfig('acme-adapter', providerId), {
         requestDeadlineMs: 2_000_000,
       });
       expect(mapped.custom_profile_bindings).toEqual([]);
-      expect(mapped.preflight.issues).toContainEqual(
-        expect.objectContaining({
-          code: 'custom_provider_profile_provider_id_reserved',
-          path: '/customProviders/acme-adapter/executionProfile/profile/identity/provider_id',
-        }),
-      );
+      expect(mapped.preflight.issues).toContainEqual({
+        code: 'custom_provider_profile_provider_id_reserved',
+        phase: 'migration',
+        path: '/customProviders/acme-adapter/executionProfile/profile/identity/provider_id',
+        message:
+          'A custom profile cannot claim a current, planned, or retired built-in provider id.',
+      });
     },
   );
 
@@ -409,8 +416,17 @@ describe('configuration mapping', () => {
     });
   });
 
-  it('resolves aliases, display names, and qualified profiles without collapsing OpenRouter', () => {
+  it('keeps retired ids out of current token resolution while preserving private v1 migration', () => {
     expect(resolveConfigurationProfileToken('perplexity-sonar')).toEqual({
+      kind: 'retired',
+      token: 'perplexity-sonar',
+      replacement: 'perplexity-sonar-pro',
+    });
+    expect(
+      resolveConfigurationProfileToken('perplexity-sonar', [], {
+        migrateRetired: true,
+      }),
+    ).toEqual({
       kind: 'exact',
       token: 'perplexity-sonar',
       target: { provider_id: 'perplexity-sonar-pro', profile_id: 'grounded' },
@@ -419,6 +435,9 @@ describe('configuration mapping', () => {
         adapter_id: 'perplexity-sonar-pro',
       },
     });
+  });
+
+  it('resolves active aliases, display names, and qualified profiles without collapsing OpenRouter', () => {
     expect(
       resolveConfigurationProfileToken('OpenRouter Online Search'),
     ).toEqual({

--- a/tests/metering.test.ts
+++ b/tests/metering.test.ts
@@ -34,9 +34,11 @@ describe('metering registry: kinds', () => {
     expect(getMeteringKind('brave-answers')).toBe('api_unit_priced');
   });
 
-  it('resolves legacy aliases to the canonical kind', () => {
-    // perplexity-sonar -> perplexity-sonar-pro (native_cost)
-    expect(getMeteringKind('perplexity-sonar')).toBe('native_cost');
+  it('does not meter retired ids as active aliases', () => {
+    expect(getMeteringKind('perplexity-sonar')).toBe('manual_unmetered');
+    expect(getMeteringKind('perplexity-deep')).toBe('manual_unmetered');
+    expect(getMeteringKind('openai-deep')).toBe('manual_unmetered');
+    expect(getMeteringKind('openai-deep-o3')).toBe('manual_unmetered');
   });
 
   it('defaults unknown/custom providers to manual_unmetered', () => {

--- a/tests/node-config-v2.test.ts
+++ b/tests/node-config-v2.test.ts
@@ -76,6 +76,42 @@ describe('explicit Node v2 config files', () => {
     expect(readFileSync(projectPath, 'utf8')).toBe(project);
   });
 
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])(
+    'preserves retired native v2 group guidance for %s',
+    (retired, replacement) => {
+      const globalPath = join(directory, `${retired}.json`);
+      writeFileSync(
+        globalPath,
+        JSON.stringify({
+          ...config(),
+          groups: { 'custom:retired': [retired] },
+        }),
+      );
+
+      const result = loadConfigV2({ global_path: globalPath });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_member_alias_removed',
+          path: '/groups/custom:retired/0',
+          message: expect.stringContaining(`use "${replacement}"`),
+        }),
+      );
+      expect(result.issues).not.toContainEqual(
+        expect.objectContaining({
+          code: 'config_group_member_unknown',
+          path: '/groups/custom:retired/0',
+        }),
+      );
+    },
+  );
+
   it('returns safe path-addressed JSON diagnostics', () => {
     const globalPath = join(directory, 'config.json');
     const secret = 'supersecret-api-key';

--- a/tests/provider-descriptors.test.ts
+++ b/tests/provider-descriptors.test.ts
@@ -16,6 +16,7 @@ import {
 import type { HttpStreamClient } from '../src/core/http-client.js';
 import { getMeteringKind } from '../src/core/metering.js';
 import { PROVIDER_CATALOG } from '../src/core/provider-catalog.js';
+import { RETIRED_PROVIDER_REPLACEMENTS } from '../src/core/retired-provider-ids.js';
 import { searchApiOptionsSchema } from '../src/core/searchapi.js';
 import {
   completeProSearchEvents,
@@ -59,6 +60,17 @@ describe('built-in provider descriptors', () => {
       if (descriptor.defaultModel && provider && 'model' in provider) {
         expect(provider.model).toBe(descriptor.defaultModel);
       }
+    }
+  });
+
+  it('keeps retired ids out of the active registry and alias map', async () => {
+    await initializeProviders();
+    for (const id of Object.keys(RETIRED_PROVIDER_REPLACEMENTS)) {
+      expect(getProvider(id)).toBeUndefined();
+      expect(PROVIDER_ID_ALIASES[id]).toBeUndefined();
+      expect(getAllProviders().map((provider) => provider.id)).not.toContain(
+        id,
+      );
     }
   });
 

--- a/tests/provider-tokens.test.ts
+++ b/tests/provider-tokens.test.ts
@@ -6,6 +6,7 @@ import {
   resolveProviderTokens,
   suggestProviders,
 } from '../src/constants.js';
+import { retiredProviderSelectionIssues } from '../src/core/provider-selection.js';
 
 const PROVIDERS: ProviderNameEntry[] = [
   { id: 'openai-research', displayName: 'OpenAI Research' },
@@ -40,22 +41,54 @@ describe('resolveProviderToken resolution order', () => {
     });
   });
 
-  it('resolves a legacy alias before a name match', () => {
-    expect(resolveProviderToken('perplexity-sonar', PROVIDERS)).toEqual({
-      kind: 'alias',
-      token: 'perplexity-sonar',
-      id: 'perplexity-sonar-pro',
-    });
-  });
-
-  it('warns and collapses retired OpenAI deep tokens to one dispatch id', () => {
+  it('does not resolve retired ids as active selection aliases', () => {
     const result = resolveProviderTokens(
       ['openai-deep', 'openai-deep-o3', 'openai-research'],
       PROVIDERS,
     );
     expect(result.ids).toEqual(['openai-research']);
-    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toHaveLength(2);
   });
+
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])('returns exact retirement guidance for %s', (retired, replacement) => {
+    expect(resolveProviderToken(retired, PROVIDERS)).toEqual({
+      kind: 'retired',
+      token: retired,
+      replacement,
+    });
+    const result = resolveProviderTokens([retired], PROVIDERS);
+    expect(result.ids).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([
+      `Provider "${retired}" was removed; use "${replacement}".`,
+    ]);
+    if (retired === 'perplexity-deep') {
+      expect(result.errors[0]).not.toContain('perplexity-deep-research');
+    }
+  });
+
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])(
+    'rejects %s even when a provider index claims it is active',
+    (retired, replacement) => {
+      expect(
+        resolveProviderToken(retired, [
+          ...PROVIDERS,
+          { id: retired, displayName: 'Compromised registry entry' },
+        ]),
+      ).toEqual({ kind: 'retired', token: retired, replacement });
+    },
+  );
 
   it('resolves a display name (exact form)', () => {
     expect(resolveProviderToken('Perplexity Sonar Pro', PROVIDERS)).toEqual({
@@ -142,15 +175,16 @@ describe('resolveProviderTokens aggregation', () => {
     expect(result.errors).toEqual([]);
   });
 
-  it('warns on legacy aliases but not on display-name matches', () => {
+  it('rejects retired ids while retaining display-name matches', () => {
     const result = resolveProviderTokens(
       ['perplexity-sonar', 'Exa Search'],
       PROVIDERS,
     );
-    expect(result.ids).toEqual(['perplexity-sonar-pro', 'exa']);
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toContain('deprecated');
-    expect(result.warnings[0]).toContain('perplexity-sonar');
+    expect(result.ids).toEqual(['exa']);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([
+      'Provider "perplexity-sonar" was removed; use "perplexity-sonar-pro".',
+    ]);
   });
 
   it('deduplicates while preserving order', () => {
@@ -192,5 +226,28 @@ describe('resolveProviderTokens aggregation', () => {
     expect(result.ids).toEqual(['my-custom']);
     expect(result.warnings).toEqual([]);
     expect(result.errors).toEqual([]);
+  });
+});
+
+describe('retired provider transport preflight', () => {
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])('reports stable transport guidance for %s', (retired, replacement) => {
+    expect(retiredProviderSelectionIssues(['exa', ` ${retired} `])).toEqual([
+      {
+        code: 'provider_token_retired',
+        path: '/providers/1',
+        message: `Provider "${retired}" was removed; use "${replacement}".`,
+      },
+    ]);
+  });
+
+  it('leaves canonical ids and display names untouched', () => {
+    expect(
+      retiredProviderSelectionIssues(['openai-research', 'Exa Search']),
+    ).toEqual([]);
   });
 });

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -450,11 +450,11 @@ describe('registry', () => {
     });
   });
 
-  it('getProvider resolves legacy provider ID aliases', async () => {
+  it('getProvider does not resolve retired provider ids', async () => {
     await initializeProviders();
-    expect(getProvider('perplexity-sonar')?.id).toBe('perplexity-sonar-pro');
-    expect(getProvider('perplexity-deep')?.id).toBe('perplexity-sonar-deep');
-    expect(getProvider('openai-deep')?.id).toBe('openai-research');
-    expect(getProvider('openai-deep-o3')?.id).toBe('openai-research');
+    expect(getProvider('perplexity-sonar')).toBeUndefined();
+    expect(getProvider('perplexity-deep')).toBeUndefined();
+    expect(getProvider('openai-deep')).toBeUndefined();
+    expect(getProvider('openai-deep-o3')).toBeUndefined();
   });
 });

--- a/tests/retired-provider-ids.test.ts
+++ b/tests/retired-provider-ids.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  migrateRetiredProviderId,
+  RETIRED_PROVIDER_REPLACEMENTS,
+  retiredProviderMigrationPriority,
+} from '../src/core/retired-provider-ids.js';
+
+describe('retired provider tombstones', () => {
+  it('is immutable and maps every retired id to its replacement', () => {
+    expect(Object.isFrozen(RETIRED_PROVIDER_REPLACEMENTS)).toBe(true);
+    expect(RETIRED_PROVIDER_REPLACEMENTS).toEqual({
+      'perplexity-sonar': 'perplexity-sonar-pro',
+      'perplexity-deep': 'perplexity-sonar-deep',
+      'openai-deep': 'openai-research',
+      'openai-deep-o3': 'openai-research',
+    });
+  });
+
+  it('keeps canonical OpenAI config ahead of o3 and deep aliases', () => {
+    const ids = ['openai-deep', 'openai-research', 'openai-deep-o3'];
+    expect(
+      [...ids].sort(
+        (left, right) =>
+          retiredProviderMigrationPriority(
+            left,
+            migrateRetiredProviderId(left),
+          ) -
+          retiredProviderMigrationPriority(
+            right,
+            migrateRetiredProviderId(right),
+          ),
+      ),
+    ).toEqual(['openai-research', 'openai-deep-o3', 'openai-deep']);
+  });
+});

--- a/tests/run-shadow-diagnostics.test.ts
+++ b/tests/run-shadow-diagnostics.test.ts
@@ -90,8 +90,37 @@ vi.mock('../src/adapters/node-registry.js', () => ({
 
 vi.mock('../src/core/provider-selection.js', () => {
   class ProviderSelectionError extends Error {}
+  const retired = {
+    'perplexity-sonar': 'perplexity-sonar-pro',
+    'perplexity-deep': 'perplexity-sonar-deep',
+    'openai-deep': 'openai-research',
+    'openai-deep-o3': 'openai-research',
+  } as const;
+  const retiredProviderSelectionIssues = (tokens?: readonly string[]) =>
+    (tokens ?? []).flatMap((token, index) => {
+      const id = token.trim() as keyof typeof retired;
+      const replacement = retired[id];
+      return replacement
+        ? [
+            {
+              code: 'provider_token_retired' as const,
+              path: `/providers/${index}`,
+              message: `Provider "${id}" was removed; use "${replacement}".`,
+            },
+          ]
+        : [];
+    });
   return {
     ProviderSelectionError,
+    retiredProviderSelectionIssues,
+    assertNoRetiredProviderSelectionTokens: (tokens?: readonly string[]) => {
+      const issues = retiredProviderSelectionIssues(tokens);
+      if (issues.length > 0) {
+        throw new ProviderSelectionError(
+          issues.map((issue) => issue.message).join(' '),
+        );
+      }
+    },
     resolveProviderSelection: () => {
       state.events.push('legacy-selection');
       if (state.selectionError) {
@@ -245,6 +274,29 @@ describe('CLI production shadow diagnostic', () => {
     }
   });
 
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])(
+    'stops CLI token %s before config, credentials, or initialization',
+    async (token, replacement) => {
+      const outcome = await executeRun('retired selector', {
+        providers: [token],
+      });
+
+      expect(outcome).toEqual({ exitCode: 2 });
+      expect(state.events).toEqual(['spinner-start', 'spinner-fail']);
+      expect(state.spinner.fail).toHaveBeenCalledWith(
+        `Provider "${token}" was removed; use "${replacement}".`,
+      );
+      expect(state.events).not.toContain('keychain-credentials');
+      expect(state.events).not.toContain('initialize');
+      expect(state.events).not.toContain('dispatch');
+    },
+  );
+
   it('keeps silent MCP results and dispatch inputs unchanged while warning only through onWarn', async () => {
     state.selectionError = false;
     const warnings: string[] = [];
@@ -323,6 +375,37 @@ describe('CLI production shadow diagnostic', () => {
       stdout.mockRestore();
     }
   });
+
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])(
+    'stops MCP token %s before config, initialization, or dispatch',
+    async (token, replacement) => {
+      const initialize = vi.fn();
+      const dispatch = vi.fn();
+      await expect(
+        runResearchSilent(
+          { query: 'retired selector', providers: [token] },
+          {
+            loadMergedConfig: () => {
+              state.events.push('load-merged');
+              return fixtureConfig;
+            },
+            initialize,
+            dispatch,
+          },
+        ),
+      ).rejects.toThrow(
+        `Provider "${token}" was removed; use "${replacement}".`,
+      );
+      expect(state.events).toEqual([]);
+      expect(initialize).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
 
   it('restarts the spinner and continues legacy execution when diagnostic stderr throws', async () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => {

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -238,6 +238,34 @@ describe('private shadow compilation', () => {
     },
   );
 
+  it.each([
+    ['perplexity-sonar/grounded', 'perplexity-sonar-pro/grounded'],
+    ['perplexity-deep/research', 'perplexity-sonar-deep/research'],
+    ['openai-deep/research', 'openai-research/research'],
+    ['openai-deep-o3/research', 'openai-research/research'],
+  ])(
+    'rejects qualified retired transport token %s with its full replacement',
+    (token, replacement) => {
+      const result = compile(
+        config({ providers: { 'openai-research': { enabled: true } } }),
+        {
+          kind: 'silent_mcp',
+          input: { query: `qualified retired ${token}`, providers: [token] },
+        },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.issues).toEqual([
+        {
+          code: 'shadow_provider_token_retired',
+          phase: 'transport',
+          path: '/providers/0',
+          message: `Provider "${token}" was removed; use "${replacement}".`,
+        },
+      ]);
+    },
+  );
+
   it('filters blank provider entries like v1 and retains stable token diagnostics', () => {
     const result = compile(config({ providers: { exa: { enabled: true } } }), {
       kind: 'silent_mcp',

--- a/tests/shadow-compilation.test.ts
+++ b/tests/shadow-compilation.test.ts
@@ -202,29 +202,41 @@ describe('private shadow compilation', () => {
     ).toBe('openrouter-chat');
   });
 
-  it('retains alias notices while deduplicating their canonical target', () => {
-    const result = compile(
-      config({
-        providers: { 'openai-research': { enabled: true } },
-        defaults: { mode: 'async' },
-      }),
-      {
-        kind: 'mcp',
-        input: {
-          query: 'OpenAI aliases',
-          providers: ['openai-deep', 'openai-research', 'openai-deep-o3'],
-          mode: 'async',
-        },
-      },
-    );
-
-    expect(profileKeys(result)).toEqual(['openai-research/research']);
-    expect(
-      result.notices.filter(
-        (notice) => notice.code === 'configuration_provider_alias_migrated',
-      ),
-    ).toHaveLength(2);
-  });
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])(
+    'rejects retired transport token %s across every ingress',
+    (token, replacement) => {
+      for (const kind of ['cli', 'mcp', 'silent_mcp'] as const) {
+        const result = compile(
+          config({ providers: { 'openai-research': { enabled: true } } }),
+          {
+            kind,
+            input: { query: `retired ${token}`, providers: [token] },
+          },
+        );
+        expect(result.ok, `${kind}/${token}`).toBe(false);
+        if (result.ok) continue;
+        expect(result).not.toHaveProperty('prepared');
+        expect(result.issues).toEqual([
+          {
+            code: 'shadow_provider_token_retired',
+            phase: 'transport',
+            path: '/providers/0',
+            message: `Provider "${token}" was removed; use "${replacement}".`,
+          },
+        ]);
+        expect(result.notices).not.toContainEqual(
+          expect.objectContaining({
+            code: 'configuration_provider_alias_migrated',
+          }),
+        );
+      }
+    },
+  );
 
   it('filters blank provider entries like v1 and retains stable token diagnostics', () => {
     const result = compile(config({ providers: { exa: { enabled: true } } }), {
@@ -820,7 +832,7 @@ describe('private shadow compilation', () => {
         kind: 'mcp',
         input: {
           query: 'alias collision',
-          providers: ['openai-deep'],
+          providers: ['openai-research'],
           mode: 'async',
         },
       },
@@ -1026,7 +1038,7 @@ describe('private shadow compilation', () => {
     const mixedPrepared = [
       {
         kind: 'cli' as const,
-        input: { query: 'mixed parity', providers: ['openai-deep'] },
+        input: { query: 'mixed parity', providers: ['openai-research'] },
       },
       {
         kind: 'mcp' as const,
@@ -1034,7 +1046,7 @@ describe('private shadow compilation', () => {
       },
       {
         kind: 'silent_mcp' as const,
-        input: { query: 'mixed parity', providers: ['openai-deep-o3'] },
+        input: { query: 'mixed parity', providers: ['openai-research'] },
       },
     ].map((transport) => {
       const result = compile(mixedSource, transport);
@@ -1080,7 +1092,7 @@ describe('private shadow compilation', () => {
       kind: 'cli',
       input: {
         query: 'provider precedence notices',
-        providers: ['openai-deep'],
+        providers: ['openai-research'],
         group: 'ignored-group',
       },
     });
@@ -1089,7 +1101,6 @@ describe('private shadow compilation', () => {
       result.notices,
     );
     for (const code of [
-      'configuration_provider_alias_migrated',
       'transport_explicit_providers_override_group',
       'legacy_mixed_mode_migrated',
     ]) {

--- a/tests/workers/shadow-compilation.test.ts
+++ b/tests/workers/shadow-compilation.test.ts
@@ -111,6 +111,55 @@ describe('private shadow compiler in workerd', () => {
     });
   });
 
+  it.each([
+    ['perplexity-sonar', 'perplexity-sonar-pro'],
+    ['perplexity-deep', 'perplexity-sonar-deep'],
+    ['openai-deep', 'openai-research'],
+    ['openai-deep-o3', 'openai-research'],
+  ])(
+    'rejects retired transport id %s before plan preparation',
+    (token, replacement) => {
+      const counts = { clock: 0, ids: 0 };
+      const result = compileShadowRequest({
+        config,
+        authoredGroups: { global: {}, project: {} },
+        credentials: {},
+        transport: {
+          kind: 'silent_mcp',
+          input: { query: `worker retired ${token}`, providers: [token] },
+        },
+        preparation: {
+          clock: {
+            now: () => {
+              counts.clock += 1;
+              return Date.parse('2026-08-09T12:00:00Z');
+            },
+          },
+          ids: {
+            next: (scope) => {
+              counts.ids += 1;
+              return `retired-${scope}`;
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        issues: [
+          {
+            code: 'shadow_provider_token_retired',
+            phase: 'transport',
+            path: '/providers/0',
+            message: `Provider "${token}" was removed; use "${replacement}".`,
+          },
+        ],
+        notices: [],
+      });
+      expect(counts).toEqual({ clock: 0, ids: 0 });
+    },
+  );
+
   it('injects the reachable maximum selected background attempt allowance', () => {
     const background: Config = {
       ...config,


### PR DESCRIPTION
## Summary

Retire four legacy provider aliases from current selection and runtime lookup while preserving deterministic v1 configuration migration.

## What's New

- Remove `perplexity-sonar`, `perplexity-deep`, `openai-deep`, and `openai-deep-o3` from active descriptors, catalogs, selectors, registry lookup, and metering.
- Keep one immutable tombstone map for v1 migration, native-v2 replacement guidance, and custom-provider reservation.
- Reject retired explicit CLI and MCP provider tokens before config loading, credentials, custom-provider initialization, or dispatch.
- Preserve qualified `provider/profile` suffixes during v1 migration and in retired-ID diagnostics.
- Preserve completed historical artifacts as opaque stored data, while pending retired handles remain unsupported.
- Remove the deprecated OpenAI wrapper modules and update migration documentation.

## Compatibility

- V1 configuration keys, fallback targets, and bare or qualified group members still migrate to canonical provider IDs.
- Native v2 configuration rejects retired IDs with exact paths and replacement guidance.
- Current selectors and runtime lookup do not reinterpret retired IDs.
- Completed historical artifacts retain their stored provider IDs and remain readable.

## Test Plan

- 1,624 unit tests
- 28 Worker tests
- 11 integration tests
- Linux and macOS PTY suites
- Typecheck, Biome lint, build, declaration generation, packed-consumer verification, engine-floor rejection, offline benchmark replay, Node 24 SEA verification, and diff checks
- Current-SHA GitHub Actions matrix: Node 22.12, 24, and 26 on Linux and Windows; engine floor; SEA; Linux and macOS PTY
- No live provider or paid API calls
