### PR TITLE
Establish v2 validation and CI foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   autoformat:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -97,6 +99,16 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Declaration consumer fixtures
+        if: runner.os == 'Linux' && matrix.node-version == 24
+        run: npm run test:declarations
+
+      - name: Contract snapshot drift
+        if: runner.os == 'Linux' && matrix.node-version == 24
+        run: |
+          npm run contracts:generate
+          git diff --exit-code -- contracts/v1
 
       - name: Unit tests
         run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     if: github.actor == 'jkudish'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -42,6 +44,26 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Declaration consumer fixtures
+        run: npm run test:declarations
+
+      - name: Contract snapshot drift
+        run: |
+          npm run contracts:generate
+          git diff --exit-code -- contracts/v1
+
+      - name: Workers compatibility tests
+        run: npm run test:workers
+
+      - name: Integration tests
+        run: npm run test:integration
+
+      - name: Packed consumer smoke test
+        run: npm run test:packed
+
+      - name: Offline benchmark fixture replay
+        run: npm run benchmark:ci
 
   release:
     needs: ci

--- a/src/core/fs-utils.ts
+++ b/src/core/fs-utils.ts
@@ -37,7 +37,10 @@ interface SafeWriteFileOptions {
   readonly windowsMutationStage?: WindowsMutationStage;
 }
 
-const WINDOWS_ACL_TIMEOUT_MS = 15_000;
+// Cold Windows PowerShell + Add-Type startup can exceed 15 seconds on loaded
+// Node 22 CI runners. Keep the security transaction bounded without treating
+// normal first-use compilation as missing ACL support.
+const WINDOWS_ACL_TIMEOUT_MS = 30_000;
 const WINDOWS_ACL_MAX_BUFFER = 64 * 1024;
 
 const WINDOWS_NATIVE_FILE_TYPE = `

--- a/tests/config-v2.test.ts
+++ b/tests/config-v2.test.ts
@@ -115,6 +115,33 @@ function nestedObjects(count: number): Record<string, unknown> {
 }
 
 describe('public v2 configuration migration', () => {
+  it('never grants trust to custom providers during v1 migration', () => {
+    const custom = customSource('acme');
+    const source = v1({
+      customProviders: {
+        acme: {
+          type: custom.type,
+          module: custom.module,
+          executionProfile: {
+            bindingId: custom.execution_profile.binding_id,
+            profile: custom.execution_profile.profile,
+          },
+        },
+      },
+      providers: { acme: { enabled: true } },
+    });
+
+    const result = migrateConfig({ global: source });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ code: 'config_custom_provider_untrusted' }),
+    );
+    expect(JSON.stringify(result)).not.toContain(
+      'trusted_provider_ids":["acme',
+    );
+  });
+
   it('migrates exact v1 defaults, mixed mode, costs, and runtime fields', () => {
     const result = migrateConfig({
       global: v1({

--- a/tests/fixtures/provider-conformance.ts
+++ b/tests/fixtures/provider-conformance.ts
@@ -1,0 +1,204 @@
+export type ProviderConformanceLane =
+  | 'options'
+  | 'credentials'
+  | 'normalization'
+  | 'safe_failure'
+  | 'citations'
+  | 'provenance'
+  | 'metering'
+  | 'lifecycle';
+
+export interface ProviderConformanceEvidence {
+  readonly evidence: readonly string[];
+  readonly lanes: readonly ProviderConformanceLane[];
+}
+
+const base = [
+  'credentials',
+  'normalization',
+  'safe_failure',
+  'provenance',
+  'metering',
+] as const;
+const grounded = [...base, 'citations'] as const;
+const background = [...grounded, 'lifecycle'] as const;
+const configurable = [...grounded, 'options'] as const;
+const configurableBackground = [...background, 'options'] as const;
+
+/**
+ * Review evidence for every implemented public profile. This is deliberately
+ * explicit: adding a catalog profile must also name the contract tests that
+ * prove its provider boundary.
+ */
+export const PROVIDER_CONFORMANCE_EVIDENCE: Readonly<
+  Record<string, ProviderConformanceEvidence>
+> = {
+  'perplexity-sonar-deep/research': {
+    evidence: ['tests/adapters/perplexity-async.test.ts'],
+    lanes: background,
+  },
+  'perplexity-deep-research/research': {
+    evidence: ['tests/adapters/perplexity-async.test.ts'],
+    lanes: background,
+  },
+  'perplexity-advanced-deep/research': {
+    evidence: ['tests/adapters/perplexity-async.test.ts'],
+    lanes: background,
+  },
+  'openai-research/research': {
+    evidence: ['tests/adapters/openai-research.test.ts'],
+    lanes: configurableBackground,
+  },
+  'gemini-deep/research': {
+    evidence: ['tests/adapters/gemini-deep-async.test.ts'],
+    lanes: configurableBackground,
+  },
+  'parallel/research': {
+    evidence: ['tests/adapters/parallel.test.ts'],
+    lanes: configurableBackground,
+  },
+  'valyu/research': {
+    evidence: ['tests/adapters/valyu.test.ts'],
+    lanes: configurableBackground,
+  },
+  'exa/research': {
+    evidence: ['tests/research-provider-adapters.test.ts'],
+    lanes: configurableBackground,
+  },
+  'tavily/research': {
+    evidence: ['tests/research-provider-adapters.test.ts'],
+    lanes: configurableBackground,
+  },
+  'you-research/research': {
+    evidence: ['tests/research-provider-adapters.test.ts'],
+    lanes: configurableBackground,
+  },
+  'perplexity-sonar-pro/grounded': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: grounded,
+  },
+  'perplexity-pro-search/grounded': {
+    evidence: ['tests/adapters/perplexity-pro-search.test.ts'],
+    lanes: configurable,
+  },
+  'gemini-grounded/grounded': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: configurable,
+  },
+  'grok/web': {
+    evidence: ['tests/adapters/grok.test.ts'],
+    lanes: configurable,
+  },
+  'grok-x-only/x': {
+    evidence: ['tests/adapters/grok.test.ts'],
+    lanes: configurable,
+  },
+  'grok-combined/combined': {
+    evidence: ['tests/adapters/grok.test.ts'],
+    lanes: configurable,
+  },
+  'openrouter/grounded': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: configurable,
+  },
+  'brave-answers/grounded': {
+    evidence: ['tests/adapters/brave-answers.test.ts'],
+    lanes: grounded,
+  },
+  'you-research/grounded': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: grounded,
+  },
+  'you-answer/grounded': {
+    evidence: ['tests/adapters/you-answer.test.ts'],
+    lanes: configurable,
+  },
+  'kagi-fastgpt/grounded': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: grounded,
+  },
+  'exa/search': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: base,
+  },
+  'perplexity-search/search': {
+    evidence: ['tests/adapters/perplexity-search.test.ts'],
+    lanes: configurable,
+  },
+  'brave-search/search': {
+    evidence: ['tests/provider-descriptors.test.ts'],
+    lanes: base,
+  },
+  'jina-search/search': {
+    evidence: ['tests/provider-descriptors.test.ts'],
+    lanes: base,
+  },
+  'firecrawl-search/search': {
+    evidence: ['tests/adapters/firecrawl-search.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'searchapi/search': {
+    evidence: ['tests/adapters/searchapi.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'serpapi/search': {
+    evidence: ['tests/provider-descriptors.test.ts'],
+    lanes: base,
+  },
+  'tavily/search': {
+    evidence: ['tests/adapters/grounded-providers.test.ts'],
+    lanes: base,
+  },
+  'parallel/search': {
+    evidence: ['tests/adapters/parallel.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'valyu/search': {
+    evidence: ['tests/adapters/valyu.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'searchapi-chatgpt/surface': {
+    evidence: ['tests/adapters/searchapi-answer-engines.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+  'searchapi-gemini/surface': {
+    evidence: ['tests/adapters/searchapi-answer-engines.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+  'searchapi-perplexity/surface': {
+    evidence: ['tests/adapters/searchapi-answer-engines.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+  'searchapi-google-ai-mode/surface': {
+    evidence: ['tests/adapters/searchapi-ai.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+  'searchapi-bing-copilot/surface': {
+    evidence: ['tests/adapters/searchapi-ai.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+  'searchapi-google-ai-overview/surface': {
+    evidence: ['tests/adapters/searchapi-google-ai-overview.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+  'claude/chat': {
+    evidence: ['tests/adapters/llm-providers.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'openai-chat/chat': {
+    evidence: ['tests/adapters/llm-providers.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'gemini-chat/chat': {
+    evidence: ['tests/adapters/llm-providers.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'openrouter/chat': {
+    evidence: ['tests/adapters/llm-providers.test.ts'],
+    lanes: [...base, 'options'],
+  },
+  'parallel/chat': {
+    evidence: ['tests/adapters/parallel.test.ts'],
+    lanes: [...grounded, 'options'],
+  },
+};

--- a/tests/fixtures/scenario-conformance.ts
+++ b/tests/fixtures/scenario-conformance.ts
@@ -1,0 +1,61 @@
+export interface ScenarioConformanceEvidence {
+  readonly file: string;
+  readonly assertion: string;
+}
+
+/**
+ * Broad v2 behavior that must remain backed by a named executable test.
+ * The inventory is intentionally small and points at the authoritative test
+ * instead of copying each scenario into another suite.
+ */
+export const SCENARIO_CONFORMANCE_EVIDENCE: Readonly<
+  Record<string, ScenarioConformanceEvidence>
+> = {
+  concurrent_fan_out: {
+    file: 'tests/execution-runtime.test.ts',
+    assertion:
+      'fans out deterministic shared reserve replacements through the real runtime loop',
+  },
+  ordered_fallback: {
+    file: 'tests/dispatcher-fallback.test.ts',
+    assertion:
+      'preserves an admitted compatible fallback after a primary failure',
+  },
+  source_deduplication: {
+    file: 'tests/normalizer.test.ts',
+    assertion: 'merges citations that only differ by UTM keys or fragment',
+  },
+  budget_cutoff: {
+    file: 'tests/dispatcher-budget.test.ts',
+    assertion: 'does not launch a fallback once the budget is exhausted',
+  },
+  durable_cancellation: {
+    file: 'tests/node-canonical-run.test.ts',
+    assertion:
+      'attempts remote cancellation only for accepted pending/running work',
+  },
+  partial_terminal_response: {
+    file: 'tests/node-canonical-run.test.ts',
+    assertion:
+      'derives partial and failed terminal shapes from exact slot outcomes',
+  },
+  collected_surface_provenance: {
+    file: 'tests/result-provenance.test.ts',
+    assertion: 'gives the six surfaces one shared collector correlation',
+  },
+  transport_consistency: {
+    file: 'tests/run-artifact-cross-transport.test.ts',
+    assertion:
+      'keeps reconciliation and every presentation transport on one durable result',
+  },
+  unsafe_link_neutralization: {
+    file: 'tests/html-report.test.ts',
+    assertion:
+      'escapes raw HTML and neutralizes unsafe links in the answer (untrusted)',
+  },
+  secret_redaction: {
+    file: 'tests/node-canonical-run.test.ts',
+    assertion:
+      'atomically stores a safe result and immutable terminal projection',
+  },
+};

--- a/tests/provider-conformance.test.ts
+++ b/tests/provider-conformance.test.ts
@@ -1,0 +1,77 @@
+import { existsSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_PROFILE_BINDING_SPECS } from '../src/core/profile-bindings.js';
+import {
+  BUILTIN_PROVIDER_CATALOG,
+  catalogProfileRefs,
+} from '../src/core/provider-profiles.js';
+import {
+  PROVIDER_CONFORMANCE_EVIDENCE,
+  type ProviderConformanceLane,
+} from './fixtures/provider-conformance.js';
+
+const requiredForAll: readonly ProviderConformanceLane[] = [
+  'credentials',
+  'normalization',
+  'safe_failure',
+  'provenance',
+  'metering',
+];
+
+function key(providerId: string, profileId: string): string {
+  return `${providerId}/${profileId}`;
+}
+
+describe('built-in provider conformance inventory', () => {
+  const implemented = catalogProfileRefs()
+    .filter(({ declaration }) => declaration.status === 'implemented')
+    .map(({ entry, declaration }) =>
+      key(entry.provider_id, declaration.profile_id),
+    )
+    .sort();
+
+  it('requires exact evidence for every implemented public profile', () => {
+    expect(Object.keys(PROVIDER_CONFORMANCE_EVIDENCE).sort()).toEqual(
+      implemented,
+    );
+    expect(implemented).toHaveLength(42);
+  });
+
+  it('keeps every implemented profile bound to one executable strategy', () => {
+    const bindings = BUILTIN_PROFILE_BINDING_SPECS.map((binding) =>
+      key(binding.provider_id, binding.profile_id),
+    );
+    expect(new Set(bindings).size).toBe(bindings.length);
+    expect([...bindings].sort()).toEqual(implemented);
+  });
+
+  it('points to real tests and declares coherent contract lanes', () => {
+    for (const { entry, declaration } of catalogProfileRefs()) {
+      if (declaration.status !== 'implemented') continue;
+      const profileKey = key(entry.provider_id, declaration.profile_id);
+      const evidence = PROVIDER_CONFORMANCE_EVIDENCE[profileKey];
+      expect(evidence, profileKey).toBeDefined();
+      expect(new Set(evidence?.lanes).size, profileKey).toBe(
+        evidence?.lanes.length,
+      );
+      for (const lane of requiredForAll) {
+        expect(evidence?.lanes, `${profileKey}:${lane}`).toContain(lane);
+      }
+      if (declaration.invocation === 'background') {
+        expect(evidence?.lanes, `${profileKey}:lifecycle`).toContain(
+          'lifecycle',
+        );
+      }
+      if (declaration.grounding_policy === 'required') {
+        expect(evidence?.lanes, `${profileKey}:citations`).toContain(
+          'citations',
+        );
+      }
+      expect(evidence?.evidence.length, profileKey).toBeGreaterThan(0);
+      for (const path of evidence?.evidence ?? []) {
+        expect(existsSync(path), `${profileKey}:${path}`).toBe(true);
+      }
+    }
+    expect(BUILTIN_PROVIDER_CATALOG).not.toHaveLength(0);
+  });
+});

--- a/tests/validation-foundation.test.ts
+++ b/tests/validation-foundation.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { SCENARIO_CONFORMANCE_EVIDENCE } from './fixtures/scenario-conformance.js';
+
+describe('v2 validation foundation', () => {
+  it('keeps every required scenario attached to a named executable test', () => {
+    expect(Object.keys(SCENARIO_CONFORMANCE_EVIDENCE).sort()).toEqual([
+      'budget_cutoff',
+      'collected_surface_provenance',
+      'concurrent_fan_out',
+      'durable_cancellation',
+      'ordered_fallback',
+      'partial_terminal_response',
+      'secret_redaction',
+      'source_deduplication',
+      'transport_consistency',
+      'unsafe_link_neutralization',
+    ]);
+
+    for (const [scenario, evidence] of Object.entries(
+      SCENARIO_CONFORMANCE_EVIDENCE,
+    )) {
+      const source = readFileSync(evidence.file, 'utf8');
+      expect(source, `${scenario}:${evidence.file}`).toContain(
+        evidence.assertion,
+      );
+    }
+  });
+
+  it('runs expensive portable gates once and keeps CI permissions narrow', () => {
+    const ci = readFileSync('.github/workflows/ci.yml', 'utf8');
+    const release = readFileSync('.github/workflows/release.yml', 'utf8');
+
+    expect(ci).toContain('permissions:\n  contents: read');
+    expect(ci).toContain("autoformat:\n    if: github.event_name == 'push'");
+    expect(ci).toContain('contents: write');
+    expect(ci.match(/Declaration consumer fixtures/g)).toHaveLength(1);
+    expect(ci.match(/Contract snapshot drift/g)).toHaveLength(1);
+    expect(ci).toContain('matrix.node-version == 24');
+    expect(ci).not.toMatch(/--coverage|--shard/);
+
+    for (const gate of [
+      'Declaration consumer fixtures',
+      'Contract snapshot drift',
+      'Workers compatibility tests',
+      'Integration tests',
+      'Packed consumer smoke test',
+      'Offline benchmark fixture replay',
+    ]) {
+      expect(release).toContain(`- name: ${gate}`);
+    }
+    expect(release).not.toMatch(/--coverage|--shard/);
+  });
+});

--- a/tests/workers/core-public-api.test.ts
+++ b/tests/workers/core-public-api.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import * as core from '../../src/core-entry.js';
+
+const CORE_RUNTIME_EXPORTS = [
+  'BUILTIN_PROVIDER_CATALOG',
+  'CitationSchema',
+  'ConfigProviderV2Schema',
+  'CustomProviderExecutionProfileV2Schema',
+  'CustomProviderSourceV2Schema',
+  'ExecutionDefaultsV2Schema',
+  'HttpRequestAbortedError',
+  'HttpRequestTimeoutError',
+  'HttpResponseTooLargeError',
+  'InMemoryCoordinationStateStore',
+  'JsonValueSchema',
+  'LibrariumConfigV2Schema',
+  'LibrariumProjectConfigV2Schema',
+  'NpmCustomProviderSourceV2Schema',
+  'ProviderCatalogError',
+  'ResearchErrorSchema',
+  'ResearchRequestSchema',
+  'ResearchResponseSchema',
+  'ResearchResultSchema',
+  'ResultProvenanceSchema',
+  'RuntimeConfigV2Schema',
+  'ScriptCustomProviderSourceV2Schema',
+  'SourceSchema',
+  'UsageSchema',
+  'VERSION',
+  'admitResearchExecution',
+  'buildPrompt',
+  'buildProviderCatalog',
+  'createProviderAttemptBridge',
+  'generateSlug',
+  'httpRequest',
+  'httpStreamRequest',
+  'materializeResearchExecution',
+  'migrateConfig',
+  'prepareResearchExecution',
+  'resolveOutputDir',
+  'runPreparedExecution',
+  'updateCoordinationState',
+  'validateConfigV2',
+].sort();
+
+describe('librarium/core Worker API', () => {
+  it('exports the exact supported runtime surface in workerd', () => {
+    expect(Object.keys(core).sort()).toEqual(CORE_RUNTIME_EXPORTS);
+  });
+
+  it('does not expose Node-only configuration or module loading APIs', () => {
+    expect(core).not.toHaveProperty('loadConfigV2');
+    expect(core).not.toHaveProperty('saveConfigV2');
+    expect(core).not.toHaveProperty('loadCustomProviders');
+  });
+});


### PR DESCRIPTION
## Summary

- require explicit conformance evidence for every implemented provider profile and key runtime scenarios
- pin the Worker-safe core export surface and prove v1 migration never invents custom-provider trust
- narrow default CI permissions and add declaration, contract-drift, Worker, integration, packed-consumer, and offline benchmark release gates

## Verification

- typecheck and lint
- unit: 109 files, 1,851 passed, 7 skipped
- build, declarations, and declaration consumer fixtures
- contract snapshot regeneration with no diff
- Worker: 8 files, 30 tests
- integration: 2 files, 11 tests
- packed consumer and PTY: 4 files, 5 tests
- offline benchmark fixture replay
- deep review: GO with one corrected Low evidence-anchor finding; panel coverage was degraded after two reviewers did not return structured verdicts before the time limit

## Holdbacks

- This is the TypeScript and CI foundation only. Cross-language PHP fixture conformance and the final release-tag repin remain separate work.
- No live or paid provider calls were made.