### PR TITLE
Add reproducible local performance baselines

### DIFF
--- a/benchmark/performance/README.md
+++ b/benchmark/performance/README.md
@@ -1,0 +1,26 @@
+# Offline performance benchmark
+
+`npm run benchmark:performance` measures local Librarium overhead only. It
+uses generated run directories and in-memory synthetic providers; it never
+loads credentials or calls a provider.
+
+The command builds a temporary benchmark entry with the repository's local
+esbuild, then writes one JSON document to stdout. Save that document with the
+Git revision it measured:
+
+```sh
+npm run build
+node benchmark/performance/cli.mjs --warmup 3 --iterations 15 > perf-before.json
+```
+
+Every result records the Git SHA, Node and host details, dataset parameters,
+warmup/iteration counts, raw sample timings, and median/p95/min/max. It covers
+fan-out, v2 artifact reading/reconciliation, browse discovery, HTML/JSONL
+reports, URL normalization/deduplication, warm and cold CLI help, packed size,
+and a SEA binary when one exists.
+
+The provider quality benchmark under `benchmark/` is separate. Do not use this
+command for live or paid benchmark calls. Timing data is host-specific, so it
+is evidence for comparing the same host and revision stack, not an absolute CI
+gate. Keep semantic tests beside an optimization and reject regressions against
+the measured baseline rather than introducing a fixed millisecond threshold.

--- a/benchmark/performance/cli.mjs
+++ b/benchmark/performance/cli.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const output = mkdtempSync(join(tmpdir(), 'librarium-performance-build-'));
+const bundler = join(root, 'node_modules', '.bin', 'esbuild');
+const runner = join(root, 'benchmark', 'performance', 'runner.ts');
+const compiled = join(output, 'runner.js');
+
+try {
+  const build = spawnSync(
+    bundler,
+    [
+      runner,
+      '--bundle',
+      '--format=esm',
+      '--platform=node',
+      `--outfile=${compiled}`,
+    ],
+    { cwd: root, encoding: 'utf8' },
+  );
+  if (build.status !== 0) throw new Error(build.stderr || build.stdout);
+  const run = spawnSync(
+    process.execPath,
+    [compiled, ...process.argv.slice(2)],
+    {
+      cwd: root,
+      stdio: 'inherit',
+      env: { ...process.env, LIBRARIUM_PERFORMANCE_ROOT: root },
+    },
+  );
+  process.exitCode = run.status ?? 1;
+} finally {
+  rmSync(output, { recursive: true, force: true });
+}

--- a/benchmark/performance/lib.mjs
+++ b/benchmark/performance/lib.mjs
@@ -21,12 +21,16 @@ export function summarizeSamples(samples) {
   };
 }
 
-export async function measure({ warmup, iterations, operation }) {
-  for (let index = 0; index < warmup; index++) await operation();
+export async function measure({ warmup, iterations, prepare, operation }) {
+  for (let index = 0; index < warmup; index++) {
+    const prepared = prepare === undefined ? undefined : await prepare();
+    await operation(prepared);
+  }
   const samples = [];
   for (let index = 0; index < iterations; index++) {
+    const prepared = prepare === undefined ? undefined : await prepare();
     const started = performance.now();
-    await operation();
+    await operation(prepared);
     samples.push(performance.now() - started);
   }
   return summarizeSamples(samples);

--- a/benchmark/performance/lib.mjs
+++ b/benchmark/performance/lib.mjs
@@ -1,0 +1,33 @@
+export const PERFORMANCE_SCHEMA_VERSION = 1;
+
+export function percentile(sorted, ratio) {
+  if (sorted.length === 0) return null;
+  return sorted[
+    Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)
+  ];
+}
+
+export function summarizeSamples(samples) {
+  if (!Array.isArray(samples) || samples.length === 0) {
+    throw new Error('Benchmark samples must not be empty');
+  }
+  const sorted = [...samples].sort((left, right) => left - right);
+  return {
+    samples_ms: samples.map((sample) => Number(sample.toFixed(3))),
+    median_ms: Number(percentile(sorted, 0.5).toFixed(3)),
+    p95_ms: Number(percentile(sorted, 0.95).toFixed(3)),
+    min_ms: Number(sorted[0].toFixed(3)),
+    max_ms: Number(sorted.at(-1).toFixed(3)),
+  };
+}
+
+export async function measure({ warmup, iterations, operation }) {
+  for (let index = 0; index < warmup; index++) await operation();
+  const samples = [];
+  for (let index = 0; index < iterations; index++) {
+    const started = performance.now();
+    await operation();
+    samples.push(performance.now() - started);
+  }
+  return summarizeSamples(samples);
+}

--- a/benchmark/performance/runner.ts
+++ b/benchmark/performance/runner.ts
@@ -1,0 +1,433 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { arch, cpus, platform, release, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createCliProgram } from '../../src/cli-program.js';
+import { discoverRuns } from '../../src/commands/browse-data.js';
+import { writeHtmlReport } from '../../src/commands/html-report-v2.js';
+import { writeJsonlReport } from '../../src/commands/jsonl-report-v2.js';
+import { deduplicateSources, normalizeUrl } from '../../src/core/normalizer.js';
+import { executeResearchRun } from '../../src/core/research-run.js';
+import {
+  readCanonicalRunReportingView,
+  writeHtmlReportForRun,
+  writeJsonlReportForRun,
+} from '../../src/node-canonical-reporting.js';
+import {
+  createRegisteredProviderAttemptBridge,
+  discoverCanonicalRunDirectories,
+  runCanonicalPreparedExecution,
+} from '../../src/node-canonical-run.js';
+import { RunArtifactRepository } from '../../src/node-run-artifacts.js';
+import { RunReconciliationService } from '../../src/node-run-reconciliation.js';
+import type { Config, Provider } from '../../src/types.js';
+import {
+  canonicalFixtureCoordinator,
+  canonicalFixturePrepared,
+  canonicalFixtureProfile,
+} from '../../tests/fixtures/canonical-run.js';
+import { measure, PERFORMANCE_SCHEMA_VERSION } from './lib.mjs';
+
+const root = process.env.LIBRARIUM_PERFORMANCE_ROOT
+  ? resolve(process.env.LIBRARIUM_PERFORMANCE_ROOT)
+  : resolve(import.meta.dirname, '..', '..');
+const defaults = { warmup: 2, iterations: 7 };
+
+function argument(name: string, fallback: number): number {
+  const index = process.argv.indexOf(name);
+  return index < 0 ? fallback : Number(process.argv[index + 1]);
+}
+
+function gitRevision(): string {
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  }).trim();
+}
+
+function bytes(path: string): number | null {
+  return existsSync(path) && statSync(path).isFile()
+    ? statSync(path).size
+    : null;
+}
+
+function sizeTree(path: string): number | null {
+  const result = spawnSync('du', ['-sk', path], { encoding: 'utf8' });
+  return result.status === 0
+    ? Number(result.stdout.trim().split(/\s+/)[0]) * 1024
+    : null;
+}
+
+function benchmarkConfig(ids: readonly string[]): Config {
+  return {
+    version: 1,
+    defaults: {
+      outputDir: '',
+      maxParallel: ids.length,
+      timeout: 1,
+      asyncTimeout: 1,
+      asyncPollInterval: 1,
+      mode: 'sync',
+      llmWebSearch: false,
+    },
+    providers: Object.fromEntries(ids.map((id) => [id, { enabled: true }])),
+    customProviders: {},
+    trustedProviderIds: [],
+    groups: {},
+  };
+}
+
+function syntheticProvider(id: string): Provider {
+  return {
+    id,
+    displayName: id,
+    tier: 'raw-search',
+    envVar: '',
+    execution: 'inline',
+    async execute() {
+      return {
+        provider: id,
+        tier: 'raw-search',
+        content: `# ${id}\n\nSynthetic result`,
+        citations: [
+          {
+            provider: id,
+            url: `https://example.test/${id}?keep=yes&utm_benchmark=1#result`,
+          },
+        ],
+        durationMs: 1,
+      };
+    },
+  };
+}
+
+async function createRun(
+  base: string,
+  name: string,
+  providerCount: number,
+): Promise<string> {
+  const ids = Array.from(
+    { length: providerCount },
+    (_, index) => `synthetic-${index}`,
+  );
+  const providers = new Map(ids.map((id) => [id, syntheticProvider(id)]));
+  const outputDir = join(base, name);
+  await executeResearchRun(
+    {
+      query: 'offline deterministic benchmark',
+      config: benchmarkConfig(ids),
+      providerIds: ids,
+      outputDir,
+      slug: name,
+    },
+    {
+      now: () => Date.parse('2026-08-13T00:00:00.000Z'),
+      providerRegistry: {
+        getProvider: (id) => providers.get(id),
+        getAllProviders: () => [...providers.values()],
+      },
+    },
+  );
+  return outputDir;
+}
+
+async function createPendingRun(base: string, name: string): Promise<string> {
+  const runDirectory = await createRun(base, name, 1);
+  const repository = new RunArtifactRepository();
+  repository.mutate(runDirectory, (manifest) => {
+    const report = manifest.providers[0];
+    if (!report) throw new Error('Synthetic benchmark run has no provider');
+    report.status = 'async-pending';
+    report.task = {
+      taskId: 'synthetic-pending-task',
+      submittedAt: Date.parse('2026-08-13T00:00:00.000Z'),
+      status: 'pending',
+      outputDir: runDirectory,
+    };
+    manifest.status = 'awaiting_async';
+    manifest.exitCode = null;
+  });
+  return runDirectory;
+}
+
+async function createCanonicalRun(base: string, name: string): Promise<string> {
+  const profile = canonicalFixtureProfile('canonical-synthetic');
+  const prepared = canonicalFixturePrepared([profile], {
+    requestId: name,
+    query: 'offline canonical benchmark',
+  });
+  const provider = syntheticProvider('adapter-canonical-synthetic');
+  const runDirectory = join(base, name);
+  mkdirSync(runDirectory, { recursive: true });
+  await runCanonicalPreparedExecution(prepared, {
+    runs_root: base,
+    run_directory: runDirectory,
+    coordinator: canonicalFixtureCoordinator(),
+    attempt_bridge: createRegisteredProviderAttemptBridge(
+      prepared,
+      (adapterId) => (adapterId === provider.id ? provider : undefined),
+      () => Date.parse('2026-08-13T00:00:00.000Z'),
+    ),
+  });
+  return runDirectory;
+}
+
+async function main(): Promise<void> {
+  const warmup = argument('--warmup', defaults.warmup);
+  const iterations = argument('--iterations', defaults.iterations);
+  if (
+    !Number.isInteger(warmup) ||
+    warmup < 0 ||
+    !Number.isInteger(iterations) ||
+    iterations < 3
+  )
+    throw new Error(
+      '--warmup must be nonnegative and --iterations must be at least 3',
+    );
+  const temp = mkdtempSync(join(tmpdir(), 'librarium-performance-'));
+  try {
+    const metrics: Array<Record<string, unknown>> = [];
+    for (const profiles of [1, 4, 16]) {
+      metrics.push({
+        name: `fan-out-${profiles}-profiles`,
+        parameters: { profiles },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: async () => {
+            const directory = mkdtempSync(join(temp, 'fanout-'));
+            try {
+              await createRun(directory, 'run', profiles);
+            } finally {
+              rmSync(directory, { recursive: true, force: true });
+            }
+          },
+        })),
+      });
+    }
+    const urls = Array.from(
+      { length: 2_000 },
+      (_, index) =>
+        `https://WWW.Example${index % 50}.test/article/${index % 200}?keep=${index % 17}&UTM_Custom_${index % 7}=x#source-${index}`,
+    );
+    metrics.push({
+      name: 'url-normalization-2000',
+      parameters: { urls: urls.length },
+      ...(await measure({
+        warmup,
+        iterations,
+        operation: () => {
+          for (const url of urls) normalizeUrl(url);
+        },
+      })),
+    });
+    metrics.push({
+      name: 'url-deduplication-2000',
+      parameters: { citations: urls.length },
+      ...(await measure({
+        warmup,
+        iterations,
+        operation: () =>
+          deduplicateSources(
+            urls.map((url, index) => ({
+              url,
+              provider: `provider-${index % 4}`,
+            })),
+          ),
+      })),
+    });
+    for (const count of [1, 20, 100]) {
+      const base = join(temp, `runs-${count}`);
+      for (let index = 0; index < count; index++)
+        await createRun(base, `run-${String(index).padStart(3, '0')}`, 1);
+      const repository = new RunArtifactRepository();
+      metrics.push({
+        name: `artifact-read-retrieved-${count}-runs`,
+        parameters: { runs: count, state: 'retrieved' },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () =>
+            repository.readSnapshot(join(base, 'run-000'), {
+              view: 'recovery',
+            }),
+        })),
+      });
+      metrics.push({
+        name: `browse-discovery-${count}-runs`,
+        parameters: { runs: count },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => discoverRuns(base, count, repository),
+        })),
+      });
+      metrics.push({
+        name: `html-report-${count}-runs`,
+        parameters: { runs: count },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => writeHtmlReport(join(base, 'run-000'), repository),
+        })),
+      });
+      metrics.push({
+        name: `jsonl-report-${count}-runs`,
+        parameters: { runs: count },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => writeJsonlReport(join(base, 'run-000'), repository),
+        })),
+      });
+      const service = new RunReconciliationService({
+        repository,
+        resolveBackgroundProvider: () => undefined,
+        getProviderConfig: () => undefined,
+        now: () => 1,
+      });
+      metrics.push({
+        name: `reconciliation-retrieved-${count}-runs`,
+        parameters: { runs: count, state: 'retrieved' },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => service.reconcileOnce(join(base, 'run-000')),
+        })),
+      });
+      metrics.push({
+        name: `artifact-read-pending-${count}-runs`,
+        parameters: { runs: count, state: 'pending' },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: async () => {
+            const directory = mkdtempSync(join(temp, 'pending-read-'));
+            try {
+              const runDirectory = await createPendingRun(directory, 'run');
+              return repository.readSnapshot(runDirectory, {
+                view: 'recovery',
+              });
+            } finally {
+              rmSync(directory, { recursive: true, force: true });
+            }
+          },
+        })),
+      });
+      metrics.push({
+        name: `reconciliation-pending-${count}-runs`,
+        parameters: { runs: count, state: 'pending' },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: async () => {
+            const directory = mkdtempSync(join(temp, 'pending-reconcile-'));
+            try {
+              const runDirectory = await createPendingRun(directory, 'run');
+              const pendingRepository = new RunArtifactRepository();
+              const pendingService = new RunReconciliationService({
+                repository: pendingRepository,
+                resolveBackgroundProvider: () => undefined,
+                getProviderConfig: () => undefined,
+                now: () => 1,
+              });
+              return pendingService.reconcileOnce(runDirectory);
+            } finally {
+              rmSync(directory, { recursive: true, force: true });
+            }
+          },
+        })),
+      });
+    }
+    for (const count of [1, 20, 100]) {
+      const base = join(temp, `canonical-runs-${count}`);
+      for (let index = 0; index < count; index++) {
+        await createCanonicalRun(
+          base,
+          `canonical-${String(index).padStart(3, '0')}`,
+        );
+      }
+      const runDirectory = join(base, 'canonical-000');
+      metrics.push({
+        name: `canonical-read-${count}-runs`,
+        parameters: { runs: count, schema_version: 3 },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => readCanonicalRunReportingView(runDirectory),
+        })),
+      });
+      metrics.push({
+        name: `canonical-discovery-${count}-runs`,
+        parameters: { runs: count, schema_version: 3 },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => discoverCanonicalRunDirectories(base, count),
+        })),
+      });
+      metrics.push({
+        name: `canonical-html-report-${count}-runs`,
+        parameters: { runs: count, schema_version: 3 },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => writeHtmlReportForRun(runDirectory),
+        })),
+      });
+      metrics.push({
+        name: `canonical-jsonl-report-${count}-runs`,
+        parameters: { runs: count, schema_version: 3 },
+        ...(await measure({
+          warmup,
+          iterations,
+          operation: () => writeJsonlReportForRun(runDirectory),
+        })),
+      });
+    }
+    metrics.push({
+      name: 'cli-warm-help',
+      parameters: { mode: 'in-process' },
+      ...(await measure({
+        warmup,
+        iterations,
+        operation: () => createCliProgram().helpInformation(),
+      })),
+    });
+    metrics.push({
+      name: 'cli-cold-help',
+      parameters: { mode: 'child-process' },
+      ...(await measure({
+        warmup: 0,
+        iterations,
+        operation: () => {
+          const result = spawnSync(
+            process.execPath,
+            ['dist/cli.js', '--help'],
+            { cwd: root, encoding: 'utf8' },
+          );
+          if (result.status !== 0)
+            throw new Error(result.stderr || 'CLI help failed');
+        },
+      })),
+    });
+    const packed = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, npm_config_cache: join(temp, 'npm-cache') },
+    });
+    const [entry] = packed.status === 0 ? JSON.parse(packed.stdout) : [];
+    process.stdout.write(
+      `${JSON.stringify({ schema_version: PERFORMANCE_SCHEMA_VERSION, git_sha: gitRevision(), node: process.version, os: { platform: platform(), release: release(), arch: arch(), cpu: cpus()[0]?.model ?? 'unknown' }, parameters: { warmup, iterations, datasets: { url_count: urls.length, runs: [1, 20, 100], canonical_runs: [1, 20, 100], fan_out_profiles: [1, 4, 16] } }, package_size: { tarball_bytes: entry?.size ?? null, unpacked_bytes: entry?.unpackedSize ?? null, sea_bytes: bytes(join(root, 'dist', 'librarium')) }, dist_bytes: sizeTree(join(root, 'dist')), metrics }, null, 2)}\n`,
+    );
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.stack : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/benchmark/performance/runner.ts
+++ b/benchmark/performance/runner.ts
@@ -241,6 +241,9 @@ async function main(): Promise<void> {
       for (let index = 0; index < count; index++)
         await createRun(base, `run-${String(index).padStart(3, '0')}`, 1);
       const repository = new RunArtifactRepository();
+      const runDirectories = Array.from({ length: count }, (_, index) =>
+        join(base, `run-${String(index).padStart(3, '0')}`),
+      );
       metrics.push({
         name: `artifact-read-retrieved-${count}-runs`,
         parameters: { runs: count, state: 'retrieved' },
@@ -248,9 +251,9 @@ async function main(): Promise<void> {
           warmup,
           iterations,
           operation: () =>
-            repository.readSnapshot(join(base, 'run-000'), {
-              view: 'recovery',
-            }),
+            runDirectories.map((directory) =>
+              repository.readSnapshot(directory, { view: 'recovery' }),
+            ),
         })),
       });
       metrics.push({
@@ -268,7 +271,10 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: () => writeHtmlReport(join(base, 'run-000'), repository),
+          operation: () =>
+            runDirectories.map((directory) =>
+              writeHtmlReport(directory, repository),
+            ),
         })),
       });
       metrics.push({
@@ -277,7 +283,10 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: () => writeJsonlReport(join(base, 'run-000'), repository),
+          operation: () =>
+            runDirectories.map((directory) =>
+              writeJsonlReport(directory, repository),
+            ),
         })),
       });
       const service = new RunReconciliationService({
@@ -292,7 +301,12 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: () => service.reconcileOnce(join(base, 'run-000')),
+          operation: () =>
+            Promise.all(
+              runDirectories.map((directory) =>
+                service.reconcileOnce(directory),
+              ),
+            ),
         })),
       });
       metrics.push({
@@ -301,13 +315,24 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: async () => {
+          prepare: async () => {
             const directory = mkdtempSync(join(temp, 'pending-read-'));
+            const runs = [];
+            for (let index = 0; index < count; index++) {
+              runs.push(
+                await createPendingRun(
+                  directory,
+                  `run-${String(index).padStart(3, '0')}`,
+                ),
+              );
+            }
+            return { directory, runs };
+          },
+          operation: ({ directory, runs }) => {
             try {
-              const runDirectory = await createPendingRun(directory, 'run');
-              return repository.readSnapshot(runDirectory, {
-                view: 'recovery',
-              });
+              return runs.map((runDirectory) =>
+                repository.readSnapshot(runDirectory, { view: 'recovery' }),
+              );
             } finally {
               rmSync(directory, { recursive: true, force: true });
             }
@@ -320,18 +345,36 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: async () => {
+          prepare: async () => {
             const directory = mkdtempSync(join(temp, 'pending-reconcile-'));
-            try {
-              const runDirectory = await createPendingRun(directory, 'run');
-              const pendingRepository = new RunArtifactRepository();
-              const pendingService = new RunReconciliationService({
+            const runs = [];
+            for (let index = 0; index < count; index++) {
+              runs.push(
+                await createPendingRun(
+                  directory,
+                  `run-${String(index).padStart(3, '0')}`,
+                ),
+              );
+            }
+            const pendingRepository = new RunArtifactRepository();
+            return {
+              directory,
+              runs,
+              service: new RunReconciliationService({
                 repository: pendingRepository,
                 resolveBackgroundProvider: () => undefined,
                 getProviderConfig: () => undefined,
                 now: () => 1,
-              });
-              return pendingService.reconcileOnce(runDirectory);
+              }),
+            };
+          },
+          operation: async ({ directory, runs, service: pendingService }) => {
+            try {
+              return await Promise.all(
+                runs.map((runDirectory) =>
+                  pendingService.reconcileOnce(runDirectory),
+                ),
+              );
             } finally {
               rmSync(directory, { recursive: true, force: true });
             }
@@ -347,14 +390,19 @@ async function main(): Promise<void> {
           `canonical-${String(index).padStart(3, '0')}`,
         );
       }
-      const runDirectory = join(base, 'canonical-000');
+      const runDirectories = Array.from({ length: count }, (_, index) =>
+        join(base, `canonical-${String(index).padStart(3, '0')}`),
+      );
       metrics.push({
         name: `canonical-read-${count}-runs`,
         parameters: { runs: count, schema_version: 3 },
         ...(await measure({
           warmup,
           iterations,
-          operation: () => readCanonicalRunReportingView(runDirectory),
+          operation: () =>
+            runDirectories.map((directory) =>
+              readCanonicalRunReportingView(directory),
+            ),
         })),
       });
       metrics.push({
@@ -372,7 +420,8 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: () => writeHtmlReportForRun(runDirectory),
+          operation: () =>
+            runDirectories.map((directory) => writeHtmlReportForRun(directory)),
         })),
       });
       metrics.push({
@@ -381,7 +430,10 @@ async function main(): Promise<void> {
         ...(await measure({
           warmup,
           iterations,
-          operation: () => writeJsonlReportForRun(runDirectory),
+          operation: () =>
+            runDirectories.map((directory) =>
+              writeJsonlReportForRun(directory),
+            ),
         })),
       });
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:sea": "node scripts/build-sea.mjs",
     "contracts:generate": "node scripts/generate-contract-snapshot.mjs",
     "benchmark": "node benchmark/cli.mjs",
+    "benchmark:performance": "node --experimental-strip-types benchmark/performance/cli.mjs",
     "benchmark:validate": "node benchmark/validate.mjs",
     "benchmark:ci": "node benchmark/ci.mjs",
     "dev": "node scripts/clean-dist.mjs && npm run verify:typescript && npm run build:declarations && tsup --watch",

--- a/src/core/normalizer.ts
+++ b/src/core/normalizer.ts
@@ -7,6 +7,7 @@ import type { Citation, DeduplicatedSource } from '../types.js';
  * - Strip trailing slashes
  * - Strip tracking params (utm_*, ref, fbclid, gclid, etc.)
  * - Lowercase hostname
+ * - Ignore fragments, which only identify client-side document locations
  */
 export function normalizeUrl(url: string): string {
   try {
@@ -17,30 +18,32 @@ export function normalizeUrl(url: string): string {
     if (parsed.hostname.startsWith('www.')) {
       parsed.hostname = parsed.hostname.slice(4);
     }
-    // Strip tracking params
-    const trackingParams = [
-      'utm_source',
-      'utm_medium',
-      'utm_campaign',
-      'utm_term',
-      'utm_content',
+    // Remove every case-insensitive UTM key, rather than only the common
+    // names. Preserve other query parameters because they can select distinct
+    // source content. Rebuild the parameters so deleting a key never skips
+    // the next entry while URLSearchParams is being iterated. Fragments are
+    // deliberately omitted below: they identify a location in a document,
+    // not a separate source for deduplication.
+    const trackingParams = new Set([
       'ref',
       'fbclid',
       'gclid',
       'msclkid',
       'mc_cid',
       'mc_eid',
-    ];
-    for (const param of trackingParams) {
-      parsed.searchParams.delete(param);
+    ]);
+    const retainedParams = [...parsed.searchParams].filter(([key]) => {
+      const normalized = key.toLowerCase();
+      return !normalized.startsWith('utm_') && !trackingParams.has(normalized);
+    });
+    parsed.search = '';
+    for (const [key, value] of retainedParams) {
+      parsed.searchParams.append(key, value);
     }
     // Rebuild without protocol, strip trailing slash
     let normalized = `${parsed.host}${parsed.pathname}`;
     if (parsed.searchParams.toString()) {
       normalized += `?${parsed.searchParams.toString()}`;
-    }
-    if (parsed.hash) {
-      normalized += parsed.hash;
     }
     return normalized.replace(/\/+$/, '');
   } catch {

--- a/tests/normalizer.test.ts
+++ b/tests/normalizer.test.ts
@@ -21,10 +21,18 @@ describe('normalizeUrl', () => {
     expect(normalizeUrl('https://example.com/page/')).toBe('example.com/page');
   });
 
-  it('strips utm_* params', () => {
+  it('strips every case-insensitive utm_* param', () => {
     const url =
-      'https://example.com/page?utm_source=twitter&utm_medium=social&utm_campaign=launch&keep=yes';
+      'https://example.com/page?utm_source=twitter&utm_custom_placement=hero&UTM_MEDIUM=social&utm_campaign=launch&keep=yes';
     expect(normalizeUrl(url)).toBe('example.com/page?keep=yes');
+  });
+
+  it('ignores fragments but preserves meaningful query parameters', () => {
+    expect(
+      normalizeUrl(
+        'https://example.com/page?article=42&filter=recent&utm_source=newsletter#evidence',
+      ),
+    ).toBe('example.com/page?article=42&filter=recent');
   });
 
   it('strips fbclid, gclid, and other tracking params', () => {
@@ -75,6 +83,23 @@ describe('deduplicateSources', () => {
     expect(result[0].citationCount).toBe(2);
     expect(result[0].providers).toContain('perplexity-sonar-pro');
     expect(result[0].providers).toContain('brave-answers');
+  });
+
+  it('merges citations that only differ by UTM keys or fragment', () => {
+    const citations: Citation[] = [
+      {
+        url: 'https://example.com/page?keep=yes&utm_campaign=launch#first',
+        provider: 'exa',
+      },
+      {
+        url: 'https://example.com/page?utm_custom=x&keep=yes#second',
+        provider: 'brave-answers',
+      },
+    ];
+
+    expect(deduplicateSources(citations)).toMatchObject([
+      { normalizedUrl: 'example.com/page?keep=yes', citationCount: 2 },
+    ]);
   });
 
   it('keeps distinct ports as separate sources', () => {

--- a/tests/performance-benchmark.test.ts
+++ b/tests/performance-benchmark.test.ts
@@ -35,4 +35,21 @@ describe('offline performance benchmark helpers', () => {
     expect(result.min_ms).toBeLessThanOrEqual(result.median_ms);
     expect(result.median_ms).toBeLessThanOrEqual(result.p95_ms);
   });
+
+  it('prepares each fixture outside the timed operation', async () => {
+    let prepared = 0;
+    const seen: number[] = [];
+    const result = await measure({
+      warmup: 1,
+      iterations: 3,
+      prepare: () => ++prepared,
+      operation: (fixture) => {
+        seen.push(fixture);
+      },
+    });
+
+    expect(prepared).toBe(4);
+    expect(seen).toEqual([1, 2, 3, 4]);
+    expect(result.samples_ms).toHaveLength(3);
+  });
 });

--- a/tests/performance-benchmark.test.ts
+++ b/tests/performance-benchmark.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  measure,
+  PERFORMANCE_SCHEMA_VERSION,
+  summarizeSamples,
+} from '../benchmark/performance/lib.mjs';
+
+describe('offline performance benchmark helpers', () => {
+  it('records raw samples with deterministic distribution summaries', () => {
+    expect(summarizeSamples([5, 1, 4, 2, 3])).toEqual({
+      samples_ms: [5, 1, 4, 2, 3],
+      median_ms: 3,
+      p95_ms: 5,
+      min_ms: 1,
+      max_ms: 5,
+    });
+  });
+
+  it('uses a versioned result schema', () => {
+    expect(PERFORMANCE_SCHEMA_VERSION).toBe(1);
+  });
+
+  it('runs the configured warmup before retaining raw samples', async () => {
+    let calls = 0;
+    const result = await measure({
+      warmup: 2,
+      iterations: 3,
+      operation: () => {
+        calls++;
+      },
+    });
+
+    expect(calls).toBe(5);
+    expect(result.samples_ms).toHaveLength(3);
+    expect(result.min_ms).toBeLessThanOrEqual(result.median_ms);
+    expect(result.median_ms).toBeLessThanOrEqual(result.p95_ms);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an offline local-performance benchmark for fan-out, v2/v3 run artifacts, reporting, URL handling, CLI help, and package size. It uses generated temp directories and synthetic providers only.

## Changes

- Record reproducible host metadata, raw samples, and distribution summaries for local performance comparisons.
- Cover v2 pending/retrieved reconciliation and canonical-v3 reporting/discovery at 1, 20, and 100 runs.
- Normalize every case-insensitive `utm_*` parameter, retain meaningful query parameters, and ignore URL fragments for source deduplication.

## Verification

- `npm test` — 107 files, 1,844 passed, 7 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build` and `npm run test:declarations`
- `npm run test:workers`, `npm run test:integration`, `npm run test:packed`, `npm run test:pty`
- `npm run benchmark:ci` with provider credentials removed
- `node benchmark/performance/cli.mjs --warmup 1 --iterations 3` — 40 offline metrics

## Holdback

- Local SEA verification is skipped: host Node 26.6.0 reports that single-executable applications are disabled.