### PR TITLE
Type provider factories and separate canonical reporting

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -284,6 +284,9 @@ export async function initializeProviders(
     try {
       provider = descriptor.factory({
         providerConfig: normalizedConfig,
+        // Descriptor validation is the only configuration boundary. Factories
+        // receive its parsed value, never the raw option record.
+        options: options.success ? options.data : {},
         defaults: config.defaults,
       });
     } catch (error) {

--- a/src/adapters/provider-descriptors.ts
+++ b/src/adapters/provider-descriptors.ts
@@ -1,10 +1,26 @@
+import type { z } from 'zod';
 import {
   BUILTIN_PROVIDER_DEFINITIONS,
   BUILTIN_PROVIDER_DEFINITIONS_IN_REGISTRATION_ORDER,
+  claudeOptions,
+  exaResearchOptions,
+  firecrawlSearchOptions,
   getBuiltinProviderDefinition,
+  openAiResearchOptions,
+  openRouterGroundedOptions,
+  openRouterOptions as openRouterOptionsSchema,
   type ProviderDescriptorDefinition,
+  parallelChatOptions,
+  parallelResearchOptions,
+  parallelSearchOptions,
+  tavilyResearchOptions,
+  webSearchOptions,
+  youResearchBackgroundOptions,
 } from '../core/provider-descriptor.js';
-import { searchApiOptionsSchema } from '../core/searchapi.js';
+import {
+  type SearchApiOptions,
+  searchApiOptionsSchema,
+} from '../core/searchapi.js';
 import type { Config, Provider, ProviderConfig } from '../types.js';
 import { BraveAnswersProvider } from './brave-answers.js';
 import { BraveSearchProvider } from './brave-search.js';
@@ -20,15 +36,16 @@ import {
   GrokProvider,
   GrokXOnlyProvider,
 } from './grok.js';
+import {
+  grokCombinedOptionsSchema,
+  grokWebOptionsSchema,
+  grokXOnlyOptionsSchema,
+} from './grok-options.js';
 import { JinaSearchProvider } from './jina-search.js';
 import { KagiFastGPTProvider } from './kagi-fastgpt.js';
 import { OpenAIChatProvider } from './openai-chat.js';
 import { OpenAIResearchProvider } from './openai-research.js';
-import type {
-  OpenRouterDataCollection,
-  OpenRouterProviderOptions,
-  OpenRouterReasoningEffort,
-} from './openrouter.js';
+import type { OpenRouterProviderOptions } from './openrouter.js';
 import { OpenRouterChatProvider } from './openrouter-chat.js';
 import { OpenRouterOnlineProvider } from './openrouter-online.js';
 import {
@@ -39,10 +56,11 @@ import {
 import { PerplexityAdvancedDeepProvider } from './perplexity-advanced-deep.js';
 import { PerplexityDeepResearchProvider } from './perplexity-deep-research.js';
 import { PerplexityProSearchProvider } from './perplexity-pro-search.js';
+import { PerplexitySearchProvider } from './perplexity-search.js';
 import {
-  PerplexitySearchProvider,
-  type PerplexitySearchProviderOptions,
-} from './perplexity-search.js';
+  type PerplexitySearchOptions,
+  PerplexitySearchOptionsSchema,
+} from './perplexity-search-options.js';
 import { PerplexitySonarDeepProvider } from './perplexity-sonar-deep.js';
 import { PerplexitySonarProProvider } from './perplexity-sonar-pro.js';
 import { SearchApiProvider } from './searchapi.js';
@@ -59,14 +77,24 @@ import type {
   ValyuResearchOptions,
   ValyuSearchOptions,
 } from './valyu-options.js';
+import {
+  ValyuResearchOptionsSchema,
+  ValyuSearchOptionsSchema,
+} from './valyu-options.js';
 import { ValyuResearchProvider } from './valyu-research.js';
 import { ValyuSearchProvider } from './valyu-search.js';
 import { YouAnswerProvider } from './you-answer.js';
+import {
+  type YouAnswerOptions,
+  YouAnswerOptionsSchema,
+} from './you-answer-options.js';
 import { YouResearchProvider } from './you-research.js';
 import { YouResearchBackgroundProvider } from './you-research-background.js';
 
 export interface BuiltInProviderFactoryContext {
-  providerConfig?: ProviderConfig;
+  providerConfig?: Omit<ProviderConfig, 'options'>;
+  /** Descriptor-validated options. This private boundary never receives raw config. */
+  options?: unknown;
   defaults?: Config['defaults'];
 }
 
@@ -77,8 +105,20 @@ export interface BuiltInProviderDescriptor
 
 type ProviderFactory = BuiltInProviderDescriptor['factory'];
 
-function option(config: ProviderConfig | undefined, key: string): unknown {
-  return config?.options?.[key];
+type TypedFactoryContext<T extends z.ZodType> = Omit<
+  BuiltInProviderFactoryContext,
+  'options'
+> & {
+  readonly options: z.output<T>;
+};
+
+/** Keep descriptor validation authoritative while preserving its inferred output. */
+function typedFactory<T extends z.ZodType>(
+  schema: T,
+  factory: (context: TypedFactoryContext<T>) => Provider,
+): ProviderFactory {
+  return (context) =>
+    factory({ ...context, options: schema.parse(context.options ?? {}) });
 }
 
 function model(
@@ -97,15 +137,16 @@ function configuredModel(
   return context.providerConfig?.model?.trim() || undefined;
 }
 
-function webSearch(context: BuiltInProviderFactoryContext): boolean {
-  const configured = option(context.providerConfig, 'webSearch');
-  return typeof configured === 'boolean'
-    ? configured
-    : (context.defaults?.llmWebSearch ?? true);
+function webSearch(
+  context: TypedFactoryContext<typeof webSearchOptions>,
+): boolean {
+  return context.options.webSearch ?? context.defaults?.llmWebSearch ?? true;
 }
 
 function openRouterOptions(
-  context: BuiltInProviderFactoryContext,
+  context: TypedFactoryContext<
+    typeof openRouterOptionsSchema | typeof openRouterGroundedOptions
+  >,
 ): Pick<
   OpenRouterProviderOptions,
   | 'providerOrder'
@@ -117,292 +158,296 @@ function openRouterOptions(
   | 'reasoningMaxTokens'
   | 'reasoningExclude'
 > {
-  const options = context.providerConfig?.options ?? {};
+  const options = context.options;
   return {
-    ...(Array.isArray(options.providerOrder) && {
-      providerOrder: options.providerOrder as string[],
+    ...(options.providerOrder !== undefined && {
+      providerOrder: options.providerOrder,
     }),
-    ...(typeof options.allowFallbacks === 'boolean' && {
+    ...(options.allowFallbacks !== undefined && {
       allowFallbacks: options.allowFallbacks,
     }),
-    ...(typeof options.requireParameters === 'boolean' && {
+    ...(options.requireParameters !== undefined && {
       requireParameters: options.requireParameters,
     }),
-    ...(options.dataCollection === 'allow' || options.dataCollection === 'deny'
-      ? { dataCollection: options.dataCollection as OpenRouterDataCollection }
-      : {}),
-    ...(typeof options.zdr === 'boolean' && { zdr: options.zdr }),
-    ...(typeof options.reasoningEffort === 'string' && {
-      reasoningEffort: options.reasoningEffort as OpenRouterReasoningEffort,
+    ...(options.dataCollection !== undefined && {
+      dataCollection: options.dataCollection,
     }),
-    ...(typeof options.reasoningMaxTokens === 'number' && {
+    ...(options.zdr !== undefined && { zdr: options.zdr }),
+    ...(options.reasoningEffort !== undefined && {
+      reasoningEffort: options.reasoningEffort,
+    }),
+    ...(options.reasoningMaxTokens !== undefined && {
       reasoningMaxTokens: options.reasoningMaxTokens,
     }),
-    ...(typeof options.reasoningExclude === 'boolean' && {
+    ...(options.reasoningExclude !== undefined && {
       reasoningExclude: options.reasoningExclude,
     }),
   };
 }
 
-function searchApiZeroRetention(
-  providerConfig: ProviderConfig | undefined,
-): boolean {
-  return searchApiOptionsSchema.parse(providerConfig?.options ?? {})
-    .zeroRetention;
+function searchApiZeroRetention(options: SearchApiOptions): boolean {
+  return options.zeroRetention;
 }
-
-function perplexitySearchOptions(
-  providerConfig: ProviderConfig | undefined,
-): PerplexitySearchProviderOptions {
-  const configured = providerConfig?.options ?? {};
-  const options: PerplexitySearchProviderOptions = {};
-  const documentedKeys = [
-    'perRequestUsd',
-    'maxResults',
-    'country',
-    'searchLanguageFilter',
-    'searchDomainAllowlist',
-    'searchDomainDenylist',
-    'searchContextSize',
-    'maxTokens',
-    'maxTokensPerPage',
-    'additionalQueries',
-  ] as const;
-
-  for (const key of documentedKeys) {
-    if (configured[key] !== undefined) {
-      options[key] = configured[key];
-    }
-  }
-  return options;
-}
-
-const METERING_OPTION_KEYS = new Set([
-  'perRequestUsd',
-  'creditUsd',
-  'creditsPerRequest',
-  'perUnitUsd',
-]);
 
 /** Descriptor metering values are local metadata, not Parallel API options. */
-function parallelOptions(
-  providerConfig: ProviderConfig | undefined,
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(providerConfig?.options ?? {}).filter(
-      ([key]) => !METERING_OPTION_KEYS.has(key),
-    ),
-  );
-}
-
-/** Options have already passed the authoritative descriptor schema. */
-function validatedOptions<T>(providerConfig: ProviderConfig | undefined): T {
-  return (providerConfig?.options ?? {}) as T;
+function parallelOptions<
+  T extends z.output<
+    | typeof parallelSearchOptions
+    | typeof parallelChatOptions
+    | typeof parallelResearchOptions
+  >,
+>(
+  options: T,
+): Omit<T, 'perRequestUsd' | 'creditUsd' | 'creditsPerRequest' | 'perUnitUsd'> {
+  const {
+    perRequestUsd: _perRequestUsd,
+    creditUsd: _creditUsd,
+    creditsPerRequest: _creditsPerRequest,
+    perUnitUsd: _perUnitUsd,
+    ...adapterOptions
+  } = options;
+  return adapterOptions;
 }
 
 const factories: Record<string, ProviderFactory> = {
-  'parallel-research': ({ providerConfig }) =>
-    new ParallelResearchProvider({
-      model:
-        configuredModel({ providerConfig }) ??
-        (typeof option(providerConfig, 'processor') === 'string'
-          ? (option(providerConfig, 'processor') as string)
-          : undefined),
-      configuredOptions: parallelOptions(providerConfig),
-    }),
-  'parallel-chat': ({ providerConfig }) =>
-    new ParallelChatProvider({
-      model: configuredModel({ providerConfig }),
-      configuredOptions: parallelOptions(providerConfig),
-    }),
-  'parallel-search': ({ providerConfig }) =>
-    new ParallelSearchProvider(parallelOptions(providerConfig)),
+  'parallel-research': typedFactory(
+    parallelResearchOptions,
+    (context) =>
+      new ParallelResearchProvider({
+        model:
+          configuredModel(context) ?? context.options.processor ?? undefined,
+        configuredOptions: parallelOptions(context.options),
+      }),
+  ),
+  'parallel-chat': typedFactory(
+    parallelChatOptions,
+    (context) =>
+      new ParallelChatProvider({
+        model: configuredModel(context),
+        configuredOptions: parallelOptions(context.options),
+      }),
+  ),
+  'parallel-search': typedFactory(
+    parallelSearchOptions,
+    (context) => new ParallelSearchProvider(parallelOptions(context.options)),
+  ),
   'perplexity-sonar-deep': () => new PerplexitySonarDeepProvider(),
   'perplexity-deep-research': (context) =>
     new PerplexityDeepResearchProvider({ model: configuredModel(context) }),
   'perplexity-advanced-deep': (context) =>
     new PerplexityAdvancedDeepProvider({ model: configuredModel(context) }),
-  'openai-research': ({ providerConfig }) =>
-    new OpenAIResearchProvider({
-      model:
-        configuredModel({ providerConfig }) ??
-        getBuiltinProviderDefinition('openai-research')?.defaultModel,
-      maxToolCalls: option(providerConfig, 'maxToolCalls'),
-      reasoningEffort: option(providerConfig, 'reasoningEffort'),
-      returnTokenBudget: option(providerConfig, 'returnTokenBudget'),
-    }),
+  'openai-research': typedFactory(
+    openAiResearchOptions,
+    (context) =>
+      new OpenAIResearchProvider({
+        model:
+          configuredModel(context) ??
+          getBuiltinProviderDefinition('openai-research')?.defaultModel,
+        maxToolCalls: context.options.maxToolCalls,
+        reasoningEffort: context.options.reasoningEffort,
+        returnTokenBudget: context.options.returnTokenBudget,
+      }),
+  ),
   'gemini-deep': (context) =>
     new GeminiDeepProvider({ model: model('gemini-deep', context) }),
   'perplexity-sonar-pro': () => new PerplexitySonarProProvider(),
   'gemini-grounded': (context) =>
     new GeminiGroundedProvider({ model: model('gemini-grounded', context) }),
-  grok: (context) =>
-    new GrokProvider({
-      model: model('grok', context),
-      searchOptions: context.providerConfig?.options,
-    }),
-  'grok-x-only': (context) =>
-    new GrokXOnlyProvider({
-      model: model('grok-x-only', context),
-      searchOptions: context.providerConfig?.options,
-    }),
-  'grok-combined': (context) =>
-    new GrokCombinedProvider({
-      model: model('grok-combined', context),
-      searchOptions: context.providerConfig?.options,
-    }),
-  'openrouter-online': (context) =>
-    new OpenRouterOnlineProvider({
-      model: model('openrouter-online', context),
-      ...openRouterOptions(context),
-    }),
+  grok: typedFactory(
+    grokWebOptionsSchema,
+    (context) =>
+      new GrokProvider({
+        model: model('grok', context),
+        searchOptions: context.options,
+      }),
+  ),
+  'grok-x-only': typedFactory(
+    grokXOnlyOptionsSchema,
+    (context) =>
+      new GrokXOnlyProvider({
+        model: model('grok-x-only', context),
+        searchOptions: context.options,
+      }),
+  ),
+  'grok-combined': typedFactory(
+    grokCombinedOptionsSchema,
+    (context) =>
+      new GrokCombinedProvider({
+        model: model('grok-combined', context),
+        searchOptions: context.options,
+      }),
+  ),
+  'openrouter-online': typedFactory(
+    openRouterGroundedOptions,
+    (context) =>
+      new OpenRouterOnlineProvider({
+        model: model('openrouter-online', context),
+        ...openRouterOptions(context),
+      }),
+  ),
   'brave-answers': () => new BraveAnswersProvider(),
   exa: () => new ExaProvider(),
-  'exa-research': ({ providerConfig }) =>
-    new ExaResearchProvider({
-      effort: option(providerConfig, 'effort') as
-        | 'minimal'
-        | 'low'
-        | 'medium'
-        | 'high'
-        | 'xhigh'
-        | 'auto'
-        | 'max'
-        | undefined,
-      systemPrompt: option(providerConfig, 'systemPrompt') as
-        | string
-        | undefined,
-      outputSchema: option(providerConfig, 'outputSchema') as
-        | Record<string, unknown>
-        | undefined,
-      maxCostDollars: option(providerConfig, 'maxCostDollars') as
-        | number
-        | undefined,
-    }),
+  'exa-research': typedFactory(
+    exaResearchOptions,
+    (context) =>
+      new ExaResearchProvider({
+        effort: context.options.effort,
+        systemPrompt: context.options.systemPrompt,
+        outputSchema: context.options.outputSchema,
+        maxCostDollars: context.options.maxCostDollars,
+      }),
+  ),
   'you-research': () => new YouResearchProvider(),
-  'you-answer': ({ providerConfig }) =>
-    new YouAnswerProvider(providerConfig?.options),
-  'you-research-background': ({ providerConfig }) =>
-    new YouResearchBackgroundProvider({
-      researchEffort: option(providerConfig, 'researchEffort') as
-        | 'lite'
-        | 'standard'
-        | 'deep'
-        | 'exhaustive'
-        | 'frontier'
-        | undefined,
-      outputSchema: option(providerConfig, 'outputSchema') as
-        | Record<string, unknown>
-        | undefined,
-      includeDomains: option(providerConfig, 'includeDomains') as
-        | string[]
-        | undefined,
-      excludeDomains: option(providerConfig, 'excludeDomains') as
-        | string[]
-        | undefined,
-      boostDomains: option(providerConfig, 'boostDomains') as
-        | string[]
-        | undefined,
-      freshness: option(providerConfig, 'freshness') as string | undefined,
-      country: option(providerConfig, 'country') as string | undefined,
-    }),
+  'you-answer': typedFactory(
+    YouAnswerOptionsSchema,
+    (context) =>
+      new YouAnswerProvider(context.options satisfies YouAnswerOptions),
+  ),
+  'you-research-background': typedFactory(
+    youResearchBackgroundOptions,
+    (context) =>
+      new YouResearchBackgroundProvider({
+        researchEffort: context.options.researchEffort,
+        outputSchema: context.options.outputSchema,
+        includeDomains: context.options.includeDomains,
+        excludeDomains: context.options.excludeDomains,
+        boostDomains: context.options.boostDomains,
+        freshness: context.options.freshness,
+        country: context.options.country,
+      }),
+  ),
   'kagi-fastgpt': () => new KagiFastGPTProvider(),
-  'perplexity-search': ({ providerConfig }) =>
-    new PerplexitySearchProvider(perplexitySearchOptions(providerConfig)),
+  'perplexity-search': typedFactory(
+    PerplexitySearchOptionsSchema,
+    (context) =>
+      new PerplexitySearchProvider(
+        context.options satisfies PerplexitySearchOptions,
+      ),
+  ),
   'brave-search': () => new BraveSearchProvider(),
   'jina-search': () => new JinaSearchProvider(),
-  'firecrawl-search': ({ providerConfig }) =>
-    new FirecrawlSearchProvider({
-      sources: option(providerConfig, 'sources'),
-      limit: option(providerConfig, 'limit'),
-      tbs: option(providerConfig, 'tbs'),
-      country: option(providerConfig, 'country'),
-      location: option(providerConfig, 'location'),
-      includeDomains: option(providerConfig, 'includeDomains'),
-      excludeDomains: option(providerConfig, 'excludeDomains'),
-      categories: option(providerConfig, 'categories'),
-      ignoreInvalidURLs: option(providerConfig, 'ignoreInvalidURLs'),
-    }),
-  searchapi: ({ providerConfig }) =>
-    new SearchApiProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
-  'searchapi-chatgpt': ({ providerConfig }) =>
-    new SearchApiChatGptProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
-  'searchapi-gemini': ({ providerConfig }) =>
-    new SearchApiGeminiProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
-  'searchapi-perplexity': ({ providerConfig }) =>
-    new SearchApiPerplexityProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
-  'searchapi-google-ai-mode': ({ providerConfig }) =>
-    new SearchApiGoogleAiModeProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
-  'searchapi-bing-copilot': ({ providerConfig }) =>
-    new SearchApiBingCopilotProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
-  'searchapi-google-ai-overview': ({ providerConfig }) =>
-    new SearchApiGoogleAiOverviewProvider({
-      zeroRetention: searchApiZeroRetention(providerConfig),
-    }),
+  'firecrawl-search': typedFactory(
+    firecrawlSearchOptions,
+    (context) =>
+      new FirecrawlSearchProvider({
+        sources: context.options.sources,
+        limit: context.options.limit,
+        tbs: context.options.tbs,
+        country: context.options.country,
+        location: context.options.location,
+        includeDomains: context.options.includeDomains,
+        excludeDomains: context.options.excludeDomains,
+        categories: context.options.categories,
+        ignoreInvalidURLs: context.options.ignoreInvalidURLs,
+      }),
+  ),
+  searchapi: typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
+  'searchapi-chatgpt': typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiChatGptProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
+  'searchapi-gemini': typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiGeminiProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
+  'searchapi-perplexity': typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiPerplexityProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
+  'searchapi-google-ai-mode': typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiGoogleAiModeProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
+  'searchapi-bing-copilot': typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiBingCopilotProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
+  'searchapi-google-ai-overview': typedFactory(
+    searchApiOptionsSchema,
+    (context) =>
+      new SearchApiGoogleAiOverviewProvider({
+        zeroRetention: searchApiZeroRetention(context.options),
+      }),
+  ),
   'perplexity-pro-search': () => new PerplexityProSearchProvider(),
   serpapi: () => new SerpApiProvider(),
   tavily: () => new TavilyProvider(),
-  'tavily-research': ({ providerConfig }) =>
-    new TavilyResearchProvider({
-      model: option(providerConfig, 'researchModel') as
-        | 'mini'
-        | 'pro'
-        | 'auto'
-        | undefined,
-      outputSchema: option(providerConfig, 'outputSchema') as
-        | Record<string, unknown>
-        | undefined,
-      citationFormat: option(providerConfig, 'citationFormat') as
-        | 'numbered'
-        | 'mla'
-        | 'apa'
-        | 'chicago'
-        | undefined,
-    }),
-  'valyu-search': ({ providerConfig }) =>
-    new ValyuSearchProvider(
-      validatedOptions<ValyuSearchOptions>(providerConfig),
-    ),
-  'valyu-research': ({ providerConfig }) =>
-    new ValyuResearchProvider(
-      validatedOptions<ValyuResearchOptions>(providerConfig),
-    ),
-  claude: (context) =>
-    new ClaudeProvider({
-      model: model('claude', context),
-      webSearch: webSearch(context),
-      maxTokens: option(context.providerConfig, 'maxTokens'),
-      thinking: option(context.providerConfig, 'thinking'),
-      effort: option(context.providerConfig, 'effort'),
-    }),
-  'openai-chat': (context) =>
-    new OpenAIChatProvider({
-      model: model('openai-chat', context),
-      webSearch: webSearch(context),
-    }),
-  'gemini-chat': (context) =>
-    new GeminiChatProvider({
-      model: model('gemini-chat', context),
-      webSearch: webSearch(context),
-    }),
-  'openrouter-chat': (context) =>
-    new OpenRouterChatProvider({
-      model: model('openrouter-chat', context),
-      webSearch: webSearch(context),
-      ...openRouterOptions(context),
-    }),
+  'tavily-research': typedFactory(
+    tavilyResearchOptions,
+    (context) =>
+      new TavilyResearchProvider({
+        model: context.options.researchModel,
+        outputSchema: context.options.outputSchema,
+        citationFormat: context.options.citationFormat,
+      }),
+  ),
+  'valyu-search': typedFactory(
+    ValyuSearchOptionsSchema,
+    (context) =>
+      new ValyuSearchProvider(context.options satisfies ValyuSearchOptions),
+  ),
+  'valyu-research': typedFactory(
+    ValyuResearchOptionsSchema,
+    (context) =>
+      new ValyuResearchProvider(context.options satisfies ValyuResearchOptions),
+  ),
+  claude: typedFactory(
+    claudeOptions,
+    (context) =>
+      new ClaudeProvider({
+        model: model('claude', context),
+        webSearch: webSearch(context),
+        maxTokens: context.options.maxTokens,
+        thinking: context.options.thinking,
+        effort: context.options.effort,
+      }),
+  ),
+  'openai-chat': typedFactory(
+    webSearchOptions,
+    (context) =>
+      new OpenAIChatProvider({
+        model: model('openai-chat', context),
+        webSearch: webSearch(context),
+      }),
+  ),
+  'gemini-chat': typedFactory(
+    webSearchOptions,
+    (context) =>
+      new GeminiChatProvider({
+        model: model('gemini-chat', context),
+        webSearch: webSearch(context),
+      }),
+  ),
+  'openrouter-chat': typedFactory(
+    openRouterOptionsSchema,
+    (context) =>
+      new OpenRouterChatProvider({
+        model: model('openrouter-chat', context),
+        webSearch: webSearch(context),
+        ...openRouterOptions(context),
+      }),
+  ),
 };
 
 export const BUILTIN_PROVIDER_DESCRIPTORS: readonly BuiltInProviderDescriptor[] =

--- a/src/commands/html-report-sanitization.ts
+++ b/src/commands/html-report-sanitization.ts
@@ -1,0 +1,78 @@
+import { Marked } from 'marked';
+
+/** Escape untrusted text before placing it in report HTML. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Only allow link schemes that cannot execute code when the report is opened
+ * from file:// (provider output and citation URLs are untrusted).
+ */
+export function safeUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (
+    !trimmed ||
+    Array.from(trimmed).some((character) => {
+      const code = character.charCodeAt(0);
+      return code < 32 || code === 127 || character === '\\';
+    })
+  )
+    return null;
+  if (/^\/\//.test(trimmed)) return null;
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === 'http:' ||
+      parsed.protocol === 'https:' ||
+      parsed.protocol === 'mailto:'
+      ? trimmed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Markdown renderer that never passes raw HTML through (provider output is
+ * untrusted), rejects unsafe link schemes, and adds rel="noopener" to
+ * external links.
+ */
+const markdown = new Marked({
+  renderer: {
+    html(token: { text: string }): string {
+      return escapeHtml(token.text);
+    },
+    link(token: {
+      href: string;
+      title?: string | null;
+      tokens: unknown;
+    }): string {
+      const title = token.title ? ` title="${escapeHtml(token.title)}"` : '';
+      const body = (this as any).parser.parseInline(token.tokens);
+      const href = safeUrl(token.href);
+      if (href === null) return `<span${title}>${body}</span>`;
+      return `<a href="${escapeHtml(href)}"${title} rel="noopener" target="_blank">${body}</a>`;
+    },
+  },
+});
+
+export function renderMarkdown(content: string): string {
+  return markdown.parse(content, { async: false }) as string;
+}
+
+/**
+ * Strip answer.md's echoed heading and Sources appendix. The returned markdown
+ * stays untrusted and must still flow through renderMarkdown().
+ */
+export function answerBody(content: string): string {
+  let body = content.replace(/\r\n/g, '\n');
+  body = body.replace(/^\s*#[^\S\n]+[^\n]*\n+/, '');
+  body = body.replace(/\n#{1,6}[^\S\n]+Sources\b[\s\S]*$/i, '\n');
+  return body.trim();
+}

--- a/src/commands/html-report-view-model.ts
+++ b/src/commands/html-report-view-model.ts
@@ -1,0 +1,52 @@
+import type { RunArtifactPresentationSourceSummary } from '../node-run-artifact-presentation.js';
+import type {
+  DeduplicatedSource,
+  ProviderReport,
+  RunManifest,
+} from '../types.js';
+
+export interface HtmlReportInput {
+  readonly manifest: Readonly<RunManifest>;
+  /** Recovery-view reports used for presentation. Defaults to manifest providers. */
+  readonly reports?: readonly Readonly<ProviderReport>[];
+  /** Provider markdown contents keyed by report outputFile. */
+  readonly providerContents: Readonly<Record<string, string>>;
+  readonly sources: readonly Readonly<DeduplicatedSource>[];
+  /** Counts aligned with the presented source rows. Defaults to manifest facts. */
+  readonly sourceSummary?: RunArtifactPresentationSourceSummary;
+  /** The synthesized grounded answer (answer.md body), when present. */
+  readonly answer?: { content: string; provider?: string; model?: string };
+}
+
+/** Pure report view model; it cannot read or mutate run artifacts. */
+export interface HtmlReportViewModel {
+  readonly manifest: Readonly<RunManifest>;
+  readonly reports: readonly Readonly<ProviderReport>[];
+  readonly providerContents: Readonly<Record<string, string>>;
+  readonly sources: readonly Readonly<DeduplicatedSource>[];
+  readonly sourceSummary: RunArtifactPresentationSourceSummary;
+  readonly answer?: { content: string; provider?: string; model?: string };
+  /** First successful provider, or the first available report. */
+  readonly activeIndex: number;
+}
+
+export function createHtmlReportViewModel(
+  input: HtmlReportInput,
+): HtmlReportViewModel {
+  const reports = input.reports ?? input.manifest.providers;
+  const firstSuccess = reports.findIndex(
+    (report) => report.status === 'success',
+  );
+  return {
+    manifest: input.manifest,
+    reports,
+    providerContents: input.providerContents,
+    sources: input.sources,
+    sourceSummary: input.sourceSummary ?? {
+      total: input.manifest.sources.total,
+      unique: input.sources.length,
+    },
+    ...(input.answer === undefined ? {} : { answer: input.answer }),
+    activeIndex: firstSuccess === -1 ? 0 : firstSuccess,
+  };
+}

--- a/src/commands/html-report.ts
+++ b/src/commands/html-report.ts
@@ -1,16 +1,33 @@
-import { Marked } from 'marked';
-import type { RunArtifactPresentationSourceSummary } from '../node-run-artifact-presentation.js';
 import type {
   ClaimSupport,
   DeduplicatedSource,
   ProviderMetering,
   ProviderReport,
   ProviderUsage,
-  RunManifest,
   VerificationMetadata,
   VerificationUsageSummary,
 } from '../types.js';
+import {
+  answerBody,
+  escapeHtml,
+  renderMarkdown,
+  safeUrl,
+} from './html-report-sanitization.js';
+import {
+  createHtmlReportViewModel,
+  type HtmlReportInput,
+  type HtmlReportViewModel,
+} from './html-report-view-model.js';
 import { formatDuration, usageLabel } from './run-format.js';
+
+export {
+  answerBody,
+  escapeHtml,
+  renderMarkdown,
+  safeUrl,
+} from './html-report-sanitization.js';
+export type { HtmlReportInput } from './html-report-view-model.js';
+export { createHtmlReportViewModel } from './html-report-view-model.js';
 
 /**
  * Self-contained HTML report generator for a run directory.
@@ -20,90 +37,6 @@ import { formatDuration, usageLabel } from './run-format.js';
  * filesystem wrapper used by `run --html`, `librarium html`, browse, and
  * status --retrieve regeneration.
  */
-
-export interface HtmlReportInput {
-  manifest: Readonly<RunManifest>;
-  /** Recovery-view reports used for presentation. Defaults to manifest providers. */
-  reports?: readonly Readonly<ProviderReport>[];
-  /** Provider markdown contents keyed by report outputFile. */
-  providerContents: Readonly<Record<string, string>>;
-  sources: readonly Readonly<DeduplicatedSource>[];
-  /** Counts aligned with the presented source rows. Defaults to manifest facts. */
-  sourceSummary?: RunArtifactPresentationSourceSummary;
-  /**
-   * The synthesized grounded answer (answer.md body) when the run produced one.
-   * Leads the report as an "Answer" section before the provider tabs.
-   * provider/model come from the manifest's additive `answer` metadata.
-   */
-  answer?: { content: string; provider?: string; model?: string };
-}
-
-export function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-/**
- * Only allow link schemes that cannot execute code when the report is opened
- * from file:// (provider output and citation URLs are untrusted).
- */
-export function safeUrl(url: string): string | null {
-  const trimmed = url.trim();
-  if (
-    !trimmed ||
-    Array.from(trimmed).some((character) => {
-      const code = character.charCodeAt(0);
-      return code < 32 || code === 127 || character === '\\';
-    })
-  )
-    return null;
-  if (/^\/\//.test(trimmed)) return null;
-  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed;
-  try {
-    const parsed = new URL(trimmed);
-    return parsed.protocol === 'http:' ||
-      parsed.protocol === 'https:' ||
-      parsed.protocol === 'mailto:'
-      ? trimmed
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Markdown renderer that never passes raw HTML through (provider output is
- * untrusted), rejects unsafe link schemes, and adds rel="noopener" to
- * external links.
- */
-const markdown = new Marked({
-  renderer: {
-    html(token: { text: string }): string {
-      return escapeHtml(token.text);
-    },
-    link(token: {
-      href: string;
-      title?: string | null;
-      tokens: unknown;
-    }): string {
-      const title = token.title ? ` title="${escapeHtml(token.title)}"` : '';
-      const body = (this as any).parser.parseInline(token.tokens);
-      const href = safeUrl(token.href);
-      if (href === null) {
-        return `<span${title}>${body}</span>`;
-      }
-      return `<a href="${escapeHtml(href)}"${title} rel="noopener" target="_blank">${body}</a>`;
-    },
-  },
-});
-
-export function renderMarkdown(content: string): string {
-  return markdown.parse(content, { async: false }) as string;
-}
 
 function glyphFor(report: ProviderReport): { glyph: string; cls: string } {
   switch (report.status) {
@@ -211,23 +144,6 @@ function providerPanelBody(
     return `${errorBanner}${renderMarkdown(content)}`;
   }
   return '<p class="pending-note">No output file found for this provider.</p>';
-}
-
-/**
- * Strip answer.md's leading `# query` heading and its trailing `## Sources`
- * list so the report renders only the answer body: the query is already the
- * report's H1 and the deduped sources have their own tab. Defensive: if the
- * expected structure is absent, the content passes through untouched. Pure
- * string surgery on already-untrusted markdown; renderMarkdown still escapes
- * raw HTML and applies safeUrl to links.
- */
-export function answerBody(content: string): string {
-  let body = content.replace(/\r\n/g, '\n');
-  // Drop a single leading level-1 heading (the echoed query).
-  body = body.replace(/^\s*#[^\S\n]+[^\n]*\n+/, '');
-  // Drop a trailing "## Sources" section through end of file.
-  body = body.replace(/\n#{1,6}[^\S\n]+Sources\b[\s\S]*$/i, '\n');
-  return body.trim();
 }
 
 /**
@@ -631,12 +547,19 @@ const SCRIPT = `(function () {
 
 /** Pure generator: manifest plus file contents in, full HTML document out. */
 export function generateHtmlReport(input: HtmlReportInput): string {
-  const { manifest, providerContents, sources, answer } = input;
-  const reports = input.reports ?? manifest.providers;
-  const sourceSummary = input.sourceSummary ?? {
-    total: manifest.sources.total,
-    unique: sources.length,
-  };
+  return renderHtmlReport(createHtmlReportViewModel(input));
+}
+
+/** Render a pure, already-loaded report view. */
+export function renderHtmlReport(view: HtmlReportViewModel): string {
+  const {
+    manifest,
+    providerContents,
+    sources,
+    answer,
+    reports,
+    sourceSummary,
+  } = view;
 
   const answerHtml =
     answer && answer.content.trim().length > 0 ? answerSection(answer) : '';
@@ -645,8 +568,7 @@ export function generateHtmlReport(input: HtmlReportInput): string {
     : '';
 
   // Default active tab: first successful provider, else the first row.
-  const firstSuccess = reports.findIndex((r) => r.status === 'success');
-  const activeIndex = firstSuccess === -1 ? 0 : firstSuccess;
+  const { activeIndex } = view;
 
   const rows = reports
     .map((report, index) => providerRow(report, index, index === activeIndex))

--- a/src/core/provider-descriptor.ts
+++ b/src/core/provider-descriptor.ts
@@ -69,7 +69,7 @@ export interface ProviderDescriptorDefinition {
 }
 
 const positiveNumber = z.number().positive();
-const commonOptions = z
+export const commonOptions = z
   .object({
     perRequestUsd: positiveNumber.optional(),
     creditUsd: positiveNumber.optional(),
@@ -77,10 +77,10 @@ const commonOptions = z
     perUnitUsd: positiveNumber.optional(),
   })
   .passthrough();
-const webSearchOptions = commonOptions.extend({
+export const webSearchOptions = commonOptions.extend({
   webSearch: z.boolean().optional(),
 });
-const openRouterOptions = webSearchOptions
+export const openRouterOptions = webSearchOptions
   .extend({
     providerOrder: z.array(z.string().trim().min(1)).nonempty().optional(),
     allowFallbacks: z.boolean().optional(),
@@ -115,22 +115,22 @@ const openRouterOptions = webSearchOptions
     }
   })
   .strict();
-const openRouterGroundedOptions = openRouterOptions.safeExtend({
+export const openRouterGroundedOptions = openRouterOptions.safeExtend({
   webSearch: z.literal(true).optional(),
 });
-const openAiResearchOptions = commonOptions.extend({
+export const openAiResearchOptions = commonOptions.extend({
   maxToolCalls: z.number().int().positive().optional(),
   reasoningEffort: z
     .enum(['none', 'low', 'medium', 'high', 'xhigh', 'max'])
     .optional(),
   returnTokenBudget: z.enum(['default', 'unlimited']).optional(),
 });
-const claudeOptions = webSearchOptions.extend({
+export const claudeOptions = webSearchOptions.extend({
   maxTokens: z.number().int().positive().optional(),
   thinking: z.enum(['adaptive', 'disabled']).optional(),
   effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
 });
-const firecrawlSearchOptions = commonOptions
+export const firecrawlSearchOptions = commonOptions
   .extend({
     sources: z
       .array(z.enum(['web', 'news']))
@@ -154,9 +154,13 @@ const firecrawlSearchOptions = commonOptions
       message: 'includeDomains and excludeDomains are mutually exclusive',
     },
   );
-const parallelSearchOptions = commonOptions.merge(ParallelSearchOptionsSchema);
-const parallelChatOptions = commonOptions.merge(ParallelChatOptionsSchema);
-const parallelResearchOptions = commonOptions.merge(
+export const parallelSearchOptions = commonOptions.merge(
+  ParallelSearchOptionsSchema,
+);
+export const parallelChatOptions = commonOptions.merge(
+  ParallelChatOptionsSchema,
+);
+export const parallelResearchOptions = commonOptions.merge(
   ParallelResearchOptionsSchema,
 );
 
@@ -170,7 +174,7 @@ const domain = z
   );
 const nonEmptyDomains = z.array(domain).min(1).max(500);
 const jsonObject = z.record(z.string(), z.unknown());
-const tavilyResearchOptions = commonOptions
+export const tavilyResearchOptions = commonOptions
   .extend({
     // `model` is reserved for the v1 target-selection field. This provider's
     // documented Research API model stays inside its strict option bag.
@@ -184,7 +188,7 @@ const tavilyResearchOptions = commonOptions
     citationFormat: z.enum(['numbered', 'mla', 'apa', 'chicago']).optional(),
   })
   .strict();
-const exaResearchOptions = commonOptions
+export const exaResearchOptions = commonOptions
   .extend({
     effort: z
       .enum(['minimal', 'low', 'medium', 'high', 'xhigh', 'auto', 'max'])
@@ -210,7 +214,7 @@ const exaResearchOptions = commonOptions
       });
     }
   });
-const youResearchBackgroundOptions = commonOptions
+export const youResearchBackgroundOptions = commonOptions
   .extend({
     researchEffort: z
       .enum(['lite', 'standard', 'deep', 'exhaustive', 'frontier'])

--- a/src/node-canonical-report-loading.ts
+++ b/src/node-canonical-report-loading.ts
@@ -1,0 +1,57 @@
+/**
+ * Read-only v3 reporting loader. Canonical run.json remains the only lifecycle
+ * authority; this module never consults or trusts derived sidecars.
+ */
+import { basename, dirname, resolve } from 'node:path';
+import { generateSummary } from './core/synthesis.js';
+import {
+  type CanonicalRunPresentation,
+  projectCanonicalRunPresentation,
+} from './node-canonical-presentation.js';
+import type { CanonicalRunManifestV3 } from './node-canonical-run.js';
+import {
+  readCanonicalRunManifest,
+  readRunJsonSchemaVersion,
+} from './node-canonical-run.js';
+
+export interface CanonicalRunReportingView {
+  readonly runDir: string;
+  readonly manifest: CanonicalRunManifestV3;
+  readonly presentation: CanonicalRunPresentation;
+  readonly summary: string;
+}
+
+/**
+ * Read a v3 run into a one-way report view without mutating lifecycle state.
+ * A non-v3 or invalid run intentionally returns null so callers can dispatch
+ * to the historical reader rather than guessing a version.
+ */
+export function readCanonicalRunReportingView(
+  runDirInput: string,
+): CanonicalRunReportingView | null {
+  const runDir = resolve(runDirInput);
+  const runsRoot = dirname(runDir);
+  try {
+    if (readRunJsonSchemaVersion(runsRoot, runDir) !== 3) return null;
+    const manifest = readCanonicalRunManifest(runsRoot, runDir);
+    const presentation = projectCanonicalRunPresentation(
+      manifest,
+      runDir,
+      basename(runDir),
+    );
+    return {
+      runDir,
+      manifest,
+      presentation,
+      summary: generateSummary({
+        query: manifest.request.query,
+        reports: presentation.reports,
+        sources: presentation.sources,
+        asyncTasks: [],
+        timestamp: Math.floor(Date.parse(manifest.generated_at) / 1_000),
+      }),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/node-canonical-report-view-model.ts
+++ b/src/node-canonical-report-view-model.ts
@@ -1,0 +1,32 @@
+/** Pure report-generator inputs projected from the canonical v3 authority. */
+import type { HtmlReportInput } from './commands/html-report.js';
+import type { JsonlReportInput } from './commands/jsonl-report.js';
+import type { CanonicalRunReportingView } from './node-canonical-report-loading.js';
+
+function presentationInput(view: CanonicalRunReportingView) {
+  const { presentation } = view;
+  return {
+    manifest: presentation.generatorManifest,
+    reports: presentation.reports,
+    providerContents: presentation.providerContents,
+    sources: presentation.sources,
+    sourceSummary: {
+      total: presentation.totalCitations,
+      unique: presentation.sources.length,
+    },
+  };
+}
+
+/** Existing HTML renderer input, derived only from canonical run.json. */
+export function canonicalHtmlReportInput(
+  view: CanonicalRunReportingView,
+): HtmlReportInput {
+  return presentationInput(view);
+}
+
+/** Existing JSONL renderer input, derived only from canonical run.json. */
+export function canonicalJsonlReportInput(
+  view: CanonicalRunReportingView,
+): JsonlReportInput {
+  return presentationInput(view);
+}

--- a/src/node-canonical-reporting.ts
+++ b/src/node-canonical-reporting.ts
@@ -1,18 +1,13 @@
-import { basename, dirname, resolve } from 'node:path';
 import { generateHtmlReport } from './commands/html-report.js';
 import { writeHtmlReport } from './commands/html-report-v2.js';
 import { generateJsonlReport } from './commands/jsonl-report.js';
 import { writeJsonlReport } from './commands/jsonl-report-v2.js';
 import { safeWriteFile } from './core/fs-utils.js';
-import { generateSummary } from './core/synthesis.js';
+import { readCanonicalRunReportingView } from './node-canonical-report-loading.js';
 import {
-  type CanonicalRunPresentation,
-  projectCanonicalRunPresentation,
-} from './node-canonical-presentation.js';
-import {
-  readCanonicalRunManifest,
-  readRunJsonSchemaVersion,
-} from './node-canonical-run.js';
+  canonicalHtmlReportInput,
+  canonicalJsonlReportInput,
+} from './node-canonical-report-view-model.js';
 import {
   DEFAULT_FS,
   resolveContainedPathWithFs,
@@ -20,47 +15,8 @@ import {
 } from './node-run-artifact-codecs.js';
 import type { RunArtifactRepository } from './node-run-artifacts.js';
 
-export interface CanonicalRunReportingView {
-  readonly runDir: string;
-  readonly presentation: CanonicalRunPresentation;
-  readonly summary: string;
-}
-
-/** Read a v3 run into a one-way presentation view without mutating authority. */
-export function readCanonicalRunReportingView(
-  runDirInput: string,
-): CanonicalRunReportingView | null {
-  const runDir = resolve(runDirInput);
-  const runsRoot = dirname(runDir);
-  let schemaVersion: number | undefined;
-  try {
-    schemaVersion = readRunJsonSchemaVersion(runsRoot, runDir);
-  } catch {
-    return null;
-  }
-  if (schemaVersion !== 3) return null;
-  try {
-    const manifest = readCanonicalRunManifest(runsRoot, runDir);
-    const presentation = projectCanonicalRunPresentation(
-      manifest,
-      runDir,
-      basename(runDir),
-    );
-    return {
-      runDir,
-      presentation,
-      summary: generateSummary({
-        query: manifest.request.query,
-        reports: presentation.reports,
-        sources: presentation.sources,
-        asyncTasks: [],
-        timestamp: Math.floor(Date.parse(manifest.generated_at) / 1_000),
-      }),
-    };
-  } catch {
-    return null;
-  }
-}
+export type { CanonicalRunReportingView } from './node-canonical-report-loading.js';
+export { readCanonicalRunReportingView } from './node-canonical-report-loading.js';
 
 function reportPath(runDir: string, fileName: string): string {
   const safeRunDir = resolveRunDirectoryWithFs(DEFAULT_FS, runDir);
@@ -76,21 +32,8 @@ export function writeHtmlReportForRun(
 ): string | null {
   const canonical = readCanonicalRunReportingView(runDir);
   if (!canonical) return writeHtmlReport(runDir, repository);
-  const { presentation } = canonical;
   const path = reportPath(canonical.runDir, 'report.html');
-  safeWriteFile(
-    path,
-    generateHtmlReport({
-      manifest: presentation.generatorManifest,
-      reports: presentation.reports,
-      providerContents: presentation.providerContents,
-      sources: presentation.sources,
-      sourceSummary: {
-        total: presentation.totalCitations,
-        unique: presentation.sources.length,
-      },
-    }),
-  );
+  safeWriteFile(path, generateHtmlReport(canonicalHtmlReportInput(canonical)));
   return path;
 }
 
@@ -101,20 +44,10 @@ export function writeJsonlReportForRun(
 ): string | null {
   const canonical = readCanonicalRunReportingView(runDir);
   if (!canonical) return writeJsonlReport(runDir, repository);
-  const { presentation } = canonical;
   const path = reportPath(canonical.runDir, 'results.jsonl');
   safeWriteFile(
     path,
-    generateJsonlReport({
-      manifest: presentation.generatorManifest,
-      reports: presentation.reports,
-      providerContents: presentation.providerContents,
-      sources: presentation.sources,
-      sourceSummary: {
-        total: presentation.totalCitations,
-        unique: presentation.sources.length,
-      },
-    }),
+    generateJsonlReport(canonicalJsonlReportInput(canonical)),
   );
   return path;
 }

--- a/tests/html-report.test.ts
+++ b/tests/html-report.test.ts
@@ -10,8 +10,10 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   answerBody,
+  createHtmlReportViewModel,
   escapeHtml,
   generateHtmlReport,
+  renderHtmlReport,
   renderMarkdown,
   safeUrl,
 } from '../src/commands/html-report.js';
@@ -147,6 +149,18 @@ describe('safeUrl', () => {
 });
 
 describe('generateHtmlReport', () => {
+  it('keeps the facade byte-identical to rendering its pure view model', () => {
+    const input = {
+      manifest: makeManifest(),
+      providerContents: { 'exa.md': '<script>unsafe</script> body' },
+      sources: SOURCES,
+    };
+
+    expect(generateHtmlReport(input)).toBe(
+      renderHtmlReport(createHtmlReportViewModel(input)),
+    );
+  });
+
   it('uses the query as the escaped page title and heading', () => {
     const html = generateHtmlReport({
       manifest: makeManifest({ query: 'a <b>"query"</b>' }),

--- a/tests/provider-descriptors.test.ts
+++ b/tests/provider-descriptors.test.ts
@@ -489,6 +489,44 @@ describe('built-in provider descriptors', () => {
     expect(request?.body).not.toHaveProperty('max_tool_calls');
   });
 
+  it('passes parsed background factory options through unchanged', async () => {
+    const httpClient = vi.fn(async () => ({
+      status: 200,
+      headers: new Headers(),
+      data: { id: 'response-1', status: 'queued' },
+    }));
+    const result = await initializeProviders({
+      credentials: { env: { OPENAI_API_KEY: 'openai-key' } },
+      httpClient,
+      providers: {
+        'openai-research': {
+          options: {
+            maxToolCalls: 3,
+            reasoningEffort: 'medium',
+            returnTokenBudget: 'unlimited',
+          },
+        },
+      },
+    });
+
+    expect(result.warnings).toEqual([]);
+    const openai = getProvider('openai-research');
+    expect(openai?.execution).toBe('background');
+    if (openai?.execution !== 'background') return;
+
+    await openai.submit('typed factory options', { timeout: 10 });
+    expect(httpClient).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/responses',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          reasoning: { effort: 'medium' },
+          tools: [{ type: 'web_search', return_token_budget: 'unlimited' }],
+          max_tool_calls: 3,
+        }),
+      }),
+    );
+  });
+
   it('isolates an invalid provider option schema from other adapters', async () => {
     const httpClient = vi.fn(async () => ({
       status: 200,

--- a/tests/standalone-canonical-report.test.ts
+++ b/tests/standalone-canonical-report.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { browseRunDir } from '../src/commands/browse.js';
 import { registerHtmlCommand } from '../src/commands/html.js';
 import { registerJsonlCommand } from '../src/commands/jsonl.js';
+import { readCanonicalRunReportingView } from '../src/node-canonical-reporting.js';
 import { runCanonicalPreparedExecution } from '../src/node-canonical-run.js';
 import type { Provider } from '../src/types.js';
 import {
@@ -74,6 +75,33 @@ describe('standalone canonical report commands', () => {
       'Canonical result',
     );
     expect(readFileSync(join(runDir, 'run.json'), 'utf8')).toBe(runJsonBefore);
+  });
+
+  it('loads v3 reporting from run.json rather than derived sidecars', async () => {
+    const runDir = await canonicalRun();
+    writeFileSync(
+      join(runDir, 'adapter-report.md'),
+      '<script>sidecar</script>',
+    );
+    writeFileSync(
+      join(runDir, 'sources.json'),
+      JSON.stringify([{ url: 'javascript:sidecar' }]),
+    );
+    writeFileSync(join(runDir, 'summary.md'), 'sidecar summary');
+
+    const view = readCanonicalRunReportingView(runDir);
+
+    expect(Object.values(view?.presentation.providerContents ?? {})).toEqual(
+      expect.arrayContaining([expect.stringContaining('Canonical result')]),
+    );
+    expect(view?.summary).not.toBe('sidecar summary');
+    expect(view?.presentation.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: 'https://example.com/canonical-source',
+        }),
+      ]),
+    );
   });
 
   it('renders schemaVersion 3 JSONL from canonical public output', async () => {


### PR DESCRIPTION
## Summary

Refactors provider construction so factories consume descriptor-validated option values, and separates canonical v3 report loading and view-model projection from presentation.

## Changes

- Preserve descriptor schemas, defaults, and fail-closed invalid-option behavior while giving built-in factories typed option inputs.
- Split HTML sanitization and pure view-model construction from rendering without changing the public facade output.
- Make canonical v3 HTML/JSONL reporting read only from `run.json`; historical readers and explicit version routing remain in place.
- Add regression coverage for typed factory policies, facade byte identity, and rejection of poisoned derived sidecars.

## Inventory and holdbacks

The Stage B audit found no additional deletion supported by caller and fixture evidence. Historical v1/v2 artifact readers and writers, explicit version routing, vendor parsers, stable exports, direct dependencies, and transitive Wrangler remain intentional compatibility holdbacks.

## Compatibility and authority

Descriptor validation remains the configuration authority. Invalid options still produce a fail-closed provider. Canonical v3 report generation uses `run.json` as the lifecycle authority and ignores derived sidecars; existing historical report paths continue to handle non-v3 runs.

## Review and verification

Deep review: GO with degraded reviewer quorum; the available quality reviewer found no issues, and the full local validation suite passed.

- Focused provider/report tests: 60 passed
- Provider descriptors/catalog/config/registry/adapters: 635 passed, 7 skipped
- HTML/JSONL/artifact/canonical/reconciliation/browse: 191 passed
- Full unit suite: 1,839 passed, 7 skipped
- Typecheck, lint, build, declaration fixtures, Worker (28), integration (11), packed consumer, PTY (5), benchmark validation, and authority/entry/shadow checks (137) all passed
- `git diff --check` passed

No live or paid calls were made.