### PR TITLE
feat(config): support Windows owner ACLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
       - name: Unit tests
         run: npm run test
 
+      - name: Native Windows owner-only ACL tests
+        if: runner.os == 'Windows'
+        run: npx vitest run tests/node-config-v2.test.ts -t Windows --reporter=verbose
+
       - name: Offline benchmark fixture replay
         if: matrix.run-integration
         run: npm run benchmark:ci

--- a/README.md
+++ b/README.md
@@ -1559,8 +1559,9 @@ Node services:
 - `saveConfigV2(config, { path })` is the explicit atomic v2 write boundary. It
   validates first and enforces owner-only permissions before commit. Unix uses
   a verified `0600` mode. Windows establishes and reads back a protected DACL
-  that grants full control only to the current process user before atomic
-  replacement. Missing ACL support fails closed before destination replacement.
+  that grants full control only to the current process user. It retains the
+  creation handle through writing, verification, and atomic replacement.
+  Missing ACL support fails closed before destination replacement.
 
 ```ts
 import {

--- a/README.md
+++ b/README.md
@@ -1557,9 +1557,10 @@ Node services:
 - `loadConfigV2({ global_path, project_path? })` reads and migrates without
   rewriting either file.
 - `saveConfigV2(config, { path })` is the explicit atomic v2 write boundary. It
-  validates first and enforces owner-only permissions before commit on Unix;
-  Windows fails before touching disk until an equivalent ACL writer is
-  available.
+  validates first and enforces owner-only permissions before commit. Unix uses
+  a verified `0600` mode. Windows establishes and reads back a protected DACL
+  that grants full control only to the current process user before atomic
+  replacement. Missing ACL support fails closed before destination replacement.
 
 ```ts
 import {

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -60,8 +60,9 @@ Usage"). The boundary matters for provider development:
   them. It also owns explicit config-file load/save: loads never rewrite and
   `saveConfigV2()` validates before an atomic owner-only write. Unix uses a
   verified `0600` mode. Windows creates the temporary file with a protected
-  DACL containing one full-control rule for the current process user and reads
-  it back before replacement; missing ACL support fails closed.
+  DACL containing one full-control rule for the current process user and keeps
+  that creation handle through write, verification, and replacement; missing
+  ACL support fails closed.
   Complete configured runs still go through the `librarium` CLI while the v2
   high-level library runner is finalized.
 

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -58,8 +58,10 @@ Usage"). The boundary matters for provider development:
 - **`librarium/node`** exposes `loadCustomProviders()` for explicitly trusted
   npm modules and scripts. It returns provider instances without registering
   them. It also owns explicit config-file load/save: loads never rewrite and
-  `saveConfigV2()` validates before an atomic owner-only Unix write. Windows
-  fails before touching disk until an equivalent ACL writer is available.
+  `saveConfigV2()` validates before an atomic owner-only write. Unix uses a
+  verified `0600` mode. Windows creates the temporary file with a protected
+  DACL containing one full-control rule for the current process user and reads
+  it back before replacement; missing ACL support fails closed.
   Complete configured runs still go through the `librarium` CLI while the v2
   high-level library runner is finalized.
 

--- a/src/core/fs-utils.ts
+++ b/src/core/fs-utils.ts
@@ -1,33 +1,208 @@
+import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import {
   chmodSync,
+  closeSync,
+  existsSync,
+  openSync,
   renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { win32 } from 'node:path';
+
+interface WindowsOwnerOnlyAcl {
+  readonly createExclusive: (path: string, markCreated: () => void) => void;
+  readonly verify: (path: string) => void;
+}
 
 interface SafeWriteFileOptions {
   readonly mode?: number;
-  /** Require Unix owner-only permissions before the rename commits the file. */
+  /** Require owner-only permissions before the rename commits the file. */
   readonly ownerOnly?: boolean;
+  /** Internal mutation-test seam. Production callers must use the default. */
+  readonly windowsAcl?: WindowsOwnerOnlyAcl;
 }
 
+const WINDOWS_ACL_TIMEOUT_MS = 15_000;
+const WINDOWS_ACL_MAX_BUFFER = 64 * 1024;
+
+const WINDOWS_ASSERT_OWNER_ONLY_ACL_SUPPORT = `
+$ErrorActionPreference = 'Stop'
+$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+if ($null -eq $sid) { throw 'The current Windows identity has no user SID.' }
+$acl = New-Object System.Security.AccessControl.FileSecurity
+$acl.SetOwner($sid)
+$acl.SetAccessRuleProtection($true, $false)
+$constructor = [IO.FileStream].GetConstructor(@(
+  [string],
+  [IO.FileMode],
+  [Security.AccessControl.FileSystemRights],
+  [IO.FileShare],
+  [int],
+  [IO.FileOptions],
+  [Security.AccessControl.FileSecurity]
+))
+if ($null -eq $constructor) { throw 'The secure FileStream constructor is unavailable.' }
+[Console]::Out.Write('supported')
+`;
+
+const WINDOWS_CREATE_OWNER_ONLY_FILE = `
+$ErrorActionPreference = 'Stop'
+$encodedPath = [Console]::In.ReadToEnd()
+$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedPath))
+$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+if ($null -eq $sid) { throw 'The current Windows identity has no user SID.' }
+
+$acl = New-Object System.Security.AccessControl.FileSecurity
+$acl.SetOwner($sid)
+$acl.SetAccessRuleProtection($true, $false)
+$rule = New-Object System.Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+  $sid,
+  [Security.AccessControl.FileSystemRights]::FullControl,
+  [Security.AccessControl.AccessControlType]::Allow
+)
+$acl.AddAccessRule($rule)
+
+$stream = $null
+$created = $false
+try {
+  $stream = New-Object IO.FileStream -ArgumentList @(
+    $path,
+    [IO.FileMode]::CreateNew,
+    [Security.AccessControl.FileSystemRights]::FullControl,
+    [IO.FileShare]::None,
+    4096,
+    [IO.FileOptions]::None,
+    $acl
+  )
+  $created = $true
+  $stream.Dispose()
+  $stream = $null
+  [Console]::Out.Write('created')
+} catch {
+  try {
+    if ($null -ne $stream) { $stream.Dispose() }
+  } finally {
+    if ($created) { [IO.File]::Delete($path) }
+  }
+  throw
+}
+`;
+
+const WINDOWS_VERIFY_OWNER_ONLY_ACL = `
+$ErrorActionPreference = 'Stop'
+$encodedPath = [Console]::In.ReadToEnd()
+$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedPath))
+$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+if ($null -eq $sid) { throw 'The current Windows identity has no user SID.' }
+
+$acl = [IO.File]::GetAccessControl($path)
+$owner = $acl.GetOwner([Security.Principal.SecurityIdentifier])
+$rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
+$fullControl = [int][Security.AccessControl.FileSystemRights]::FullControl
+$noneInheritance = [Security.AccessControl.InheritanceFlags]::None
+$nonePropagation = [Security.AccessControl.PropagationFlags]::None
+$allow = [Security.AccessControl.AccessControlType]::Allow
+
+if ($owner.Value -ne $sid.Value) { throw 'The file owner is not the current user.' }
+if (-not $acl.AreAccessRulesProtected) { throw 'The file DACL is not protected.' }
+if ($rules.Count -ne 1) { throw 'The file DACL does not contain exactly one ACE.' }
+$rule = $rules[0]
+if ($rule.IdentityReference.Value -ne $sid.Value) { throw 'The file ACE is not for the current user.' }
+if ($rule.IsInherited) { throw 'The file ACE is inherited.' }
+if ($rule.AccessControlType -ne $allow) { throw 'The file ACE is not an allow rule.' }
+if ([int]$rule.FileSystemRights -ne $fullControl) { throw 'The file ACE is not full control.' }
+if ($rule.InheritanceFlags -ne $noneInheritance) { throw 'The file ACE has inheritance flags.' }
+if ($rule.PropagationFlags -ne $nonePropagation) { throw 'The file ACE has propagation flags.' }
+
+[Console]::Out.Write('verified')
+`;
+
+function windowsPowerShellExecutable(): string {
+  const systemRoot = process.env.SystemRoot;
+  if (systemRoot === undefined || !win32.isAbsolute(systemRoot)) {
+    throw new Error('A valid Windows system root is required.');
+  }
+  return win32.join(
+    systemRoot,
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe',
+  );
+}
+
+function runWindowsAclScript(path: string, script: string): string {
+  return execFileSync(
+    windowsPowerShellExecutable(),
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-EncodedCommand',
+      Buffer.from(script, 'utf16le').toString('base64'),
+    ],
+    {
+      encoding: 'utf8',
+      input: Buffer.from(path, 'utf8').toString('base64'),
+      maxBuffer: WINDOWS_ACL_MAX_BUFFER,
+      shell: false,
+      timeout: WINDOWS_ACL_TIMEOUT_MS,
+      windowsHide: true,
+    },
+  );
+}
+
+/** Fail before filesystem mutation when the required inbox ACL tool is absent. */
+export function assertWindowsOwnerOnlyAclSupport(): void {
+  if (process.platform !== 'win32') return;
+  if (!existsSync(windowsPowerShellExecutable())) {
+    throw new Error('Windows PowerShell is required for owner-only writes.');
+  }
+  if (
+    runWindowsAclScript('', WINDOWS_ASSERT_OWNER_ONLY_ACL_SUPPORT) !==
+    'supported'
+  ) {
+    throw new Error('Windows owner-only ACL preflight returned no proof.');
+  }
+}
+
+/** Exclusively create a file with a protected current-user-only DACL. */
+export function createWindowsOwnerOnlyFile(path: string): void {
+  if (runWindowsAclScript(path, WINDOWS_CREATE_OWNER_ONLY_FILE) !== 'created') {
+    throw new Error('Windows owner-only creation returned no proof.');
+  }
+}
+
+/** Read back and verify the exact owner-only Windows security descriptor. */
+export function verifyWindowsOwnerOnlyAcl(path: string): void {
+  if (runWindowsAclScript(path, WINDOWS_VERIFY_OWNER_ONLY_ACL) !== 'verified') {
+    throw new Error('Windows owner-only ACL verification returned no proof.');
+  }
+}
+
+const DEFAULT_WINDOWS_ACL: WindowsOwnerOnlyAcl = {
+  createExclusive: (path, markCreated) => {
+    createWindowsOwnerOnlyFile(path);
+    markCreated();
+  },
+  verify: verifyWindowsOwnerOnlyAcl,
+};
+
 /**
- * Atomically write a file by writing to a temp file and renaming.
+ * Atomically write a file by writing to an exclusive sibling temp file and
+ * renaming it over the destination.
  *
- * When ownerOnly is set, this intentionally supports Unix permission bits
- * only. Callers must reject Windows before touching the destination because
- * this helper does not establish a Windows ACL equivalent to mode 0600.
+ * Owner-only writes establish and verify their Unix mode or Windows DACL on
+ * the empty temp file before writing content, then verify again before rename.
  */
 export function safeWriteFile(
   path: string,
   content: string,
   options?: SafeWriteFileOptions,
 ): void {
-  if (options?.ownerOnly && process.platform === 'win32') {
-    throw new Error('Owner-only writes are unsupported on Windows.');
-  }
   const createMode = options?.ownerOnly ? 0o600 : options?.mode;
   if (
     options?.ownerOnly &&
@@ -36,34 +211,67 @@ export function safeWriteFile(
   ) {
     throw new Error('Owner-only writes require mode 600.');
   }
-  const tmp = `${path}.tmp.${randomUUID().slice(0, 8)}`;
+  const tmp = `${path}.tmp.${randomUUID()}`;
+  let descriptor: number | undefined;
+  let created = false;
+
   try {
-    // wx makes temp-file creation exclusive even if a random-name collision
-    // or a pre-existing symlink is present.
-    writeFileSync(tmp, content, {
-      encoding: 'utf-8',
-      flag: 'wx',
-      mode: createMode,
-    });
-    if (options?.ownerOnly) {
-      const expectedMode = 0o600;
-      // The mode argument is subject to umask; chmod and verify the exact
-      // owner-only bits while the file is still uncommitted. Ordinary callers
-      // that provide only `mode` keep their historical platform semantics.
-      chmodSync(tmp, expectedMode);
-      if ((statSync(tmp).mode & 0o777) !== expectedMode) {
-        throw new Error(
-          `Temporary file mode must be ${expectedMode.toString(8)}.`,
-        );
+    if (options?.ownerOnly && process.platform === 'win32') {
+      const windowsAcl = options.windowsAcl ?? DEFAULT_WINDOWS_ACL;
+      // FileMode.CreateNew plus FileSecurity applies the protected DACL in the
+      // same OS create operation. No broadly inherited handle exists first.
+      windowsAcl.createExclusive(tmp, () => {
+        created = true;
+      });
+      if (!created) {
+        throw new Error('Windows owner-only creation returned no proof.');
+      }
+      windowsAcl.verify(tmp);
+      descriptor = openSync(tmp, 'r+');
+    } else {
+      // wx makes creation exclusive even if a random-name collision or a
+      // pre-existing symlink is present. Track ownership so a collision never
+      // causes cleanup to delete a path that this call did not create.
+      descriptor = openSync(tmp, 'wx', createMode);
+      created = true;
+      if (options?.ownerOnly) {
+        const expectedMode = 0o600;
+        // The creation mode is subject to umask. Force and verify the exact
+        // owner-only bits while the file is still empty and uncommitted.
+        chmodSync(tmp, expectedMode);
+        if ((statSync(tmp).mode & 0o777) !== expectedMode) {
+          throw new Error(
+            `Temporary file mode must be ${expectedMode.toString(8)}.`,
+          );
+        }
       }
     }
-    renameSync(tmp, path);
-  } catch (e) {
-    try {
-      unlinkSync(tmp);
-    } catch {
-      /* ignore */
+
+    writeFileSync(descriptor, content, { encoding: 'utf8' });
+    closeSync(descriptor);
+    descriptor = undefined;
+
+    if (options?.ownerOnly && process.platform === 'win32') {
+      (options.windowsAcl ?? DEFAULT_WINDOWS_ACL).verify(tmp);
     }
-    throw e;
+
+    renameSync(tmp, path);
+    created = false;
+  } catch (error) {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        /* preserve the original failure */
+      }
+    }
+    if (created) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* preserve the original failure */
+      }
+    }
+    throw error;
   }
 }

--- a/src/core/fs-utils.ts
+++ b/src/core/fs-utils.ts
@@ -66,7 +66,8 @@ public static class LibrariumNativeFile {
     int rootOffset = IntPtr.Size == 8 ? 8 : 4;
     int lengthOffset = rootOffset + IntPtr.Size;
     int nameOffset = lengthOffset + sizeof(uint);
-    int size = nameOffset + name.Length;
+    int structureSize = IntPtr.Size == 8 ? 24 : 16;
+    int size = structureSize + name.Length;
     IntPtr buffer = Marshal.AllocHGlobal(size);
     try {
       for (int index = 0; index < size; index++) Marshal.WriteByte(buffer, index, 0);

--- a/src/core/fs-utils.ts
+++ b/src/core/fs-utils.ts
@@ -13,9 +13,19 @@ import {
 import { win32 } from 'node:path';
 
 interface WindowsOwnerOnlyAcl {
-  readonly createExclusive: (path: string, markCreated: () => void) => void;
-  readonly verify: (path: string) => void;
+  readonly replaceAtomically: (
+    temporaryPath: string,
+    destinationPath: string,
+    content: string,
+    mutationStage?: WindowsMutationStage,
+  ) => void;
 }
+
+type WindowsMutationStage =
+  | 'initial-verify-to-write'
+  | 'write-to-final-verify'
+  | 'final-verify-to-rename'
+  | 'failure-cleanup';
 
 interface SafeWriteFileOptions {
   readonly mode?: number;
@@ -23,13 +33,74 @@ interface SafeWriteFileOptions {
   readonly ownerOnly?: boolean;
   /** Internal mutation-test seam. Production callers must use the default. */
   readonly windowsAcl?: WindowsOwnerOnlyAcl;
+  /** Native Windows regression hook. Never set in production. */
+  readonly windowsMutationStage?: WindowsMutationStage;
 }
 
 const WINDOWS_ACL_TIMEOUT_MS = 15_000;
 const WINDOWS_ACL_MAX_BUFFER = 64 * 1024;
 
+const WINDOWS_NATIVE_FILE_TYPE = `
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+public static class LibrariumNativeFile {
+  private enum FILE_INFO_BY_HANDLE_CLASS {
+    FileRenameInfo = 3,
+    FileDispositionInfo = 4
+  }
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool SetFileInformationByHandle(
+    SafeFileHandle handle,
+    FILE_INFO_BY_HANDLE_CLASS informationClass,
+    IntPtr information,
+    uint bufferSize
+  );
+
+  public static void Rename(SafeFileHandle handle, string destination) {
+    byte[] name = Encoding.Unicode.GetBytes(destination);
+    int rootOffset = IntPtr.Size == 8 ? 8 : 4;
+    int lengthOffset = rootOffset + IntPtr.Size;
+    int nameOffset = lengthOffset + sizeof(uint);
+    int size = nameOffset + name.Length;
+    IntPtr buffer = Marshal.AllocHGlobal(size);
+    try {
+      for (int index = 0; index < size; index++) Marshal.WriteByte(buffer, index, 0);
+      Marshal.WriteInt32(buffer, 0, 1);
+      Marshal.WriteIntPtr(buffer, rootOffset, IntPtr.Zero);
+      Marshal.WriteInt32(buffer, lengthOffset, name.Length);
+      Marshal.Copy(name, 0, IntPtr.Add(buffer, nameOffset), name.Length);
+      if (!SetFileInformationByHandle(handle, FILE_INFO_BY_HANDLE_CLASS.FileRenameInfo, buffer, (uint)size)) {
+        throw new Win32Exception(Marshal.GetLastWin32Error());
+      }
+    } finally {
+      Marshal.FreeHGlobal(buffer);
+    }
+  }
+
+  public static void DeleteOnClose(SafeFileHandle handle) {
+    IntPtr buffer = Marshal.AllocHGlobal(1);
+    try {
+      Marshal.WriteByte(buffer, 0, 1);
+      if (!SetFileInformationByHandle(handle, FILE_INFO_BY_HANDLE_CLASS.FileDispositionInfo, buffer, 1)) {
+        throw new Win32Exception(Marshal.GetLastWin32Error());
+      }
+    } finally {
+      Marshal.FreeHGlobal(buffer);
+    }
+  }
+}
+`;
+
 const WINDOWS_ASSERT_OWNER_ONLY_ACL_SUPPORT = `
 $ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+${WINDOWS_NATIVE_FILE_TYPE}
+'@
 $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
 if ($null -eq $sid) { throw 'The current Windows identity has no user SID.' }
 $acl = New-Object System.Security.AccessControl.FileSecurity
@@ -45,13 +116,23 @@ $constructor = [IO.FileStream].GetConstructor(@(
   [Security.AccessControl.FileSecurity]
 ))
 if ($null -eq $constructor) { throw 'The secure FileStream constructor is unavailable.' }
+[void][LibrariumNativeFile]
 [Console]::Out.Write('supported')
 `;
 
-const WINDOWS_CREATE_OWNER_ONLY_FILE = `
+const WINDOWS_REPLACE_OWNER_ONLY_FILE = `
 $ErrorActionPreference = 'Stop'
-$encodedPath = [Console]::In.ReadToEnd()
-$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedPath))
+$payload = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$temporaryPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($payload.temporaryPath))
+$destinationPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($payload.destinationPath))
+$content = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($payload.content))
+$mutationStage = $payload.mutationStage
+$mutationConfirmed = $false
+
+Add-Type -TypeDefinition @'
+${WINDOWS_NATIVE_FILE_TYPE}
+'@
+
 $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
 if ($null -eq $sid) { throw 'The current Windows identity has no user SID.' }
 
@@ -65,11 +146,50 @@ $rule = New-Object System.Security.AccessControl.FileSystemAccessRule -ArgumentL
 )
 $acl.AddAccessRule($rule)
 
+function Assert-OwnerOnlyAcl([IO.FileStream] $stream) {
+  $verifiedAcl = $stream.GetAccessControl()
+  $owner = $verifiedAcl.GetOwner([Security.Principal.SecurityIdentifier])
+  $rules = @($verifiedAcl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
+  $fullControl = [int][Security.AccessControl.FileSystemRights]::FullControl
+  $noneInheritance = [Security.AccessControl.InheritanceFlags]::None
+  $nonePropagation = [Security.AccessControl.PropagationFlags]::None
+  $allow = [Security.AccessControl.AccessControlType]::Allow
+
+  if ($owner.Value -ne $sid.Value) { throw 'The file owner is not the current user.' }
+  if (-not $verifiedAcl.AreAccessRulesProtected) { throw 'The file DACL is not protected.' }
+  if ($rules.Count -ne 1) { throw 'The file DACL does not contain exactly one ACE.' }
+  $verifiedRule = $rules[0]
+  if ($verifiedRule.IdentityReference.Value -ne $sid.Value) { throw 'The file ACE is not for the current user.' }
+  if ($verifiedRule.IsInherited) { throw 'The file ACE is inherited.' }
+  if ($verifiedRule.AccessControlType -ne $allow) { throw 'The file ACE is not an allow rule.' }
+  if ([int]$verifiedRule.FileSystemRights -ne $fullControl) { throw 'The file ACE is not full control.' }
+  if ($verifiedRule.InheritanceFlags -ne $noneInheritance) { throw 'The file ACE has inheritance flags.' }
+  if ($verifiedRule.PropagationFlags -ne $nonePropagation) { throw 'The file ACE has propagation flags.' }
+}
+
+function Assert-NamespaceSwapBlocked([string] $stage) {
+  if ($mutationStage -ne $stage) { return }
+  $heldPath = "$temporaryPath.swap"
+  $moveBlocked = $false
+  try {
+    [IO.File]::Move($temporaryPath, $heldPath)
+  } catch [IO.IOException] {
+    $win32Error = $_.Exception.HResult -band 0xffff
+    if ($win32Error -ne 32) { throw }
+    $moveBlocked = $true
+    $script:mutationConfirmed = $true
+  }
+  if (-not $moveBlocked) {
+    [IO.File]::WriteAllText($temporaryPath, 'attacker replacement')
+    throw "Namespace substitution unexpectedly succeeded at $stage."
+  }
+}
+
 $stream = $null
-$created = $false
+$committed = $false
 try {
   $stream = New-Object IO.FileStream -ArgumentList @(
-    $path,
+    $temporaryPath,
     [IO.FileMode]::CreateNew,
     [Security.AccessControl.FileSystemRights]::FullControl,
     [IO.FileShare]::None,
@@ -77,15 +197,44 @@ try {
     [IO.FileOptions]::None,
     $acl
   )
-  $created = $true
+  Assert-OwnerOnlyAcl $stream
+  Assert-NamespaceSwapBlocked 'initial-verify-to-write'
+
+  $bytes = [Text.Encoding]::UTF8.GetBytes($content)
+  $stream.Write($bytes, 0, $bytes.Length)
+  $stream.Flush($true)
+  Assert-NamespaceSwapBlocked 'write-to-final-verify'
+  Assert-OwnerOnlyAcl $stream
+  Assert-NamespaceSwapBlocked 'final-verify-to-rename'
+
+  if ($null -ne $mutationStage -and $mutationStage -ne 'failure-cleanup' -and -not $mutationConfirmed) {
+    throw "The namespace mutation was not tested at $mutationStage."
+  }
+
+  if ($mutationStage -eq 'failure-cleanup') {
+    throw 'Injected failure before handle-bound cleanup.'
+  }
+
+  [LibrariumNativeFile]::Rename($stream.SafeFileHandle, $destinationPath)
+  $committed = $true
+  Assert-OwnerOnlyAcl $stream
   $stream.Dispose()
   $stream = $null
-  [Console]::Out.Write('created')
+  [Console]::Out.Write('replaced')
 } catch {
   try {
-    if ($null -ne $stream) { $stream.Dispose() }
+    if ($null -ne $stream -and -not $committed) {
+      try {
+        Assert-NamespaceSwapBlocked 'failure-cleanup'
+        if ($mutationStage -eq 'failure-cleanup' -and -not $mutationConfirmed) {
+          throw 'The namespace mutation was not tested during failure cleanup.'
+        }
+      } finally {
+        [LibrariumNativeFile]::DeleteOnClose($stream.SafeFileHandle)
+      }
+    }
   } finally {
-    if ($created) { [IO.File]::Delete($path) }
+    if ($null -ne $stream) { $stream.Dispose() }
   }
   throw
 }
@@ -155,6 +304,41 @@ function runWindowsAclScript(path: string, script: string): string {
   );
 }
 
+function runWindowsOwnerOnlyReplace(
+  temporaryPath: string,
+  destinationPath: string,
+  content: string,
+  mutationStage?: WindowsMutationStage,
+): string {
+  return execFileSync(
+    windowsPowerShellExecutable(),
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-EncodedCommand',
+      Buffer.from(WINDOWS_REPLACE_OWNER_ONLY_FILE, 'utf16le').toString(
+        'base64',
+      ),
+    ],
+    {
+      encoding: 'utf8',
+      input: JSON.stringify({
+        temporaryPath: Buffer.from(temporaryPath, 'utf8').toString('base64'),
+        destinationPath: Buffer.from(destinationPath, 'utf8').toString(
+          'base64',
+        ),
+        content: Buffer.from(content, 'utf8').toString('base64'),
+        mutationStage,
+      }),
+      maxBuffer: WINDOWS_ACL_MAX_BUFFER,
+      shell: false,
+      timeout: WINDOWS_ACL_TIMEOUT_MS,
+      windowsHide: true,
+    },
+  );
+}
+
 /** Fail before filesystem mutation when the required inbox ACL tool is absent. */
 export function assertWindowsOwnerOnlyAclSupport(): void {
   if (process.platform !== 'win32') return;
@@ -169,10 +353,22 @@ export function assertWindowsOwnerOnlyAclSupport(): void {
   }
 }
 
-/** Exclusively create a file with a protected current-user-only DACL. */
-export function createWindowsOwnerOnlyFile(path: string): void {
-  if (runWindowsAclScript(path, WINDOWS_CREATE_OWNER_ONLY_FILE) !== 'created') {
-    throw new Error('Windows owner-only creation returned no proof.');
+/** Replace a destination while retaining one protected temp-file handle. */
+function replaceWindowsOwnerOnlyFile(
+  temporaryPath: string,
+  destinationPath: string,
+  content: string,
+  mutationStage?: WindowsMutationStage,
+): void {
+  if (
+    runWindowsOwnerOnlyReplace(
+      temporaryPath,
+      destinationPath,
+      content,
+      mutationStage,
+    ) !== 'replaced'
+  ) {
+    throw new Error('Windows owner-only replacement returned no proof.');
   }
 }
 
@@ -184,11 +380,7 @@ export function verifyWindowsOwnerOnlyAcl(path: string): void {
 }
 
 const DEFAULT_WINDOWS_ACL: WindowsOwnerOnlyAcl = {
-  createExclusive: (path, markCreated) => {
-    createWindowsOwnerOnlyFile(path);
-    markCreated();
-  },
-  verify: verifyWindowsOwnerOnlyAcl,
+  replaceAtomically: replaceWindowsOwnerOnlyFile,
 };
 
 /**
@@ -196,7 +388,8 @@ const DEFAULT_WINDOWS_ACL: WindowsOwnerOnlyAcl = {
  * renaming it over the destination.
  *
  * Owner-only writes establish and verify their Unix mode or Windows DACL on
- * the empty temp file before writing content, then verify again before rename.
+ * the empty temp file before writing content. Windows retains the creation
+ * handle through the final ACL check and handle-bound rename.
  */
 export function safeWriteFile(
   path: string,
@@ -218,16 +411,16 @@ export function safeWriteFile(
   try {
     if (options?.ownerOnly && process.platform === 'win32') {
       const windowsAcl = options.windowsAcl ?? DEFAULT_WINDOWS_ACL;
-      // FileMode.CreateNew plus FileSecurity applies the protected DACL in the
-      // same OS create operation. No broadly inherited handle exists first.
-      windowsAcl.createExclusive(tmp, () => {
-        created = true;
-      });
-      if (!created) {
-        throw new Error('Windows owner-only creation returned no proof.');
-      }
-      windowsAcl.verify(tmp);
-      descriptor = openSync(tmp, 'r+');
+      // The Windows transaction retains the creation handle through ACL
+      // verification, write, handle-bound rename, and failure disposal. Node
+      // must never act on the temporary pathname after this call begins.
+      windowsAcl.replaceAtomically(
+        tmp,
+        path,
+        content,
+        options.windowsMutationStage,
+      );
+      return;
     } else {
       // wx makes creation exclusive even if a random-name collision or a
       // pre-existing symlink is present. Track ownership so a collision never
@@ -250,10 +443,6 @@ export function safeWriteFile(
     writeFileSync(descriptor, content, { encoding: 'utf8' });
     closeSync(descriptor);
     descriptor = undefined;
-
-    if (options?.ownerOnly && process.platform === 'win32') {
-      (options.windowsAcl ?? DEFAULT_WINDOWS_ACL).verify(tmp);
-    }
 
     renameSync(tmp, path);
     created = false;

--- a/src/node-config-v2.ts
+++ b/src/node-config-v2.ts
@@ -7,7 +7,10 @@ import {
   migrateConfig,
   validateConfigV2,
 } from './core/config-v2.js';
-import { safeWriteFile } from './core/fs-utils.js';
+import {
+  assertWindowsOwnerOnlyAclSupport,
+  safeWriteFile,
+} from './core/fs-utils.js';
 import type { PreparationIssue } from './core/research-request.js';
 
 export interface LoadConfigV2Options {
@@ -105,10 +108,11 @@ export function loadConfigV2(
 /**
  * Explicitly persist a validated native v2 configuration.
  *
- * The write is atomic and owner-only on Unix. Windows fails before touching
- * disk until Librarium can establish and verify an equivalent ACL. Loading and
- * ordinary execution never call this function, so migration cannot silently
- * rewrite user files.
+ * The write is atomic and owner-only. Unix uses a verified 0600 mode. Windows
+ * establishes a protected DACL containing only the current user, verifies it
+ * before writing content, and verifies it again before atomic replacement.
+ * Missing Windows ACL support fails closed. Loading and ordinary execution
+ * never call this function, so migration cannot silently rewrite user files.
  */
 export function saveConfigV2(
   config: LibrariumConfigV2,
@@ -121,9 +125,11 @@ export function saveConfigV2(
       validated.issues,
     );
   }
-  if (process.platform === 'win32') {
+  try {
+    assertWindowsOwnerOnlyAclSupport();
+  } catch {
     throw new ConfigV2FileError(
-      'Owner-only config saves are unsupported on Windows because no equivalent ACL is established.',
+      'Owner-only config saves require verified Windows ACL support.',
     );
   }
   const path = resolve(options.path);

--- a/src/node-config-v2.ts
+++ b/src/node-config-v2.ts
@@ -109,8 +109,8 @@ export function loadConfigV2(
  * Explicitly persist a validated native v2 configuration.
  *
  * The write is atomic and owner-only. Unix uses a verified 0600 mode. Windows
- * establishes a protected DACL containing only the current user, verifies it
- * before writing content, and verifies it again before atomic replacement.
+ * establishes a protected DACL containing only the current user, then retains
+ * the creation handle through writing, verification, and atomic replacement.
  * Missing Windows ACL support fails closed. Loading and ordinary execution
  * never call this function, so migration cannot silently rewrite user files.
  */

--- a/tests/node-config-v2.test.ts
+++ b/tests/node-config-v2.test.ts
@@ -284,21 +284,29 @@ describe('explicit Node v2 config files', () => {
       mode: 0o600,
       ownerOnly: true,
       windowsAcl: {
-        createExclusive(tempPath, markCreated) {
-          writeFileSync(tempPath, '', { flag: 'wx' });
-          markCreated();
-          observed.push(`created:${readFileSync(tempPath, 'utf8')}`);
-        },
-        verify(tempPath) {
-          observed.push(`verified:${readFileSync(tempPath, 'utf8')}`);
+        replaceAtomically(
+          temporaryPath,
+          destinationPath,
+          content,
+          mutationStage,
+        ) {
+          observed.push(
+            `temporary:${temporaryPath.startsWith(`${path}.tmp.`)}`,
+          );
+          observed.push(`destination:${destinationPath === path}`);
+          observed.push(`content:${content}`);
+          observed.push(`mutation:${mutationStage}`);
+          writeFileSync(destinationPath, content, { flag: 'wx' });
         },
       },
+      windowsMutationStage: 'final-verify-to-rename',
     });
 
     expect(observed).toEqual([
-      'created:',
-      'verified:',
-      'verified:owner-only-content',
+      'temporary:true',
+      'destination:true',
+      'content:owner-only-content',
+      'mutation:final-verify-to-rename',
     ]);
     expect(readFileSync(path, 'utf8')).toBe('owner-only-content');
     expect(readdirSync(directory)).toEqual(['windows-order.json']);
@@ -315,13 +323,8 @@ describe('explicit Node v2 config files', () => {
         mode: 0o600,
         ownerOnly: true,
         windowsAcl: {
-          createExclusive(tempPath, markCreated) {
-            writeFileSync(tempPath, '', { flag: 'wx' });
-            markCreated();
+          replaceAtomically() {
             throw new Error('injected ACL application failure');
-          },
-          verify() {
-            throw new Error('verification must not run');
           },
         },
       }),
@@ -342,13 +345,10 @@ describe('explicit Node v2 config files', () => {
         mode: 0o600,
         ownerOnly: true,
         windowsAcl: {
-          createExclusive(tempPath) {
+          replaceAtomically(tempPath) {
             collisionPath = tempPath;
             writeFileSync(tempPath, 'someone-else');
             throw new Error('injected exclusive-create collision');
-          },
-          verify() {
-            throw new Error('verification must not run');
           },
         },
       }),
@@ -363,21 +363,18 @@ describe('explicit Node v2 config files', () => {
     }
     const path = join(directory, 'windows-verify-failure.json');
     writeFileSync(path, 'original');
-    let verifications = 0;
 
     expect(() =>
       safeWriteFile(path, 'must-not-commit', {
         mode: 0o600,
         ownerOnly: true,
         windowsAcl: {
-          createExclusive(tempPath, markCreated) {
+          replaceAtomically(tempPath) {
             writeFileSync(tempPath, '', { flag: 'wx' });
-            markCreated();
-          },
-          verify() {
-            verifications += 1;
-            if (verifications === 2) {
+            try {
               throw new Error('injected ACL verification failure');
+            } finally {
+              rmSync(tempPath);
             }
           },
         },
@@ -399,12 +396,13 @@ describe('explicit Node v2 config files', () => {
         mode: 0o600,
         ownerOnly: true,
         windowsAcl: {
-          createExclusive(tempPath, markCreated) {
+          replaceAtomically(tempPath) {
             writeFileSync(tempPath, '', { flag: 'wx' });
-            markCreated();
-          },
-          verify() {
-            throw new Error('injected first ACL verification failure');
+            try {
+              throw new Error('injected first ACL verification failure');
+            } finally {
+              rmSync(tempPath);
+            }
           },
         },
       }),
@@ -533,6 +531,45 @@ describe.runIf(process.platform === 'win32')(
       addNativeWindowsEveryoneRule(path);
 
       expect(() => verifyWindowsOwnerOnlyAcl(path)).toThrow();
+    });
+
+    it.each([
+      'initial-verify-to-write',
+      'write-to-final-verify',
+      'final-verify-to-rename',
+    ] as const)(
+      'blocks namespace substitution at %s while retaining the creation handle',
+      (windowsMutationStage) => {
+        const path = join(directory, `${windowsMutationStage}.json`);
+
+        safeWriteFile(path, 'handle-bound-content', {
+          mode: 0o600,
+          ownerOnly: true,
+          windowsMutationStage,
+        });
+
+        verifyWindowsOwnerOnlyAcl(path);
+        expect(readFileSync(path, 'utf8')).toBe('handle-bound-content');
+        expect(readdirSync(directory)).toEqual([
+          `${windowsMutationStage}.json`,
+        ]);
+      },
+    );
+
+    it('binds failure cleanup to the retained handle after a swap attempt', () => {
+      const path = join(directory, 'cleanup-replacement.json');
+      writeFileSync(path, 'original-destination');
+
+      expect(() =>
+        safeWriteFile(path, 'must-not-commit', {
+          mode: 0o600,
+          ownerOnly: true,
+          windowsMutationStage: 'failure-cleanup',
+        }),
+      ).toThrow('Injected failure before handle-bound cleanup.');
+
+      expect(readFileSync(path, 'utf8')).toBe('original-destination');
+      expect(readdirSync(directory)).toEqual(['cleanup-replacement.json']);
     });
   },
 );

--- a/tests/node-config-v2.test.ts
+++ b/tests/node-config-v2.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -10,9 +11,12 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LibrariumConfigV2 } from '../src/core/config-v2.js';
-import { safeWriteFile } from '../src/core/fs-utils.js';
+import {
+  safeWriteFile,
+  verifyWindowsOwnerOnlyAcl,
+} from '../src/core/fs-utils.js';
 import {
   ConfigV2FileError,
   loadConfigV2,
@@ -41,6 +45,89 @@ function config(): LibrariumConfigV2 {
   };
 }
 
+function setNativeWindowsInheritedAcl(path: string): void {
+  const systemRoot = process.env.SystemRoot;
+  if (systemRoot === undefined) {
+    throw new Error('SystemRoot is required for native Windows ACL tests.');
+  }
+  const script = `
+$ErrorActionPreference = 'Stop'
+$encodedPath = [Console]::In.ReadToEnd()
+$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedPath))
+$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+$everyone = New-Object Security.Principal.SecurityIdentifier 'S-1-1-0'
+$inherit = [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [Security.AccessControl.InheritanceFlags]::ObjectInherit
+$acl = New-Object Security.AccessControl.DirectorySecurity
+$acl.SetOwner($sid)
+$acl.SetAccessRuleProtection($true, $false)
+$acl.AddAccessRule((New-Object Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+  $sid,
+  [Security.AccessControl.FileSystemRights]::FullControl,
+  $inherit,
+  [Security.AccessControl.PropagationFlags]::None,
+  [Security.AccessControl.AccessControlType]::Allow
+)))
+$acl.AddAccessRule((New-Object Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+  $everyone,
+  [Security.AccessControl.FileSystemRights]::ReadAndExecute,
+  $inherit,
+  [Security.AccessControl.PropagationFlags]::None,
+  [Security.AccessControl.AccessControlType]::Allow
+)))
+[IO.Directory]::SetAccessControl($path, $acl)
+`;
+  execFileSync(
+    join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-EncodedCommand',
+      Buffer.from(script, 'utf16le').toString('base64'),
+    ],
+    {
+      input: Buffer.from(path, 'utf8').toString('base64'),
+      shell: false,
+      windowsHide: true,
+    },
+  );
+}
+
+function addNativeWindowsEveryoneRule(path: string): void {
+  const systemRoot = process.env.SystemRoot;
+  if (systemRoot === undefined) {
+    throw new Error('SystemRoot is required for native Windows ACL tests.');
+  }
+  const script = `
+$ErrorActionPreference = 'Stop'
+$encodedPath = [Console]::In.ReadToEnd()
+$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedPath))
+$everyone = New-Object Security.Principal.SecurityIdentifier 'S-1-1-0'
+$acl = [IO.File]::GetAccessControl($path)
+$acl.AddAccessRule((New-Object Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+  $everyone,
+  [Security.AccessControl.FileSystemRights]::Read,
+  [Security.AccessControl.AccessControlType]::Allow
+)))
+[IO.File]::SetAccessControl($path, $acl)
+`;
+  execFileSync(
+    join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-EncodedCommand',
+      Buffer.from(script, 'utf16le').toString('base64'),
+    ],
+    {
+      input: Buffer.from(path, 'utf8').toString('base64'),
+      shell: false,
+      windowsHide: true,
+    },
+  );
+}
+
 describe('explicit Node v2 config files', () => {
   let directory: string;
 
@@ -49,6 +136,7 @@ describe('explicit Node v2 config files', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     rmSync(directory, { recursive: true, force: true });
   });
 
@@ -170,12 +258,161 @@ describe('explicit Node v2 config files', () => {
     }
   });
 
-  it('rejects owner-only saves on Windows before creating directories', () => {
-    if (process.platform !== 'win32') return;
-    const path = join(directory, 'windows', 'config.json');
-    expect(() => saveConfigV2(config(), { path })).toThrow(ConfigV2FileError);
+  it('rejects missing Windows ACL support before creating directories', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    const previousSystemRoot = process.env.SystemRoot;
+    process.env.SystemRoot = 'relative-system-root';
+    const path = join(directory, 'windows-preflight', 'config.json');
+    try {
+      expect(() => saveConfigV2(config(), { path })).toThrow(ConfigV2FileError);
+      expect(existsSync(path)).toBe(false);
+      expect(existsSync(dirname(path))).toBe(false);
+    } finally {
+      if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+      else process.env.SystemRoot = previousSystemRoot;
+    }
+  });
+
+  it('requires Windows ACL verification before bytes and replacement', () => {
+    if (process.platform !== 'win32') {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    }
+    const path = join(directory, 'windows-order.json');
+    const observed: string[] = [];
+
+    safeWriteFile(path, 'owner-only-content', {
+      mode: 0o600,
+      ownerOnly: true,
+      windowsAcl: {
+        createExclusive(tempPath, markCreated) {
+          writeFileSync(tempPath, '', { flag: 'wx' });
+          markCreated();
+          observed.push(`created:${readFileSync(tempPath, 'utf8')}`);
+        },
+        verify(tempPath) {
+          observed.push(`verified:${readFileSync(tempPath, 'utf8')}`);
+        },
+      },
+    });
+
+    expect(observed).toEqual([
+      'created:',
+      'verified:',
+      'verified:owner-only-content',
+    ]);
+    expect(readFileSync(path, 'utf8')).toBe('owner-only-content');
+    expect(readdirSync(directory)).toEqual(['windows-order.json']);
+  });
+
+  it('cleans a Windows temp file when ACL application fails', () => {
+    if (process.platform !== 'win32') {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    }
+    const path = join(directory, 'windows-apply-failure.json');
+
+    expect(() =>
+      safeWriteFile(path, 'must-not-commit', {
+        mode: 0o600,
+        ownerOnly: true,
+        windowsAcl: {
+          createExclusive(tempPath, markCreated) {
+            writeFileSync(tempPath, '', { flag: 'wx' });
+            markCreated();
+            throw new Error('injected ACL application failure');
+          },
+          verify() {
+            throw new Error('verification must not run');
+          },
+        },
+      }),
+    ).toThrow('injected ACL application failure');
     expect(existsSync(path)).toBe(false);
-    expect(existsSync(dirname(path))).toBe(false);
+    expect(readdirSync(directory)).toEqual([]);
+  });
+
+  it('does not unlink a colliding Windows temp path it did not create', () => {
+    if (process.platform !== 'win32') {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    }
+    const path = join(directory, 'windows-create-collision.json');
+    let collisionPath = '';
+
+    expect(() =>
+      safeWriteFile(path, 'must-not-commit', {
+        mode: 0o600,
+        ownerOnly: true,
+        windowsAcl: {
+          createExclusive(tempPath) {
+            collisionPath = tempPath;
+            writeFileSync(tempPath, 'someone-else');
+            throw new Error('injected exclusive-create collision');
+          },
+          verify() {
+            throw new Error('verification must not run');
+          },
+        },
+      }),
+    ).toThrow('injected exclusive-create collision');
+    expect(readFileSync(collisionPath, 'utf8')).toBe('someone-else');
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('keeps the destination and cleans the Windows temp after verification failure', () => {
+    if (process.platform !== 'win32') {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    }
+    const path = join(directory, 'windows-verify-failure.json');
+    writeFileSync(path, 'original');
+    let verifications = 0;
+
+    expect(() =>
+      safeWriteFile(path, 'must-not-commit', {
+        mode: 0o600,
+        ownerOnly: true,
+        windowsAcl: {
+          createExclusive(tempPath, markCreated) {
+            writeFileSync(tempPath, '', { flag: 'wx' });
+            markCreated();
+          },
+          verify() {
+            verifications += 1;
+            if (verifications === 2) {
+              throw new Error('injected ACL verification failure');
+            }
+          },
+        },
+      }),
+    ).toThrow('injected ACL verification failure');
+    expect(readFileSync(path, 'utf8')).toBe('original');
+    expect(readdirSync(directory)).toEqual(['windows-verify-failure.json']);
+  });
+
+  it('keeps the destination and cleans the Windows temp after first verification failure', () => {
+    if (process.platform !== 'win32') {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    }
+    const path = join(directory, 'windows-first-verify-failure.json');
+    writeFileSync(path, 'original');
+
+    expect(() =>
+      safeWriteFile(path, 'must-not-write', {
+        mode: 0o600,
+        ownerOnly: true,
+        windowsAcl: {
+          createExclusive(tempPath, markCreated) {
+            writeFileSync(tempPath, '', { flag: 'wx' });
+            markCreated();
+          },
+          verify() {
+            throw new Error('injected first ACL verification failure');
+          },
+        },
+      }),
+    ).toThrow('injected first ACL verification failure');
+    expect(readFileSync(path, 'utf8')).toBe('original');
+    expect(readdirSync(directory)).toEqual([
+      'windows-first-verify-failure.json',
+    ]);
   });
 
   it('preserves ordinary mode-only atomic writes on every platform', () => {
@@ -243,3 +480,59 @@ describe('explicit Node v2 config files', () => {
     );
   });
 });
+
+describe.runIf(process.platform === 'win32')(
+  'native Windows owner-only ACL saves',
+  () => {
+    let directory: string;
+
+    beforeEach(() => {
+      directory = mkdtempSync(join(tmpdir(), 'librarium-config-v2-windows-'));
+    });
+
+    afterEach(() => {
+      rmSync(directory, { recursive: true, force: true });
+    });
+
+    it('performs a Windows first write and whole-file overwrite with owner-only ACLs', () => {
+      const path = join(directory, "config [owner] ' &.json");
+      saveConfigV2(config(), { path });
+      verifyWindowsOwnerOnlyAcl(path);
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(config());
+
+      const replacement: LibrariumConfigV2 = {
+        ...config(),
+        runtime: {
+          output_dir: './windows-replacement-runs',
+          llm_web_search: false,
+        },
+      };
+      saveConfigV2(replacement, { path });
+
+      verifyWindowsOwnerOnlyAcl(path);
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(replacement);
+      expect(readdirSync(directory)).toEqual(["config [owner] ' &.json"]);
+    });
+
+    it('removes inherited Windows trustees from a restrictive parent ACL', () => {
+      const parent = join(directory, 'restricted-inheritance');
+      mkdirSync(parent);
+      setNativeWindowsInheritedAcl(parent);
+      const path = join(parent, 'config.json');
+
+      saveConfigV2(config(), { path });
+
+      verifyWindowsOwnerOnlyAcl(path);
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(config());
+      expect(readdirSync(parent)).toEqual(['config.json']);
+    });
+
+    it('rejects a Windows ACL after an extra trustee is added', () => {
+      const path = join(directory, 'tampered-config.json');
+      saveConfigV2(config(), { path });
+      addNativeWindowsEveryoneRule(path);
+
+      expect(() => verifyWindowsOwnerOnlyAcl(path)).toThrow();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Implements #2695 by enabling fail-closed, owner-only Windows saves for the explicit Node v2 config API and closing the pathname-substitution race found in the first implementation. The Windows save now keeps one creation-time handle from exclusive temp creation through ACL proof, UTF-8 write, durable flush, atomic replacement, and failure cleanup.

## Changes

- Create the sibling temp with `FileMode.CreateNew`, `FileShare.None`, and a protected DACL containing one non-inherited `FullControl` ACE for the current process user SID.
- Run create, handle-bound ACL verification, UTF-8 write, `Flush(true)`, final verification, and replacement in one fixed PowerShell transaction.
- Replace the destination with `SetFileInformationByHandle(FileRenameInfo)` using the retained `SafeFileHandle`; verify that same handle after rename.
- Size the native rename buffer as the full `FILE_RENAME_INFO` structure plus the UTF-16 file-name bytes on both 32-bit and 64-bit Windows.
- Mark failed pre-commit objects for deletion with handle-based `FileDispositionInfo`. Node never unlinks the Windows temp pathname.
- Compile the same P/Invoke helper during the filesystem-free Windows preflight, before a missing destination parent can be created.
- Keep the fixed UTF-16LE encoded command, base64-over-stdin data transport, absolute inbox PowerShell path, `shell: false`, Unix `0600` behavior, and v1/mode-only behavior.
- Add native mutation stages that attempt namespace substitution at initial verify→write, write→final verify, final verify→handle rename, and failure cleanup. Each requires `ERROR_SHARING_VIOLATION` and checks final object continuity.
- Document the retained-handle owner-only behavior in the public config API docs.

## Security design and official sources

The object protected at creation is the object written, verified, renamed, or disposed. `FileShare.None` blocks competing opens that request read, write, or delete access while the handle is retained; Windows delete access includes rename. All untrusted paths and content stay out of the fixed program text and process arguments.

Primary references, accessed 2026-08-12:

- [Microsoft: CreateFileW sharing modes](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew)
- [Microsoft: SetFileInformationByHandle](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileinformationbyhandle)
- [Microsoft: FILE_RENAME_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_rename_info)
- [Microsoft: FILE_DISPOSITION_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_disposition_info)
- [Microsoft: FileStream.GetAccessControl](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.getaccesscontrol?view=netframework-4.8.1)
- [Microsoft: FileStream.Flush(Boolean)](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.flush?view=netframework-4.8.1)
- [Node.js: execFileSync](https://nodejs.org/docs/latest-v22.x/api/child_process.html)

## Compatibility and holdbacks

- v1 saves and non-owner-only `safeWriteFile` callers retain their existing behavior.
- Unix owner-only saves retain exclusive temp creation, exact `0600` enforcement, and atomic rename.
- Windows requires inbox Windows PowerShell 5.1 and an ACL-capable filesystem; unsupported environments fail closed.
- Atomic namespace replacement does not add directory fsync or promise power-loss durability.
- A forced child termination can leave an owner-only UUID temporary object because handle-disposition code cannot run after termination. The destination stays unchanged, and no later parent operation acts on that pathname.
- Administrators, backup operators, kernel-level actors, and same-user processes remain outside the ordinary DACL isolation boundary.
- No dependencies, lockfiles, providers, production systems, live credentials, or databases changed.

## Testing

Local evidence for changes through `fc24cd3d0c7526f0c93f887085cdb0b4ee8b0700`:

- [x] Focused config-v2: 20 passed, 7 native Windows tests skipped locally.
- [x] Full unit: 101 files, 1,683 passed, 7 native Windows tests skipped locally.
- [x] Typecheck and lint passed; lint checked 357 files.
- [x] Build and declaration build passed.
- [x] Declaration fixtures passed.
- [x] Worker suite: 7 files, 28 passed.
- [x] Integration: 2 files, 11 passed.
- [x] Packed consumer verified inventory, exports, declarations, Worker-safe graph, side effects, and CLI.
- [x] Deep review: three independent security, quality, and verification judgments returned GO; no Critical or High code findings.
- [x] GitHub Actions run `31660364124`: Windows Node 22.12, 24, and 26 each passed the full unit job and the separate native owner-only ACL suite.
- [x] The same run passed Ubuntu Node 22.12, 24, and 26, Worker, integration, packed consumer, PTY, SEA, and runtime-floor checks.

## Checklist

- [x] No dependency or lockfile changes
- [x] No provider registration or config schema changes
- [x] PR remains unmerged
