### PR TITLE
Add frozen exact pricing and budget admission

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "benchmark:performance": "node --experimental-strip-types benchmark/performance/cli.mjs",
     "benchmark:validate": "node benchmark/validate.mjs",
     "benchmark:ci": "node benchmark/ci.mjs",
+    "pricing:snapshot": "node scripts/pricing-snapshot.mjs",
     "dev": "node scripts/clean-dist.mjs && npm run verify:typescript && npm run build:declarations && tsup --watch",
     "test": "vitest run",
     "test:integration": "npm run build && vitest run --config vitest.integration.config.ts",

--- a/scripts/pricing-snapshot.mjs
+++ b/scripts/pricing-snapshot.mjs
@@ -1,0 +1,22 @@
+import { build } from 'esbuild';
+
+const result = await build({
+  entryPoints: ['scripts/pricing-snapshot.ts'],
+  absWorkingDir: process.cwd(),
+  bundle: true,
+  format: 'esm',
+  platform: 'node',
+  target: 'node22.12',
+  write: false,
+});
+
+const source = result.outputFiles[0]?.contents;
+if (!source) throw new Error('Pricing snapshot workflow did not produce output');
+
+const url = `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`;
+try {
+  await import(url);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/pricing-snapshot.ts
+++ b/scripts/pricing-snapshot.ts
@@ -1,0 +1,180 @@
+import { readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import {
+  type PricingSnapshotInput,
+  pricingSnapshotFingerprint,
+  validatePricingSnapshot,
+  verifyPricingSnapshotFingerprint,
+} from '../src/core/pricing.js';
+
+const ZERO_FINGERPRINT = `sha256:${'0'.repeat(64)}`;
+const REMOTE_PATH_PATTERN = /^(?:(?:https?|ftp|data|file):|\\\\)/i;
+const REVIEWER_PATTERN = /^[a-z0-9][a-z0-9._@-]{0,63}$/i;
+
+interface ReviewReceipt {
+  readonly schema_version: 1;
+  readonly decision: 'approved';
+  readonly reviewer: string;
+  readonly reviewed_at: string;
+  readonly snapshot_version: string;
+  readonly snapshot_fingerprint: string;
+}
+
+function usage(): never {
+  throw new Error(
+    'Usage: pricing-snapshot <sync|review|freeze> --input <local-json> --output <local-json> [--reviewer <id> | --review <receipt-json>]',
+  );
+}
+
+function option(name: string, required = true): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  const value = index >= 0 ? process.argv[index + 1] : undefined;
+  if (required && (!value || value.startsWith('--'))) usage();
+  return value;
+}
+
+function localPath(value: string | undefined, label: string): string {
+  if (!value) usage();
+  if (REMOTE_PATH_PATTERN.test(value)) {
+    throw new Error(
+      `${label} must be a local filesystem path; remote inputs are denied.`,
+    );
+  }
+  return resolve(value);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must contain a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+async function readJson(path: string, label: string): Promise<unknown> {
+  let source: string;
+  try {
+    source = await readFile(path, 'utf8');
+  } catch {
+    throw new Error(`${label} could not be read.`);
+  }
+  try {
+    return JSON.parse(source);
+  } catch {
+    throw new Error(`${label} must contain valid JSON.`);
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  const temporary = `${path}.tmp-${process.pid}`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    await rename(temporary, path);
+  } catch (error) {
+    await unlink(temporary).catch(() => undefined);
+    throw error;
+  }
+}
+
+function stagedSnapshot(value: unknown): PricingSnapshotInput {
+  const candidate = record(value, 'Pricing candidate');
+  const provisional = validatePricingSnapshot({
+    ...candidate,
+    fingerprint: ZERO_FINGERPRINT,
+  } as unknown as PricingSnapshotInput);
+  const fingerprint = pricingSnapshotFingerprint(provisional);
+  const staged = validatePricingSnapshot({ ...provisional, fingerprint });
+  verifyPricingSnapshotFingerprint(staged);
+  return staged;
+}
+
+function approvedSnapshot(value: unknown): PricingSnapshotInput {
+  const snapshot = validatePricingSnapshot(
+    record(value, 'Pricing snapshot') as unknown as PricingSnapshotInput,
+  );
+  verifyPricingSnapshotFingerprint(snapshot);
+  return snapshot;
+}
+
+function reviewReceipt(value: unknown): ReviewReceipt {
+  const receipt = record(value, 'Pricing review receipt');
+  const allowed = new Set([
+    'schema_version',
+    'decision',
+    'reviewer',
+    'reviewed_at',
+    'snapshot_version',
+    'snapshot_fingerprint',
+  ]);
+  if (
+    Object.keys(receipt).some((key) => !allowed.has(key)) ||
+    receipt.schema_version !== 1 ||
+    receipt.decision !== 'approved' ||
+    typeof receipt.reviewer !== 'string' ||
+    !REVIEWER_PATTERN.test(receipt.reviewer) ||
+    typeof receipt.reviewed_at !== 'string' ||
+    !receipt.reviewed_at.endsWith('Z') ||
+    !Number.isFinite(Date.parse(receipt.reviewed_at)) ||
+    typeof receipt.snapshot_version !== 'string' ||
+    receipt.snapshot_version.length === 0 ||
+    receipt.snapshot_version.length > 256 ||
+    typeof receipt.snapshot_fingerprint !== 'string' ||
+    !/^sha256:[0-9a-f]{64}$/.test(receipt.snapshot_fingerprint)
+  ) {
+    throw new Error('Pricing review receipt is malformed.');
+  }
+  return receipt as unknown as ReviewReceipt;
+}
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+  if (!['sync', 'review', 'freeze'].includes(command ?? '')) usage();
+  const input = localPath(option('input'), 'Input');
+  const output = localPath(option('output'), 'Output');
+
+  if (command === 'sync') {
+    const candidate = stagedSnapshot(
+      await readJson(input, 'Pricing candidate'),
+    );
+    await writeJson(output, candidate);
+    console.log(`Staged local pricing candidate ${candidate.fingerprint}.`);
+    return;
+  }
+
+  const snapshot = approvedSnapshot(await readJson(input, 'Pricing snapshot'));
+  if (command === 'review') {
+    const reviewer = option('reviewer');
+    if (!reviewer || !REVIEWER_PATTERN.test(reviewer)) {
+      throw new Error('Reviewer must be a bounded non-secret identifier.');
+    }
+    const receipt: ReviewReceipt = {
+      schema_version: 1,
+      decision: 'approved',
+      reviewer,
+      reviewed_at: new Date().toISOString(),
+      snapshot_version: snapshot.version,
+      snapshot_fingerprint: snapshot.fingerprint,
+    };
+    await writeJson(output, receipt);
+    console.log(`Approved pricing candidate ${snapshot.fingerprint}.`);
+    return;
+  }
+
+  const receiptPath = localPath(option('review'), 'Review receipt');
+  const receipt = reviewReceipt(
+    await readJson(receiptPath, 'Pricing review receipt'),
+  );
+  if (
+    receipt.snapshot_version !== snapshot.version ||
+    receipt.snapshot_fingerprint !== snapshot.fingerprint
+  ) {
+    throw new Error('Pricing review receipt does not match the snapshot.');
+  }
+  await writeJson(output, snapshot);
+  console.log(`Froze reviewed pricing snapshot ${snapshot.fingerprint}.`);
+}
+
+await main();

--- a/src/core/pricing-snapshot.ts
+++ b/src/core/pricing-snapshot.ts
@@ -1,0 +1,475 @@
+import type {
+  NormalizedBillableUnit,
+  PriceDefinitionInput,
+  PriceRate,
+  PricingCompleteness,
+  PricingSnapshotInput,
+} from './pricing.js';
+import { validatePricingSnapshot } from './pricing.js';
+
+const REVIEWED_AT = '2026-08-13T00:00:00.000Z';
+
+interface DefinitionOptions {
+  readonly target?: PriceDefinitionInput['effective_target'];
+  readonly conditions?: PriceDefinitionInput['conditions'];
+  readonly completeness?: PricingCompleteness;
+  readonly expected: readonly NormalizedBillableUnit[];
+  readonly fixed?: PriceDefinitionInput['fixed_quantities'];
+  readonly rates?: readonly PriceRate[];
+  readonly missing?: readonly NormalizedBillableUnit[];
+  readonly reason?: string;
+  readonly reference: string;
+  readonly fallback?: true;
+}
+
+function definition(
+  providerId: string,
+  profileId: string,
+  options: DefinitionOptions,
+): PriceDefinitionInput {
+  return {
+    id: `${providerId}.${profileId}.${options.target?.target_id ?? 'profile'}`,
+    provider_id: providerId,
+    profile_id: profileId,
+    ...(options.target && { effective_target: options.target }),
+    ...(options.conditions && { conditions: options.conditions }),
+    currency: 'USD',
+    completeness: options.completeness ?? 'complete',
+    confidence:
+      (options.completeness ?? 'complete') === 'unavailable'
+        ? 'unknown'
+        : options.fallback
+          ? 'medium'
+          : 'confirmed',
+    expected_units: options.expected,
+    ...(options.fixed && { fixed_quantities: options.fixed }),
+    missing_units: options.missing ?? [],
+    rates: options.rates ?? [],
+    ...(options.reason && { unknown_reason: options.reason }),
+    provenance: {
+      source_class: options.fallback
+        ? 'frozen_reviewed_fallback'
+        : 'frozen_official_snapshot',
+      source_reference: options.reference,
+      effective_at: REVIEWED_AT,
+      retrieved_at: REVIEWED_AT,
+    },
+  };
+}
+
+function unavailable(
+  providerId: string,
+  profileId: string,
+  expected: readonly NormalizedBillableUnit[],
+  reason: string,
+  reference: string,
+  fixed?: PriceDefinitionInput['fixed_quantities'],
+): PriceDefinitionInput {
+  return definition(providerId, profileId, {
+    completeness: 'unavailable',
+    expected,
+    ...(fixed && { fixed }),
+    missing: expected,
+    reason,
+    reference,
+  });
+}
+
+function rate(
+  unit: NormalizedBillableUnit,
+  amountDecimal: string,
+  perDecimal = '1',
+): PriceRate {
+  return {
+    unit,
+    amount_decimal: amountDecimal,
+    per_decimal: perDecimal,
+  };
+}
+
+const tokenUnits = [
+  'uncached_input_tokens',
+  'output_tokens',
+] as const satisfies readonly NormalizedBillableUnit[];
+const routedReason =
+  'The effective routed model or provider endpoint determines the price.';
+const accountReason =
+  'The account plan or negotiated contract determines the USD rate.';
+const quantitiesReason =
+  'The provider controls one or more billable quantities before completion.';
+
+const DEFINITIONS: readonly PriceDefinitionInput[] = [
+  // Parallel
+  definition('parallel', 'research', {
+    target: { kind: 'preset', target_id: 'pro' },
+    expected: ['processor_requests'],
+    fixed: { processor_requests: '1' },
+    rates: [rate('processor_requests', '0.1')],
+    reference: 'official:docs.parallel.ai/getting-started/pricing',
+  }),
+  definition('parallel', 'chat', {
+    target: { kind: 'model', target_id: 'base' },
+    expected: ['requests'],
+    fixed: { requests: '1' },
+    rates: [rate('requests', '0.01')],
+    reference: 'official:docs.parallel.ai/getting-started/pricing',
+  }),
+  unavailable(
+    'parallel',
+    'search',
+    ['requests', 'results'],
+    'Search mode and additional-result count change the price.',
+    'official:docs.parallel.ai/getting-started/pricing',
+    { requests: '1' },
+  ),
+
+  // Perplexity
+  definition('perplexity-sonar-deep', 'research', {
+    target: { kind: 'model', target_id: 'sonar-deep-research' },
+    expected: [
+      ...tokenUnits,
+      'reasoning_tokens',
+      'searches',
+      'perplexity:citation_tokens',
+    ],
+    rates: [
+      rate('uncached_input_tokens', '2', '1000000'),
+      rate('output_tokens', '8', '1000000'),
+      rate('reasoning_tokens', '3', '1000000'),
+      rate('searches', '5', '1000'),
+      rate('perplexity:citation_tokens', '2', '1000000'),
+    ],
+    reference: 'official:docs.perplexity.ai/docs/getting-started/pricing',
+  }),
+  unavailable(
+    'perplexity-deep-research',
+    'research',
+    ['research_requests'],
+    routedReason,
+    'official:docs.perplexity.ai/docs/getting-started/pricing',
+  ),
+  unavailable(
+    'perplexity-advanced-deep',
+    'research',
+    ['research_requests'],
+    routedReason,
+    'official:docs.perplexity.ai/docs/getting-started/pricing',
+  ),
+  definition('perplexity-sonar-pro', 'grounded', {
+    target: { kind: 'model', target_id: 'sonar-pro' },
+    expected: [...tokenUnits, 'requests'],
+    fixed: { requests: '1' },
+    rates: [
+      rate('uncached_input_tokens', '3', '1000000'),
+      rate('output_tokens', '15', '1000000'),
+      rate('requests', '6', '1000'),
+    ],
+    reference: 'official:docs.perplexity.ai/docs/getting-started/pricing',
+  }),
+  definition('perplexity-pro-search', 'grounded', {
+    target: { kind: 'model', target_id: 'sonar-pro' },
+    expected: [...tokenUnits, 'requests'],
+    fixed: { requests: '1' },
+    rates: [
+      rate('uncached_input_tokens', '3', '1000000'),
+      rate('output_tokens', '15', '1000000'),
+      rate('requests', '14', '1000'),
+    ],
+    reference: 'official:docs.perplexity.ai/docs/sonar/pro-search/quickstart',
+  }),
+  definition('perplexity-search', 'search', {
+    expected: ['requests'],
+    fixed: { requests: '1' },
+    rates: [rate('requests', '5', '1000')],
+    reference: 'official:docs.perplexity.ai/docs/getting-started/pricing',
+  }),
+
+  // OpenAI
+  definition('openai-research', 'research', {
+    target: { kind: 'model', target_id: 'gpt-5.6-sol' },
+    completeness: 'partial',
+    expected: [
+      ...tokenUnits,
+      'cache_read_tokens',
+      'cache_write_tokens',
+      'reasoning_tokens',
+      'searches',
+      'openai:long_context_surcharge',
+    ],
+    rates: [
+      rate('uncached_input_tokens', '5', '1000000'),
+      rate('output_tokens', '30', '1000000'),
+      rate('reasoning_tokens', '30', '1000000'),
+      rate('cache_read_tokens', '0.5', '1000000'),
+      rate('cache_write_tokens', '6.25', '1000000'),
+      rate('searches', '10', '1000'),
+    ],
+    missing: ['openai:long_context_surcharge'],
+    reason:
+      'Long-context, processing-mode, and background lifecycle conditions are not bounded before completion.',
+    reference: 'official:developers.openai.com/api/docs/models/gpt-5.6-sol',
+  }),
+  unavailable(
+    'openai-chat',
+    'chat',
+    [...tokenUnits, 'searches'],
+    'The reviewed evidence did not freeze the exact current gpt-5-mini rate and tool conditions.',
+    'official:openai.com/api/pricing',
+  ),
+
+  // Gemini
+  definition('gemini-grounded', 'grounded', {
+    target: { kind: 'model', target_id: 'gemini-2.5-flash' },
+    conditions: { account_plan: 'payg', billing_mode: 'standard' },
+    expected: [...tokenUnits, 'cache_read_tokens', 'searches'],
+    rates: [
+      rate('uncached_input_tokens', '0.3', '1000000'),
+      rate('output_tokens', '2.5', '1000000'),
+      rate('cache_read_tokens', '0.03', '1000000'),
+      rate('searches', '35', '1000'),
+    ],
+    reference: 'official:ai.google.dev/gemini-api/docs/pricing',
+  }),
+  unavailable(
+    'gemini-deep',
+    'research',
+    [...tokenUnits, 'reasoning_tokens', 'searches'],
+    quantitiesReason,
+    'official:ai.google.dev/gemini-api/docs/deep-research',
+  ),
+  definition('gemini-chat', 'chat', {
+    target: { kind: 'model', target_id: 'gemini-3.6-flash' },
+    conditions: { account_plan: 'payg', billing_mode: 'standard' },
+    expected: [...tokenUnits, 'cache_read_tokens', 'searches'],
+    rates: [
+      rate('uncached_input_tokens', '1.5', '1000000'),
+      rate('output_tokens', '9', '1000000'),
+      rate('cache_read_tokens', '0.15', '1000000'),
+      rate('searches', '14', '1000'),
+    ],
+    reference: 'official:ai.google.dev/gemini-api/docs/pricing',
+  }),
+
+  // xAI
+  ...[
+    ['grok', 'web'],
+    ['grok-x-only', 'x'],
+    ['grok-combined', 'combined'],
+  ].map(([providerId, profileId]) =>
+    definition(providerId, profileId, {
+      target: { kind: 'model', target_id: 'grok-4.5' },
+      expected: [
+        ...tokenUnits,
+        'cache_read_tokens',
+        'reasoning_tokens',
+        'searches',
+      ],
+      rates: [
+        rate('uncached_input_tokens', '2', '1000000'),
+        rate('output_tokens', '6', '1000000'),
+        rate('reasoning_tokens', '6', '1000000'),
+        rate('cache_read_tokens', '0.3', '1000000'),
+        rate('searches', '5', '1000'),
+      ],
+      reference: 'official:docs.x.ai/developers/pricing',
+    }),
+  ),
+
+  // OpenRouter
+  unavailable(
+    'openrouter',
+    'grounded',
+    [...tokenUnits, 'tool_calls'],
+    routedReason,
+    'official:openrouter.ai/docs/guides/routing/provider-selection',
+  ),
+  unavailable(
+    'openrouter',
+    'chat',
+    [...tokenUnits, 'tool_calls'],
+    routedReason,
+    'official:openrouter.ai/docs/guides/routing/provider-selection',
+  ),
+
+  // Brave
+  definition('brave-search', 'search', {
+    expected: ['requests'],
+    fixed: { requests: '1' },
+    rates: [rate('requests', '5', '1000')],
+    reference: 'official:brave.com/search/api',
+  }),
+  definition('brave-answers', 'grounded', {
+    expected: [...tokenUnits, 'searches'],
+    rates: [
+      rate('uncached_input_tokens', '5', '1000000'),
+      rate('output_tokens', '5', '1000000'),
+      rate('searches', '4', '1000'),
+    ],
+    reference: 'official:brave.com/search/api',
+  }),
+
+  // You.com
+  definition('you-research', 'grounded', {
+    expected: ['research_requests'],
+    fixed: { research_requests: '1' },
+    rates: [rate('research_requests', '50', '1000')],
+    reference: 'official:you.com/docs/administration/billing',
+  }),
+  definition('you-research', 'research', {
+    expected: ['research_requests'],
+    fixed: { research_requests: '1' },
+    rates: [rate('research_requests', '50', '1000')],
+    reference: 'official:you.com/docs/guides/research',
+  }),
+  unavailable(
+    'you-answer',
+    'grounded',
+    ['requests'],
+    'The current official inventory does not publish a stable Answer API rate matching this adapter.',
+    'official:you.com/pricing',
+    { requests: '1' },
+  ),
+
+  // Kagi
+  definition('kagi-fastgpt', 'grounded', {
+    expected: ['requests'],
+    fixed: { requests: '1' },
+    rates: [rate('requests', '0.015')],
+    reference: 'official:help.kagi.com/kagi/api/fastgpt.html',
+  }),
+
+  // Exa
+  definition('exa', 'search', {
+    expected: ['requests', 'exa:content_pages'],
+    fixed: { requests: '1', 'exa:content_pages': '10' },
+    rates: [
+      rate('requests', '7', '1000'),
+      rate('exa:content_pages', '1', '1000'),
+    ],
+    reference: 'official:exa.ai/pricing',
+  }),
+  definition('exa', 'research', {
+    expected: ['exa:agent_compute_units', 'searches'],
+    rates: [rate('exa:agent_compute_units', '0.1'), rate('searches', '0.005')],
+    reference: 'official:exa.ai/pricing',
+  }),
+
+  // Jina
+  unavailable(
+    'jina-search',
+    'search',
+    ['jina:tokens'],
+    'Jina publishes token consumption but no stable public USD conversion.',
+    'official:jina.ai/reader',
+  ),
+
+  // Firecrawl
+  unavailable(
+    'firecrawl-search',
+    'search',
+    ['credits'],
+    accountReason,
+    'official:firecrawl.dev/pricing',
+    { credits: '2' },
+  ),
+
+  // SearchAPI: all prices are account-plan dependent.
+  ...[
+    ['searchapi', 'search', '1'],
+    ['searchapi-chatgpt', 'surface', '1'],
+    ['searchapi-gemini', 'surface', '1'],
+    ['searchapi-perplexity', 'surface', '1'],
+    ['searchapi-google-ai-mode', 'surface', '1'],
+    ['searchapi-bing-copilot', 'surface', '1'],
+    ['searchapi-google-ai-overview', 'surface', '2'],
+  ].map(([providerId, profileId, requests]) =>
+    unavailable(
+      providerId,
+      profileId,
+      ['requests'],
+      accountReason,
+      'official:searchapi.io/pricing',
+      { requests },
+    ),
+  ),
+
+  // SerpApi
+  unavailable(
+    'serpapi',
+    'search',
+    ['requests'],
+    accountReason,
+    'official:serpapi.com/pricing',
+    { requests: '1' },
+  ),
+
+  // Tavily
+  definition('tavily', 'search', {
+    conditions: { account_plan: 'payg' },
+    expected: ['credits'],
+    fixed: { credits: '2' },
+    rates: [rate('credits', '0.008')],
+    reference: 'official:tavily.com/pricing',
+    fallback: true,
+  }),
+  unavailable(
+    'tavily',
+    'research',
+    ['credits'],
+    'The auto research model and account plan determine credit consumption and USD value.',
+    'official:tavily.com/pricing',
+  ),
+
+  // Valyu
+  unavailable(
+    'valyu',
+    'search',
+    ['results'],
+    'Each returned result can have a different source-class price.',
+    'official:docs.valyu.ai/pricing',
+  ),
+  definition('valyu', 'research', {
+    target: { kind: 'preset', target_id: 'standard' },
+    expected: ['research_requests'],
+    fixed: { research_requests: '1' },
+    rates: [rate('research_requests', '0.5')],
+    reference: 'official:docs.valyu.ai/pricing',
+  }),
+
+  // Anthropic
+  definition('claude', 'chat', {
+    target: { kind: 'model', target_id: 'claude-sonnet-5' },
+    completeness: 'partial',
+    expected: [
+      ...tokenUnits,
+      'cache_read_tokens',
+      'cache_write_tokens',
+      'searches',
+    ],
+    rates: [
+      rate('uncached_input_tokens', '2', '1000000'),
+      rate('output_tokens', '10', '1000000'),
+      rate('cache_read_tokens', '0.2', '1000000'),
+      rate('cache_write_tokens', '2.5', '1000000'),
+    ],
+    missing: ['searches'],
+    reason:
+      'Web search tool billing and cache lifetime must be observed explicitly.',
+    reference: 'official:platform.claude.com/docs/en/about-claude/pricing',
+  }),
+];
+
+/**
+ * The only runtime pricing source. It is reviewed, immutable, and network-free.
+ * Update it only through the explicit local sync/review/freeze workflow.
+ */
+export const BUILTIN_PRICING_SNAPSHOT: PricingSnapshotInput =
+  validatePricingSnapshot({
+    schema_version: 1,
+    version: '2026-08-13.v1',
+    reviewed_at: REVIEWED_AT,
+    currency: 'USD',
+    fingerprint:
+      'sha256:0a12e0c17f3d42ba5f4ba99ac919304d99f8b2e6bad48686cca8f582cb9dd00f',
+    definitions: DEFINITIONS,
+  });

--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -1,0 +1,1277 @@
+import type {
+  ProviderIdentity,
+  TargetKind,
+} from '../contracts/domain/index.js';
+import {
+  canonicalJson,
+  compareCanonicalStrings,
+} from './catalog-fingerprint.js';
+
+export const PRICING_SNAPSHOT_SCHEMA_VERSION = 1;
+export const PRICING_SNAPSHOT_FINGERPRINT_ALGORITHM = 'sha256';
+
+const DECIMAL_PATTERN = /^(?:0|[1-9]\d*)(?:\.\d{1,36})?$/;
+const CURRENCY_PATTERN = /^[A-Z]{3}$/;
+const FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const PROVIDER_UNIT_PATTERN = /^[a-z][a-z0-9-]{0,62}:[a-z][a-z0-9_]{0,62}$/;
+const SOURCE_REFERENCE_PATTERN =
+  /^(?:official|reviewed|configured|provider):[a-z0-9.-]+(?:\/[a-z0-9._~/-]+)*$/;
+const UTC_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
+const MAX_PRICE_DEFINITIONS = 4096;
+const MAX_DEFINITION_UNITS = 64;
+const COMPLETENESS_VALUES = new Set(['complete', 'partial', 'unavailable']);
+const CONFIDENCE_VALUES = new Set(['confirmed', 'high', 'medium', 'unknown']);
+const SOURCE_CLASS_VALUES = new Set([
+  'configured_account_rate',
+  'frozen_official_snapshot',
+  'frozen_reviewed_fallback',
+]);
+const TARGET_KIND_VALUES = new Set(['model', 'agent', 'preset']);
+
+export const NORMALIZED_BILLABLE_UNITS = [
+  'uncached_input_tokens',
+  'output_tokens',
+  'cache_read_tokens',
+  'cache_write_tokens',
+  'reasoning_tokens',
+  'requests',
+  'searches',
+  'tool_calls',
+  'images',
+  'audio_seconds',
+  'rows',
+  'results',
+  'credits',
+  'processor_requests',
+  'research_requests',
+] as const;
+
+export type NormalizedBillableUnit =
+  | (typeof NORMALIZED_BILLABLE_UNITS)[number]
+  | `${string}:${string}`;
+export type PricingCompleteness = 'complete' | 'partial' | 'unavailable';
+export type PricingConfidence = 'confirmed' | 'high' | 'medium' | 'unknown';
+export type PricingSourceClass =
+  | 'provider_reported_actual'
+  | 'configured_account_rate'
+  | 'frozen_official_snapshot'
+  | 'frozen_reviewed_fallback'
+  | 'unknown';
+export type ComputedActualSource =
+  | 'computed_from_tokens'
+  | 'computed_from_request'
+  | 'computed_from_credits';
+
+export interface PricingConditions {
+  readonly account_plan?: string;
+  readonly region?: string;
+  readonly billing_mode?: string;
+  readonly tool_mode?: string;
+  readonly research_mode?: string;
+  readonly [condition: string]: string | undefined;
+}
+
+export interface EffectivePricingIdentity {
+  readonly provider_id: string;
+  readonly kind?: TargetKind;
+  readonly target_id?: string;
+}
+
+export interface PriceRate {
+  readonly unit: NormalizedBillableUnit;
+  readonly amount_decimal: string;
+  readonly per_decimal: string;
+}
+
+export interface PricingProvenanceInput {
+  readonly source_class:
+    | 'configured_account_rate'
+    | 'frozen_official_snapshot'
+    | 'frozen_reviewed_fallback';
+  readonly source_reference: string;
+  readonly effective_at: string;
+  readonly retrieved_at: string;
+}
+
+export interface PriceDefinitionInput {
+  readonly id: string;
+  readonly provider_id: string;
+  readonly profile_id: string;
+  readonly effective_target?: {
+    readonly provider_id?: string;
+    readonly kind: TargetKind;
+    readonly target_id: string;
+  };
+  readonly conditions?: PricingConditions;
+  readonly currency: string;
+  readonly completeness: PricingCompleteness;
+  readonly confidence: PricingConfidence;
+  readonly expected_units: readonly NormalizedBillableUnit[];
+  readonly fixed_quantities?: Readonly<
+    Partial<Record<NormalizedBillableUnit, string>>
+  >;
+  readonly missing_units: readonly NormalizedBillableUnit[];
+  readonly rates: readonly PriceRate[];
+  readonly unknown_reason?: string;
+  readonly provenance: PricingProvenanceInput;
+}
+
+export interface PricingSnapshotInput {
+  readonly schema_version: number;
+  readonly version: string;
+  readonly reviewed_at: string;
+  readonly currency: string;
+  readonly fingerprint: string;
+  readonly definitions: readonly PriceDefinitionInput[];
+}
+
+export interface PricingProvenance extends PricingProvenanceInput {
+  readonly currency: string;
+  readonly definition_fingerprint: string;
+  readonly snapshot_version: string;
+  readonly snapshot_fingerprint: string;
+  readonly conditions: PricingConditions;
+}
+
+export interface PricingQuote {
+  readonly status: PricingCompleteness;
+  readonly amount_decimal?: string;
+  readonly known_minimum_decimal?: string;
+  readonly known_maximum_decimal?: string;
+  readonly currency: string;
+  readonly expected_units: readonly NormalizedBillableUnit[];
+  readonly billable_quantities: Readonly<
+    Partial<Record<NormalizedBillableUnit, string>>
+  >;
+  readonly missing_units: readonly NormalizedBillableUnit[];
+  readonly unknown_reason?: string;
+  readonly confidence: PricingConfidence;
+  readonly requested_identity: ProviderIdentity;
+  readonly effective_identity?: EffectivePricingIdentity;
+  readonly snapshot_version: string;
+  readonly snapshot_fingerprint: string;
+  readonly provenance?: PricingProvenance;
+}
+
+export interface PricingLookup {
+  readonly requested_identity: ProviderIdentity;
+  readonly effective_identity?: EffectivePricingIdentity;
+  readonly conditions?: PricingConditions;
+  readonly quantities?: Readonly<
+    Partial<Record<NormalizedBillableUnit, string>>
+  >;
+  /** Provider evidence may replace a fixed preflight quantity after execution. */
+  readonly quantity_source?: 'estimate' | 'provider_reported';
+}
+
+export interface ProviderReportedActual {
+  readonly amount_decimal: string;
+  readonly currency: string;
+  readonly observed_at: string;
+  readonly source_reference: string;
+}
+
+export interface ResolvedActualCost {
+  readonly amount_decimal: string;
+  readonly currency: string;
+  readonly source: 'provider_reported' | ComputedActualSource;
+  readonly source_class: PricingSourceClass;
+  readonly requested_identity: ProviderIdentity;
+  readonly effective_identity?: EffectivePricingIdentity;
+  readonly provenance:
+    | PricingProvenance
+    | {
+        readonly currency: string;
+        readonly source_class: 'provider_reported_actual';
+        readonly observed_at: string;
+        readonly source_reference?: string;
+        readonly snapshot_version: string;
+        readonly snapshot_fingerprint: string;
+        readonly conditions: PricingConditions;
+      };
+  readonly quote?: PricingQuote;
+}
+
+export interface ActualCostInput extends PricingLookup {
+  readonly provider_reported_actual?: ProviderReportedActual;
+  readonly provider_reported_units?: Readonly<
+    Partial<Record<NormalizedBillableUnit, string>>
+  >;
+}
+
+interface Decimal {
+  readonly coefficient: bigint;
+  readonly scale: number;
+}
+
+export class PricingCatalogError extends Error {}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+  Object.freeze(value);
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return value;
+}
+
+function ownFrozen<T>(value: T): T {
+  return deepFreeze(structuredClone(value));
+}
+
+function jsonRecord(value: unknown, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new PricingCatalogError(`${field} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactObjectKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  field: string,
+): void {
+  const allowedKeys = new Set(allowed);
+  const unexpected = Object.keys(value).find((key) => !allowedKeys.has(key));
+  if (unexpected !== undefined) {
+    throw new PricingCatalogError(
+      `${field} contains an unexpected field: ${unexpected}`,
+    );
+  }
+}
+
+function boundedString(value: unknown, field: string, maximum = 1024): void {
+  if (typeof value !== 'string' || value.length > maximum) {
+    throw new PricingCatalogError(`${field} must be a bounded string.`);
+  }
+}
+
+function boundedArray(
+  value: unknown,
+  field: string,
+  maximum = MAX_DEFINITION_UNITS,
+): readonly unknown[] {
+  if (!Array.isArray(value) || value.length > maximum) {
+    throw new PricingCatalogError(
+      `${field} must be an array with at most ${maximum} entries.`,
+    );
+  }
+  return value;
+}
+
+function assertPriceDefinitionShape(
+  value: unknown,
+): asserts value is PriceDefinitionInput {
+  const definition = jsonRecord(value, 'definition');
+  exactObjectKeys(
+    definition,
+    [
+      'id',
+      'provider_id',
+      'profile_id',
+      'effective_target',
+      'conditions',
+      'currency',
+      'completeness',
+      'confidence',
+      'expected_units',
+      'fixed_quantities',
+      'missing_units',
+      'rates',
+      'unknown_reason',
+      'provenance',
+    ],
+    'definition',
+  );
+  for (const field of [
+    'id',
+    'provider_id',
+    'profile_id',
+    'currency',
+  ] as const) {
+    boundedString(definition[field], `definition.${field}`, 256);
+  }
+  if (!COMPLETENESS_VALUES.has(definition.completeness as string)) {
+    throw new PricingCatalogError('definition.completeness is invalid.');
+  }
+  if (!CONFIDENCE_VALUES.has(definition.confidence as string)) {
+    throw new PricingCatalogError('definition.confidence is invalid.');
+  }
+  const expected = boundedArray(definition.expected_units, 'expected_units');
+  const missing = boundedArray(definition.missing_units, 'missing_units');
+  for (const [index, unit] of [...expected, ...missing].entries()) {
+    boundedString(unit, `definition unit ${index}`, 128);
+  }
+  const rates = boundedArray(definition.rates, 'rates');
+  for (const [index, value_] of rates.entries()) {
+    const rate = jsonRecord(value_, `rates[${index}]`);
+    exactObjectKeys(
+      rate,
+      ['unit', 'amount_decimal', 'per_decimal'],
+      `rates[${index}]`,
+    );
+    boundedString(rate.unit, `rates[${index}].unit`, 128);
+    boundedString(rate.amount_decimal, `rates[${index}].amount_decimal`, 128);
+    boundedString(rate.per_decimal, `rates[${index}].per_decimal`, 128);
+  }
+  const fixed = jsonRecord(
+    definition.fixed_quantities ?? {},
+    'fixed_quantities',
+  );
+  if (Object.keys(fixed).length > MAX_DEFINITION_UNITS) {
+    throw new PricingCatalogError(
+      'fixed_quantities contains too many entries.',
+    );
+  }
+  for (const [unit, quantity] of Object.entries(fixed)) {
+    boundedString(unit, 'fixed quantity unit', 128);
+    boundedString(quantity, `fixed_quantities.${unit}`, 128);
+  }
+  const conditions = jsonRecord(definition.conditions ?? {}, 'conditions');
+  if (Object.keys(conditions).length > 32) {
+    throw new PricingCatalogError('conditions contains too many entries.');
+  }
+  for (const [condition, conditionValue] of Object.entries(conditions)) {
+    boundedString(condition, 'condition name', 64);
+    boundedString(conditionValue, `conditions.${condition}`, 128);
+  }
+  if (definition.effective_target !== undefined) {
+    const target = jsonRecord(definition.effective_target, 'effective_target');
+    exactObjectKeys(
+      target,
+      ['provider_id', 'kind', 'target_id'],
+      'effective_target',
+    );
+    if (target.provider_id !== undefined) {
+      boundedString(target.provider_id, 'effective_target.provider_id', 256);
+    }
+    if (!TARGET_KIND_VALUES.has(target.kind as string)) {
+      throw new PricingCatalogError('effective_target.kind is invalid.');
+    }
+    boundedString(target.target_id, 'effective_target.target_id', 256);
+  }
+  if (definition.unknown_reason !== undefined) {
+    boundedString(definition.unknown_reason, 'unknown_reason', 1024);
+  }
+  const provenance = jsonRecord(definition.provenance, 'provenance');
+  exactObjectKeys(
+    provenance,
+    ['source_class', 'source_reference', 'effective_at', 'retrieved_at'],
+    'provenance',
+  );
+  if (!SOURCE_CLASS_VALUES.has(provenance.source_class as string)) {
+    throw new PricingCatalogError('provenance.source_class is invalid.');
+  }
+  for (const field of [
+    'source_reference',
+    'effective_at',
+    'retrieved_at',
+  ] as const) {
+    boundedString(provenance[field], `provenance.${field}`, 512);
+  }
+}
+
+function assertPricingSnapshotShape(
+  value: unknown,
+): asserts value is PricingSnapshotInput {
+  const snapshot = jsonRecord(value, 'snapshot');
+  exactObjectKeys(
+    snapshot,
+    [
+      'schema_version',
+      'version',
+      'reviewed_at',
+      'currency',
+      'fingerprint',
+      'definitions',
+    ],
+    'snapshot',
+  );
+  boundedString(snapshot.version, 'snapshot.version', 256);
+  boundedString(snapshot.reviewed_at, 'snapshot.reviewed_at', 64);
+  boundedString(snapshot.currency, 'snapshot.currency', 3);
+  boundedString(snapshot.fingerprint, 'snapshot.fingerprint', 71);
+  const definitions = boundedArray(
+    snapshot.definitions,
+    'snapshot.definitions',
+    MAX_PRICE_DEFINITIONS,
+  );
+  for (const definition of definitions) assertPriceDefinitionShape(definition);
+}
+
+function nonempty(value: string, field: string): string {
+  const containsControl = [...value].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+  if (value.length === 0 || value.trim() !== value || containsControl) {
+    throw new PricingCatalogError(
+      `${field} must be non-empty, trimmed, and control-free.`,
+    );
+  }
+  return value;
+}
+
+function parseDecimal(value: string, field: string): Decimal {
+  if (value.length > 128 || !DECIMAL_PATTERN.test(value)) {
+    throw new PricingCatalogError(
+      `${field} must be a bounded non-negative base-10 decimal string.`,
+    );
+  }
+  const [whole, fraction = ''] = value.split('.');
+  return normalizeDecimal({
+    coefficient: BigInt(`${whole}${fraction}`),
+    scale: fraction.length,
+  });
+}
+
+function positiveDecimal(value: string, field: string): Decimal {
+  const parsed = parseDecimal(value, field);
+  if (parsed.coefficient === 0n) {
+    throw new PricingCatalogError(`${field} must be greater than zero.`);
+  }
+  return parsed;
+}
+
+function normalizeDecimal(value: Decimal): Decimal {
+  let coefficient = value.coefficient;
+  let scale = value.scale;
+  while (scale > 0 && coefficient % 10n === 0n) {
+    coefficient /= 10n;
+    scale -= 1;
+  }
+  return { coefficient, scale };
+}
+
+function decimalText(value: Decimal): string {
+  const normalized = normalizeDecimal(value);
+  if (normalized.coefficient === 0n) return '0';
+  const digits = normalized.coefficient.toString();
+  if (normalized.scale === 0) return digits;
+  const padded = digits.padStart(normalized.scale + 1, '0');
+  const boundary = padded.length - normalized.scale;
+  return `${padded.slice(0, boundary)}.${padded.slice(boundary)}`;
+}
+
+const SHA256_ROUND_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+] as const;
+
+function rotateRight(value: number, count: number): number {
+  return (value >>> count) | (value << (32 - count));
+}
+
+/** Dependency-free, synchronous SHA-256 for the sync Worker-safe catalog. */
+function sha256Hex(bytes: Uint8Array): string {
+  const bitLength = bytes.length * 8;
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x1_0000_0000));
+  view.setUint32(paddedLength - 4, bitLength >>> 0);
+
+  const hash = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+    0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      words[index] = view.getUint32(offset + index * 4);
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const left = words[index - 15] ?? 0;
+      const right = words[index - 2] ?? 0;
+      const sigma0 =
+        rotateRight(left, 7) ^ rotateRight(left, 18) ^ (left >>> 3);
+      const sigma1 =
+        rotateRight(right, 17) ^ rotateRight(right, 19) ^ (right >>> 10);
+      words[index] =
+        ((words[index - 16] ?? 0) +
+          sigma0 +
+          (words[index - 7] ?? 0) +
+          sigma1) >>>
+        0;
+    }
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const temporary1 =
+        (h +
+          sum1 +
+          choice +
+          (SHA256_ROUND_CONSTANTS[index] ?? 0) +
+          (words[index] ?? 0)) >>>
+        0;
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temporary2 = (sum0 + majority) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temporary1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temporary1 + temporary2) >>> 0;
+    }
+    hash[0] = ((hash[0] ?? 0) + a) >>> 0;
+    hash[1] = ((hash[1] ?? 0) + b) >>> 0;
+    hash[2] = ((hash[2] ?? 0) + c) >>> 0;
+    hash[3] = ((hash[3] ?? 0) + d) >>> 0;
+    hash[4] = ((hash[4] ?? 0) + e) >>> 0;
+    hash[5] = ((hash[5] ?? 0) + f) >>> 0;
+    hash[6] = ((hash[6] ?? 0) + g) >>> 0;
+    hash[7] = ((hash[7] ?? 0) + h) >>> 0;
+  }
+  return [...hash].map((word) => word.toString(16).padStart(8, '0')).join('');
+}
+
+function decimalAdd(left: Decimal, right: Decimal): Decimal {
+  const scale = Math.max(left.scale, right.scale);
+  return normalizeDecimal({
+    coefficient:
+      left.coefficient * 10n ** BigInt(scale - left.scale) +
+      right.coefficient * 10n ** BigInt(scale - right.scale),
+    scale,
+  });
+}
+
+function greatestCommonDivisor(left: bigint, right: bigint): bigint {
+  let a = left;
+  let b = right;
+  while (b !== 0n) [a, b] = [b, a % b];
+  return a;
+}
+
+function exactRateCost(
+  quantity: Decimal,
+  amount: Decimal,
+  per: Decimal,
+): Decimal {
+  let numerator =
+    quantity.coefficient * amount.coefficient * 10n ** BigInt(per.scale);
+  let denominator =
+    per.coefficient * 10n ** BigInt(quantity.scale + amount.scale);
+  const divisor = greatestCommonDivisor(numerator, denominator);
+  numerator /= divisor;
+  denominator /= divisor;
+
+  let twos = 0;
+  let fives = 0;
+  while (denominator % 2n === 0n) {
+    denominator /= 2n;
+    twos += 1;
+  }
+  while (denominator % 5n === 0n) {
+    denominator /= 5n;
+    fives += 1;
+  }
+  if (denominator !== 1n) {
+    throw new PricingCatalogError(
+      'A price calculation produced a non-terminating decimal.',
+    );
+  }
+  const scale = Math.max(twos, fives);
+  numerator *= 2n ** BigInt(scale - twos) * 5n ** BigInt(scale - fives);
+  return normalizeDecimal({ coefficient: numerator, scale });
+}
+
+function canonicalUnit(value: string, field: string): NormalizedBillableUnit {
+  if (
+    !(NORMALIZED_BILLABLE_UNITS as readonly string[]).includes(value) &&
+    !PROVIDER_UNIT_PATTERN.test(value)
+  ) {
+    throw new PricingCatalogError(
+      `${field} must be a normalized unit or a safe provider-namespaced unit.`,
+    );
+  }
+  return value as NormalizedBillableUnit;
+}
+
+function canonicalConditions(
+  conditions: PricingConditions | undefined,
+  field: string,
+): PricingConditions {
+  const output: Record<string, string> = {};
+  for (const [key, value] of Object.entries(conditions ?? {}).sort(
+    ([left], [right]) => compareCanonicalStrings(left, right),
+  )) {
+    if (!/^[a-z][a-z0-9_]{0,63}$/.test(key) || value === undefined) {
+      throw new PricingCatalogError(`${field} contains an invalid condition.`);
+    }
+    output[key] = nonempty(value, `${field}.${key}`).toLowerCase();
+  }
+  return output;
+}
+
+function canonicalTimestamp(value: string, field: string): string {
+  const match = UTC_TIMESTAMP_PATTERN.exec(value);
+  const milliseconds = Date.parse(value);
+  if (!match || !Number.isFinite(milliseconds)) {
+    throw new PricingCatalogError(
+      `${field} must be an RFC 3339 UTC timestamp.`,
+    );
+  }
+  const [, year, month, day, hour, minute, second, fraction = ''] = match;
+  const date = new Date(milliseconds);
+  if (
+    date.getUTCFullYear() !== Number(year) ||
+    date.getUTCMonth() !== Number(month) - 1 ||
+    date.getUTCDate() !== Number(day) ||
+    date.getUTCHours() !== Number(hour) ||
+    date.getUTCMinutes() !== Number(minute) ||
+    date.getUTCSeconds() !== Number(second) ||
+    date.getUTCMilliseconds() !== Number(fraction.padEnd(3, '0'))
+  ) {
+    throw new PricingCatalogError(
+      `${field} must be a real RFC 3339 UTC timestamp.`,
+    );
+  }
+  return value;
+}
+
+function definitionKey(definition: PriceDefinitionInput): string {
+  return canonicalJson({
+    provider_id: definition.provider_id.trim().toLowerCase(),
+    profile_id: definition.profile_id.trim().toLowerCase(),
+    effective_target: definition.effective_target
+      ? {
+          provider_id: (
+            definition.effective_target.provider_id ?? definition.provider_id
+          )
+            .trim()
+            .toLowerCase(),
+          kind: definition.effective_target.kind,
+          target_id: definition.effective_target.target_id.trim().toLowerCase(),
+        }
+      : undefined,
+    conditions: canonicalConditions(definition.conditions, 'conditions'),
+    source_class: definition.provenance.source_class,
+  });
+}
+
+function validateDefinition(
+  input: PriceDefinitionInput,
+  snapshotCurrency: string,
+): PriceDefinitionInput {
+  assertPriceDefinitionShape(input);
+  nonempty(input.id, 'definition.id');
+  nonempty(input.provider_id, 'definition.provider_id');
+  nonempty(input.profile_id, 'definition.profile_id');
+  if (
+    !CURRENCY_PATTERN.test(input.currency) ||
+    input.currency !== snapshotCurrency
+  ) {
+    throw new PricingCatalogError(
+      'Every price definition must use the snapshot currency.',
+    );
+  }
+  if (input.effective_target) {
+    if (input.effective_target.provider_id !== undefined) {
+      nonempty(
+        input.effective_target.provider_id,
+        'effective_target.provider_id',
+      );
+    }
+    nonempty(input.effective_target.target_id, 'effective_target.target_id');
+  }
+  const expected = input.expected_units.map((unit, index) =>
+    canonicalUnit(unit, `expected_units[${index}]`),
+  );
+  const missing = input.missing_units.map((unit, index) =>
+    canonicalUnit(unit, `missing_units[${index}]`),
+  );
+  if (
+    new Set(expected).size !== expected.length ||
+    new Set(missing).size !== missing.length
+  ) {
+    throw new PricingCatalogError('Expected and missing units must be unique.');
+  }
+  if (missing.some((unit) => !expected.includes(unit))) {
+    throw new PricingCatalogError('Missing units must also be expected units.');
+  }
+
+  const rateUnits = new Set<NormalizedBillableUnit>();
+  for (const [index, rate] of input.rates.entries()) {
+    const unit = canonicalUnit(rate.unit, `rates[${index}].unit`);
+    if (rateUnits.has(unit)) {
+      throw new PricingCatalogError(`Duplicate rate unit: ${unit}`);
+    }
+    rateUnits.add(unit);
+    const amount = positiveDecimal(
+      rate.amount_decimal,
+      `rates[${index}].amount_decimal`,
+    );
+    const per = positiveDecimal(
+      rate.per_decimal,
+      `rates[${index}].per_decimal`,
+    );
+    exactRateCost({ coefficient: 1n, scale: 0 }, amount, per);
+    if (!expected.includes(unit)) {
+      throw new PricingCatalogError('Rate units must also be expected units.');
+    }
+  }
+  for (const [unit, quantity] of Object.entries(input.fixed_quantities ?? {})) {
+    if (quantity === undefined) continue;
+    canonicalUnit(unit, 'fixed_quantities unit');
+    positiveDecimal(quantity, `fixed_quantities.${unit}`);
+    if (!expected.includes(unit as NormalizedBillableUnit)) {
+      throw new PricingCatalogError(
+        'Fixed quantities must use expected units.',
+      );
+    }
+  }
+  const uncovered = expected.filter((unit) => !rateUnits.has(unit));
+  if (
+    canonicalJson([...uncovered].sort()) !== canonicalJson([...missing].sort())
+  ) {
+    throw new PricingCatalogError(
+      'missing_units must exactly identify expected units without a rate.',
+    );
+  }
+  if (input.completeness === 'complete' && missing.length > 0) {
+    throw new PricingCatalogError(
+      'Complete definitions cannot have missing units.',
+    );
+  }
+  if (
+    expected.length === 0 ||
+    (input.completeness !== 'unavailable' && input.rates.length === 0)
+  ) {
+    throw new PricingCatalogError(
+      'Price definitions require expected units and priced definitions require rates.',
+    );
+  }
+  if (
+    input.completeness === 'partial' &&
+    (missing.length === 0 || input.rates.length === 0)
+  ) {
+    throw new PricingCatalogError(
+      'Partial definitions require at least one rate and one missing unit.',
+    );
+  }
+  if (input.completeness === 'unavailable' && input.rates.length > 0) {
+    throw new PricingCatalogError(
+      'Unavailable definitions cannot contain rates.',
+    );
+  }
+  if (input.completeness !== 'complete' && !input.unknown_reason) {
+    throw new PricingCatalogError(
+      'Partial and unavailable definitions require an unknown reason.',
+    );
+  }
+  if (!SOURCE_REFERENCE_PATTERN.test(input.provenance.source_reference)) {
+    throw new PricingCatalogError(
+      'Pricing source references must be redacted public identifiers.',
+    );
+  }
+  canonicalTimestamp(input.provenance.effective_at, 'provenance.effective_at');
+  canonicalTimestamp(input.provenance.retrieved_at, 'provenance.retrieved_at');
+  canonicalConditions(input.conditions, 'conditions');
+  return ownFrozen(input);
+}
+
+export function validatePricingSnapshot(
+  input: PricingSnapshotInput,
+): PricingSnapshotInput {
+  assertPricingSnapshotShape(input);
+  if (input.schema_version !== PRICING_SNAPSHOT_SCHEMA_VERSION) {
+    throw new PricingCatalogError(
+      'Unsupported pricing snapshot schema version.',
+    );
+  }
+  nonempty(input.version, 'snapshot.version');
+  canonicalTimestamp(input.reviewed_at, 'snapshot.reviewed_at');
+  if (!CURRENCY_PATTERN.test(input.currency)) {
+    throw new PricingCatalogError(
+      'Snapshot currency must be an ISO 4217 code.',
+    );
+  }
+  if (!FINGERPRINT_PATTERN.test(input.fingerprint)) {
+    throw new PricingCatalogError('Snapshot fingerprint must be SHA-256.');
+  }
+  if (input.definitions.length === 0) {
+    throw new PricingCatalogError('Pricing snapshots cannot be empty.');
+  }
+  const keys = new Set<string>();
+  const ids = new Set<string>();
+  const definitions = input.definitions.map((definition) => {
+    const validated = validateDefinition(definition, input.currency);
+    const key = definitionKey(validated);
+    if (keys.has(key)) {
+      throw new PricingCatalogError(
+        'Pricing snapshot contains a normalized identity collision.',
+      );
+    }
+    if (ids.has(validated.id.toLowerCase())) {
+      throw new PricingCatalogError('Pricing definition ids must be unique.');
+    }
+    keys.add(key);
+    ids.add(validated.id.toLowerCase());
+    if (
+      Date.parse(validated.provenance.retrieved_at) >
+      Date.parse(input.reviewed_at)
+    ) {
+      throw new PricingCatalogError(
+        'Pricing definitions cannot be retrieved after the snapshot review.',
+      );
+    }
+    return validated;
+  });
+  return ownFrozen({ ...input, definitions });
+}
+
+export function pricingSnapshotPayload(input: PricingSnapshotInput): unknown {
+  const { fingerprint: _fingerprint, ...payload } = input;
+  return {
+    ...payload,
+    definitions: [...payload.definitions]
+      .sort((left, right) => compareCanonicalStrings(left.id, right.id))
+      .map((definition) => ({
+        ...definition,
+        expected_units: [...definition.expected_units].sort(
+          compareCanonicalStrings,
+        ),
+        missing_units: [...definition.missing_units].sort(
+          compareCanonicalStrings,
+        ),
+        rates: [...definition.rates].sort((left, right) =>
+          compareCanonicalStrings(left.unit, right.unit),
+        ),
+      })),
+  };
+}
+
+export function pricingSnapshotFingerprint(
+  input: PricingSnapshotInput,
+): string {
+  const bytes = new TextEncoder().encode(
+    canonicalJson(pricingSnapshotPayload(input)),
+  );
+  return `sha256:${sha256Hex(bytes)}`;
+}
+
+export function priceDefinitionFingerprint(
+  input: PriceDefinitionInput,
+): string {
+  const bytes = new TextEncoder().encode(
+    canonicalJson({
+      ...input,
+      expected_units: [...input.expected_units].sort(compareCanonicalStrings),
+      missing_units: [...input.missing_units].sort(compareCanonicalStrings),
+      rates: [...input.rates].sort((left, right) =>
+        compareCanonicalStrings(left.unit, right.unit),
+      ),
+    }),
+  );
+  return `sha256:${sha256Hex(bytes)}`;
+}
+
+export function verifyPricingSnapshotFingerprint(
+  input: PricingSnapshotInput,
+): void {
+  const actual = pricingSnapshotFingerprint(input);
+  if (actual !== input.fingerprint) {
+    throw new PricingCatalogError(
+      'Pricing snapshot fingerprint does not match its content.',
+    );
+  }
+}
+
+export function assertPricingSnapshotFresh(
+  input: PricingSnapshotInput,
+  now: string,
+  maximumAgeMs: number,
+): void {
+  const reviewedAt = Date.parse(input.reviewed_at);
+  const nowAt = Date.parse(now);
+  if (
+    !Number.isFinite(nowAt) ||
+    !now.endsWith('Z') ||
+    !Number.isSafeInteger(maximumAgeMs) ||
+    maximumAgeMs < 0
+  ) {
+    throw new PricingCatalogError('Invalid pricing freshness boundary.');
+  }
+  if (reviewedAt > nowAt) {
+    throw new PricingCatalogError(
+      'Pricing snapshot review time is in the future.',
+    );
+  }
+  if (nowAt - reviewedAt > maximumAgeMs) {
+    throw new PricingCatalogError(
+      'Pricing snapshot is stale for this freeze review.',
+    );
+  }
+}
+
+function requestedTarget(
+  identity: ProviderIdentity,
+): EffectivePricingIdentity | undefined {
+  const target = identity.target.underlying ?? identity.target.primary;
+  return target.target_id && target.kind
+    ? {
+        provider_id: identity.provider_id,
+        kind: target.kind,
+        target_id: target.target_id,
+      }
+    : undefined;
+}
+
+function matchesDefinition(
+  definition: PriceDefinitionInput,
+  lookup: PricingLookup,
+): boolean {
+  if (
+    definition.provider_id.toLowerCase() !==
+      lookup.requested_identity.provider_id.toLowerCase() ||
+    definition.profile_id.toLowerCase() !==
+      lookup.requested_identity.profile_id.toLowerCase()
+  ) {
+    return false;
+  }
+  const effective =
+    lookup.effective_identity ?? requestedTarget(lookup.requested_identity);
+  if (definition.effective_target) {
+    if (
+      !effective ||
+      effective.provider_id.toLowerCase() !==
+        (
+          definition.effective_target.provider_id ?? definition.provider_id
+        ).toLowerCase() ||
+      effective.kind !== definition.effective_target.kind ||
+      effective.target_id?.toLowerCase() !==
+        definition.effective_target.target_id.toLowerCase()
+    ) {
+      return false;
+    }
+  }
+  return (
+    canonicalJson(canonicalConditions(definition.conditions, 'conditions')) ===
+    canonicalJson(canonicalConditions(lookup.conditions, 'conditions'))
+  );
+}
+
+function sourcePriority(
+  source: PricingProvenanceInput['source_class'],
+): number {
+  return source === 'configured_account_rate'
+    ? 2
+    : source === 'frozen_official_snapshot'
+      ? 3
+      : 4;
+}
+
+export class PricingCatalog {
+  readonly snapshot: PricingSnapshotInput;
+  readonly configured_definitions: readonly PriceDefinitionInput[];
+
+  constructor(
+    snapshot: PricingSnapshotInput,
+    configuredDefinitions: readonly PriceDefinitionInput[] = [],
+  ) {
+    this.snapshot = validatePricingSnapshot(snapshot);
+    verifyPricingSnapshotFingerprint(this.snapshot);
+    const configuredKeys = new Set<string>();
+    this.configured_definitions = ownFrozen(
+      configuredDefinitions.map((definition) => {
+        if (definition.provenance.source_class !== 'configured_account_rate') {
+          throw new PricingCatalogError(
+            'Runtime pricing overrides must be explicit configured account rates.',
+          );
+        }
+        const validated = validateDefinition(definition, snapshot.currency);
+        const key = definitionKey(validated);
+        if (configuredKeys.has(key)) {
+          throw new PricingCatalogError(
+            'Configured pricing contains a normalized identity collision.',
+          );
+        }
+        configuredKeys.add(key);
+        return validated;
+      }),
+    );
+  }
+
+  definition(lookup: PricingLookup): PriceDefinitionInput | undefined {
+    return [...this.configured_definitions, ...this.snapshot.definitions]
+      .filter((definition) => matchesDefinition(definition, lookup))
+      .sort((left, right) => {
+        const priority =
+          sourcePriority(left.provenance.source_class) -
+          sourcePriority(right.provenance.source_class);
+        return priority || compareCanonicalStrings(left.id, right.id);
+      })[0];
+  }
+
+  quote(lookup: PricingLookup): PricingQuote {
+    const resolvedEffective =
+      lookup.effective_identity ?? requestedTarget(lookup.requested_identity);
+    const definition = this.definition(lookup);
+    if (!definition) {
+      return ownFrozen({
+        status: 'unavailable',
+        currency: this.snapshot.currency,
+        expected_units: [],
+        billable_quantities: {},
+        missing_units: [],
+        unknown_reason:
+          'No frozen price definition matches the exact profile, effective target, and billing conditions.',
+        confidence: 'unknown',
+        requested_identity: lookup.requested_identity,
+        ...(resolvedEffective && {
+          effective_identity: resolvedEffective,
+        }),
+        snapshot_version: this.snapshot.version,
+        snapshot_fingerprint: this.snapshot.fingerprint,
+      });
+    }
+
+    const quantities = new Map<NormalizedBillableUnit, Decimal>();
+    const quantityInputs =
+      lookup.quantity_source === 'provider_reported'
+        ? {
+            ...(definition.fixed_quantities ?? {}),
+            ...(lookup.quantities ?? {}),
+          }
+        : {
+            ...(lookup.quantities ?? {}),
+            ...(definition.fixed_quantities ?? {}),
+          };
+    for (const [unit, value] of Object.entries(quantityInputs)) {
+      if (value === undefined) continue;
+      quantities.set(
+        canonicalUnit(unit, 'quantity unit'),
+        parseDecimal(value, `quantities.${unit}`),
+      );
+    }
+    const rates = new Map(definition.rates.map((rate) => [rate.unit, rate]));
+    let total: Decimal = { coefficient: 0n, scale: 0 };
+    let priced = false;
+    const missing = new Set<NormalizedBillableUnit>(definition.missing_units);
+    for (const [unit, quantity] of quantities) {
+      if (
+        quantity.coefficient > 0n &&
+        !definition.expected_units.includes(unit)
+      ) {
+        missing.add(unit);
+      }
+    }
+    for (const unit of definition.expected_units) {
+      const quantity = quantities.get(unit);
+      const rate = rates.get(unit);
+      if (!quantity || !rate) {
+        missing.add(unit);
+        continue;
+      }
+      if (quantity.coefficient === 0n) continue;
+      total = decimalAdd(
+        total,
+        exactRateCost(
+          quantity,
+          positiveDecimal(rate.amount_decimal, `${rate.unit}.amount_decimal`),
+          positiveDecimal(rate.per_decimal, `${rate.unit}.per_decimal`),
+        ),
+      );
+      priced = true;
+    }
+    const missingUnits = [...missing].sort(compareCanonicalStrings);
+    const complete =
+      definition.completeness === 'complete' && missingUnits.length === 0;
+    const amount = decimalText(total);
+    const provenance: PricingProvenance = {
+      ...definition.provenance,
+      currency: definition.currency,
+      definition_fingerprint: priceDefinitionFingerprint(definition),
+      snapshot_version: this.snapshot.version,
+      snapshot_fingerprint: this.snapshot.fingerprint,
+      conditions: canonicalConditions(definition.conditions, 'conditions'),
+    };
+    return ownFrozen({
+      status: complete
+        ? 'complete'
+        : definition.completeness === 'unavailable'
+          ? 'unavailable'
+          : 'partial',
+      ...((priced || complete) && {
+        amount_decimal: amount,
+        known_minimum_decimal: amount,
+      }),
+      ...(complete && { known_maximum_decimal: amount }),
+      currency: definition.currency,
+      expected_units: [
+        ...new Set([...definition.expected_units, ...missingUnits]),
+      ].sort(compareCanonicalStrings),
+      billable_quantities: Object.fromEntries(
+        [...quantities.entries()].map(([unit, quantity]) => [
+          unit,
+          decimalText(quantity),
+        ]),
+      ),
+      missing_units: missingUnits,
+      ...(!complete && {
+        unknown_reason:
+          definition.unknown_reason ??
+          'One or more expected billable quantities are unknown.',
+      }),
+      confidence: definition.confidence,
+      requested_identity: lookup.requested_identity,
+      ...(resolvedEffective && {
+        effective_identity: resolvedEffective,
+      }),
+      snapshot_version: this.snapshot.version,
+      snapshot_fingerprint: this.snapshot.fingerprint,
+      provenance,
+    });
+  }
+
+  actual(input: ActualCostInput): ResolvedActualCost | undefined {
+    const reported = input.provider_reported_actual;
+    if (reported) {
+      const amount = decimalText(
+        parseDecimal(
+          reported.amount_decimal,
+          'provider_reported_actual.amount_decimal',
+        ),
+      );
+      if (reported.currency !== this.snapshot.currency) {
+        throw new PricingCatalogError(
+          'Provider-reported cost currency does not match the catalog.',
+        );
+      }
+      canonicalTimestamp(
+        reported.observed_at,
+        'provider_reported_actual.observed_at',
+      );
+      if (!SOURCE_REFERENCE_PATTERN.test(reported.source_reference)) {
+        throw new PricingCatalogError(
+          'Provider actual source reference is not redacted.',
+        );
+      }
+      return ownFrozen({
+        amount_decimal: amount,
+        currency: reported.currency,
+        source: 'provider_reported',
+        source_class: 'provider_reported_actual',
+        requested_identity: input.requested_identity,
+        ...((input.effective_identity ??
+          requestedTarget(input.requested_identity)) && {
+          effective_identity:
+            input.effective_identity ??
+            requestedTarget(input.requested_identity),
+        }),
+        provenance: {
+          currency: reported.currency,
+          source_class: 'provider_reported_actual',
+          observed_at: reported.observed_at,
+          ...(reported.source_reference && {
+            source_reference: reported.source_reference,
+          }),
+          snapshot_version: this.snapshot.version,
+          snapshot_fingerprint: this.snapshot.fingerprint,
+          conditions: canonicalConditions(input.conditions, 'conditions'),
+        },
+      });
+    }
+    if (!input.provider_reported_units) return undefined;
+    const quote = this.quote({
+      requested_identity: input.requested_identity,
+      effective_identity: input.effective_identity,
+      conditions: input.conditions,
+      quantities: input.provider_reported_units,
+      quantity_source: 'provider_reported',
+    });
+    if (quote.status !== 'complete' || quote.amount_decimal === undefined) {
+      return undefined;
+    }
+    const units = Object.keys(input.provider_reported_units);
+    const source: ComputedActualSource = units.every(
+      (unit) => unit === 'credits',
+    )
+      ? 'computed_from_credits'
+      : units.some((unit) => unit.endsWith('_tokens'))
+        ? 'computed_from_tokens'
+        : 'computed_from_request';
+    return ownFrozen({
+      amount_decimal: quote.amount_decimal,
+      currency: quote.currency,
+      source,
+      source_class: quote.provenance?.source_class ?? 'unknown',
+      requested_identity: quote.requested_identity,
+      ...(quote.effective_identity && {
+        effective_identity: quote.effective_identity,
+      }),
+      provenance: quote.provenance as PricingProvenance,
+      quote,
+    });
+  }
+}
+
+/** Explicit USD-to-canonical-budget boundary. No other pricing path rounds. */
+export function usdDecimalToMicrousd(
+  amountDecimal: string,
+  rounding: 'ceil' | 'floor' | 'reject' = 'reject',
+): string {
+  const amount = parseDecimal(amountDecimal, 'amount_decimal');
+  if (amount.scale <= 6) {
+    return (amount.coefficient * 10n ** BigInt(6 - amount.scale)).toString();
+  }
+  const divisor = 10n ** BigInt(amount.scale - 6);
+  const quotient = amount.coefficient / divisor;
+  const remainder = amount.coefficient % divisor;
+  if (remainder === 0n || rounding === 'floor') return quotient.toString();
+  if (rounding === 'ceil') return (quotient + 1n).toString();
+  throw new PricingCatalogError(
+    'USD amount requires explicit rounding at the microusd budget boundary.',
+  );
+}
+
+export function budgetEstimateFromQuote(quote: PricingQuote):
+  | {
+      readonly estimated_cost_microusd: string;
+      readonly billable_units: readonly { unit: string; quantity: string }[];
+    }
+  | undefined {
+  if (
+    quote.status !== 'complete' ||
+    quote.currency !== 'USD' ||
+    quote.known_maximum_decimal === undefined
+  ) {
+    return undefined;
+  }
+  const definitionQuantities = Object.entries(quote.billable_quantities)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([unit, quantity]) => ({ unit, quantity }));
+  // The accepted terminal contract permits snake-case units only. Keep
+  // namespaced provider units private and fail closed instead of widening the
+  // shared TypeScript/PHP interchange contract for pricing.
+  if (
+    definitionQuantities.some(
+      ({ unit }) => !/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/.test(unit),
+    )
+  ) {
+    return undefined;
+  }
+  return ownFrozen({
+    estimated_cost_microusd: usdDecimalToMicrousd(
+      quote.known_maximum_decimal,
+      'ceil',
+    ),
+    billable_units: definitionQuantities,
+  });
+}

--- a/src/core/profile-catalog.ts
+++ b/src/core/profile-catalog.ts
@@ -27,6 +27,12 @@ import type {
   PlanningProfile,
 } from './execution-plan.js';
 import {
+  budgetEstimateFromQuote,
+  type PriceDefinitionInput,
+  PricingCatalog,
+} from './pricing.js';
+import { BUILTIN_PRICING_SNAPSHOT } from './pricing-snapshot.js';
+import {
   buildProfileBindings,
   type ProfileBinding,
 } from './profile-bindings.js';
@@ -99,12 +105,16 @@ export interface CatalogProviderConfig {
   readonly enabled?: boolean;
   readonly model?: string;
   readonly options?: Readonly<Record<string, unknown>>;
+  /** Exact non-secret account/region/billing facts used only for price matching. */
+  readonly pricingConditions?: Readonly<Record<string, string>>;
 }
 
 export interface ProviderCatalogOptions {
   readonly catalog?: readonly ProviderCatalogEntry[];
   /** v1 provider configuration, keyed by adapter id. */
   readonly providerConfigs?: Readonly<Record<string, CatalogProviderConfig>>;
+  /** Reviewed exact account rates. These override the frozen official snapshot. */
+  readonly configuredPricing?: readonly PriceDefinitionInput[];
   readonly credentials?: CredentialContext;
   /**
    * Admission can validate request and configuration semantics before a Node
@@ -196,6 +206,7 @@ function resolveDeclaration(
   declaration: ExecutableProfileDeclaration,
   binding: ProfileBinding | undefined,
   options: ProviderCatalogOptions,
+  pricing: PricingCatalog,
 ): ResolvedCatalogProfile {
   const declared = declaredExecutionProfile(entry.provider_id, declaration);
   const reasons: string[] = [];
@@ -232,7 +243,6 @@ function resolveDeclaration(
     : true;
 
   let profile = declared;
-  let estimate: NetworkFreeEstimate | undefined;
   let configurationValid = true;
   try {
     // The whole provider config is handed over, not just `options`: the
@@ -246,10 +256,18 @@ function resolveDeclaration(
       options: providerConfig?.options ?? {},
     });
     profile = resolution.profile;
-    estimate = resolution.estimate;
   } catch {
     configurationValid = false;
   }
+
+  const quote = pricing.quote({
+    requested_identity: profile.identity,
+    ...(providerConfig?.pricingConditions && {
+      conditions: providerConfig.pricingConditions,
+    }),
+  });
+  const estimate: NetworkFreeEstimate | undefined =
+    budgetEstimateFromQuote(quote);
 
   if (!enabled) reasons.push('profile_disabled');
   if (!credentialValid) reasons.push('credential_missing');
@@ -335,6 +353,10 @@ function resolveCustomProfile(
 export function buildProviderCatalog(
   options: ProviderCatalogOptions = {},
 ): ProviderCatalog {
+  const pricing = new PricingCatalog(
+    BUILTIN_PRICING_SNAPSHOT,
+    options.configuredPricing,
+  );
   const entries = options.catalog ?? BUILTIN_PROVIDER_CATALOG;
   const refs = catalogProfileRefs(entries);
 
@@ -469,6 +491,7 @@ export function buildProviderCatalog(
           catalogProfileKey(entry.provider_id, declaration.profile_id),
         ),
         options,
+        pricing,
       ),
     ),
     ...customProfiles.map((custom, index) =>
@@ -766,6 +789,11 @@ export function buildProviderCatalog(
   );
   const digest = catalogFingerprint({
     revision,
+    pricing: {
+      snapshot_version: pricing.snapshot.version,
+      snapshot_fingerprint: pricing.snapshot.fingerprint,
+      configured_definitions: pricing.configured_definitions,
+    },
     custom_profiles: customProfiles,
     profiles: planningProfiles,
     workflows: BUILTIN_WORKFLOW_IDS.map((id) => ({

--- a/tests/pricing-snapshot-workflow.test.ts
+++ b/tests/pricing-snapshot-workflow.test.ts
@@ -1,0 +1,185 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type PricingSnapshotInput,
+  verifyPricingSnapshotFingerprint,
+} from '../src/core/pricing.js';
+import { BUILTIN_PRICING_SNAPSHOT } from '../src/core/pricing-snapshot.js';
+import { buildProviderCatalog } from '../src/core/profile-catalog.js';
+
+const createdDirectories: string[] = [];
+const workflow = join(process.cwd(), 'scripts/pricing-snapshot.mjs');
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'librarium-pricing-'));
+  createdDirectories.push(directory);
+  return directory;
+}
+
+function run(...arguments_: string[]) {
+  return spawnSync(process.execPath, [workflow, ...arguments_], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('offline pricing snapshot workflow', () => {
+  it('stages, explicitly reviews, and freezes the same immutable snapshot', async () => {
+    const directory = await temporaryDirectory();
+    const input = join(directory, 'input.json');
+    const candidate = join(directory, 'candidate.json');
+    const receipt = join(directory, 'review.json');
+    const frozen = join(directory, 'frozen.json');
+    const unfingerprinted = { ...BUILTIN_PRICING_SNAPSHOT, fingerprint: '' };
+    await writeFile(input, JSON.stringify(unfingerprinted), 'utf8');
+
+    expect(run('sync', '--input', input, '--output', candidate).status).toBe(0);
+    expect(
+      run(
+        'review',
+        '--input',
+        candidate,
+        '--output',
+        receipt,
+        '--reviewer',
+        'pricing-review',
+      ).status,
+    ).toBe(0);
+    expect(
+      run(
+        'freeze',
+        '--input',
+        candidate,
+        '--output',
+        frozen,
+        '--review',
+        receipt,
+      ).status,
+    ).toBe(0);
+
+    const result = JSON.parse(
+      await readFile(frozen, 'utf8'),
+    ) as PricingSnapshotInput;
+    expect(result.fingerprint).toBe(BUILTIN_PRICING_SNAPSHOT.fingerprint);
+    expect(() => verifyPricingSnapshotFingerprint(result)).not.toThrow();
+  });
+
+  it('rejects remote inputs and a review receipt for different content', async () => {
+    const remote = run(
+      'sync',
+      '--input',
+      'https://example.com/pricing.json',
+      '--output',
+      'candidate.json',
+    );
+    expect(remote.status).not.toBe(0);
+    expect(remote.stderr).toContain('remote inputs are denied');
+
+    const directory = await temporaryDirectory();
+    const candidate = join(directory, 'candidate.json');
+    const receipt = join(directory, 'review.json');
+    const frozen = join(directory, 'frozen.json');
+    await writeFile(
+      candidate,
+      JSON.stringify(BUILTIN_PRICING_SNAPSHOT),
+      'utf8',
+    );
+    await writeFile(
+      receipt,
+      JSON.stringify({
+        schema_version: 1,
+        decision: 'approved',
+        reviewer: 'pricing-review',
+        reviewed_at: '2026-08-13T00:00:00.000Z',
+        snapshot_version: BUILTIN_PRICING_SNAPSHOT.version,
+        snapshot_fingerprint: `sha256:${'f'.repeat(64)}`,
+      }),
+      'utf8',
+    );
+
+    const mismatch = run(
+      'freeze',
+      '--input',
+      candidate,
+      '--output',
+      frozen,
+      '--review',
+      receipt,
+    );
+    expect(mismatch.status).not.toBe(0);
+    expect(mismatch.stderr).toContain('does not match');
+  });
+
+  it.each([
+    ['non-object snapshot', []],
+    [
+      'unknown snapshot field',
+      { ...BUILTIN_PRICING_SNAPSHOT, unexpected: true },
+    ],
+    [
+      'malformed definition shape',
+      {
+        ...BUILTIN_PRICING_SNAPSHOT,
+        definitions: [
+          {
+            ...BUILTIN_PRICING_SNAPSHOT.definitions[0],
+            rates: 'not-an-array',
+          },
+        ],
+      },
+    ],
+    [
+      'invalid runtime enum',
+      {
+        ...BUILTIN_PRICING_SNAPSHOT,
+        definitions: [
+          {
+            ...BUILTIN_PRICING_SNAPSHOT.definitions[0],
+            completeness: 'free',
+          },
+        ],
+      },
+    ],
+    [
+      'oversized unit collection',
+      {
+        ...BUILTIN_PRICING_SNAPSHOT,
+        definitions: [
+          {
+            ...BUILTIN_PRICING_SNAPSHOT.definitions[0],
+            expected_units: Array.from({ length: 65 }, () => 'requests'),
+          },
+        ],
+      },
+    ],
+  ])('rejects %s from candidate JSON', async (_label, value) => {
+    const directory = await temporaryDirectory();
+    const input = join(directory, 'input.json');
+    const candidate = join(directory, 'candidate.json');
+    await writeFile(input, JSON.stringify(value), 'utf8');
+
+    const result = run('sync', '--input', input, '--output', candidate);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).not.toBe('');
+  });
+
+  it('does not access the network during ordinary catalog resolution', () => {
+    const fetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('network denied'));
+    buildProviderCatalog();
+    expect(fetch).not.toHaveBeenCalled();
+    fetch.mockRestore();
+  });
+});

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,0 +1,652 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import type { ProviderIdentity } from '../src/contracts/domain/index.js';
+import { canonicalJson } from '../src/core/catalog-fingerprint.js';
+import {
+  assertPricingSnapshotFresh,
+  budgetEstimateFromQuote,
+  type PriceDefinitionInput,
+  PricingCatalog,
+  PricingCatalogError,
+  type PricingSnapshotInput,
+  priceDefinitionFingerprint,
+  pricingSnapshotFingerprint,
+  pricingSnapshotPayload,
+  usdDecimalToMicrousd,
+  validatePricingSnapshot,
+  verifyPricingSnapshotFingerprint,
+} from '../src/core/pricing.js';
+import { BUILTIN_PRICING_SNAPSHOT } from '../src/core/pricing-snapshot.js';
+import { BUILTIN_PROFILE_BINDING_SPECS } from '../src/core/profile-bindings.js';
+
+const NOW = '2026-08-13T00:00:00.000Z';
+
+function identity(
+  providerId = 'test-provider',
+  profileId = 'chat',
+  targetId = 'model-a',
+): ProviderIdentity {
+  return {
+    provider_id: providerId,
+    profile_id: profileId,
+    target: {
+      primary: {
+        model_selection: 'configurable',
+        kind: 'model',
+        target_id: targetId,
+      },
+    },
+  };
+}
+
+function definition(
+  overrides: Partial<PriceDefinitionInput> = {},
+): PriceDefinitionInput {
+  return {
+    id: 'test-provider.chat.model-a',
+    provider_id: 'test-provider',
+    profile_id: 'chat',
+    effective_target: { kind: 'model', target_id: 'model-a' },
+    currency: 'USD',
+    completeness: 'complete',
+    confidence: 'confirmed',
+    expected_units: ['uncached_input_tokens', 'output_tokens'],
+    missing_units: [],
+    rates: [
+      {
+        unit: 'uncached_input_tokens',
+        amount_decimal: '0.3',
+        per_decimal: '1000000',
+      },
+      {
+        unit: 'output_tokens',
+        amount_decimal: '2.5',
+        per_decimal: '1000000',
+      },
+    ],
+    provenance: {
+      source_class: 'frozen_official_snapshot',
+      source_reference: 'official:example.com/pricing',
+      effective_at: NOW,
+      retrieved_at: NOW,
+    },
+    ...overrides,
+  };
+}
+
+function snapshot(
+  definitions: readonly PriceDefinitionInput[] = [definition()],
+  overrides: Partial<PricingSnapshotInput> = {},
+): PricingSnapshotInput {
+  const candidate: PricingSnapshotInput = {
+    schema_version: 1,
+    version: 'test.v1',
+    reviewed_at: NOW,
+    currency: 'USD',
+    fingerprint: `sha256:${'0'.repeat(64)}`,
+    definitions,
+    ...overrides,
+  };
+  return overrides.fingerprint === undefined
+    ? { ...candidate, fingerprint: pricingSnapshotFingerprint(candidate) }
+    : candidate;
+}
+
+describe('pricing snapshot validation', () => {
+  it('covers every implemented built-in profile exactly once', () => {
+    const bound = BUILTIN_PROFILE_BINDING_SPECS.map(
+      ({ provider_id, profile_id }) => `${provider_id}/${profile_id}`,
+    ).sort();
+    const priced = BUILTIN_PRICING_SNAPSHOT.definitions
+      .map(({ provider_id, profile_id }) => `${provider_id}/${profile_id}`)
+      .sort();
+
+    expect(priced).toEqual(bound);
+    expect(new Set(priced).size).toBe(42);
+    expect(
+      BUILTIN_PRICING_SNAPSHOT.definitions.every((entry) =>
+        ['complete', 'partial', 'unavailable'].includes(entry.completeness),
+      ),
+    ).toBe(true);
+  });
+
+  it.each(['-1', 'NaN', 'Infinity', '1e309', '', '1.'.padEnd(130, '0')])(
+    'rejects malformed, negative, nonfinite, or unsafe rates: %s',
+    (amount) => {
+      expect(() =>
+        validatePricingSnapshot(
+          snapshot([
+            definition({
+              rates: [
+                {
+                  unit: 'uncached_input_tokens',
+                  amount_decimal: amount,
+                  per_decimal: '1',
+                },
+                {
+                  unit: 'output_tokens',
+                  amount_decimal: '1',
+                  per_decimal: '1',
+                },
+              ],
+            }),
+          ]),
+        ),
+      ).toThrow(PricingCatalogError);
+    },
+  );
+
+  it('rejects zero divisors, mixed currency, malformed completeness, and unsafe units', () => {
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition({
+            rates: [
+              {
+                unit: 'uncached_input_tokens',
+                amount_decimal: '1',
+                per_decimal: '0',
+              },
+              {
+                unit: 'output_tokens',
+                amount_decimal: '1',
+                per_decimal: '1',
+              },
+            ],
+          }),
+        ]),
+      ),
+    ).toThrow('greater than zero');
+    expect(() =>
+      validatePricingSnapshot(snapshot([definition({ currency: 'EUR' })])),
+    ).toThrow('snapshot currency');
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition({
+            completeness: 'complete',
+            expected_units: [
+              'uncached_input_tokens',
+              'output_tokens',
+              'credits',
+            ],
+            missing_units: ['credits'],
+          }),
+        ]),
+      ),
+    ).toThrow('Complete definitions');
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition({
+            expected_units: ['unsafe unit'],
+            missing_units: ['unsafe unit'],
+            rates: [],
+            completeness: 'unavailable',
+            unknown_reason: 'No rate.',
+          }),
+        ]),
+      ),
+    ).toThrow('normalized unit');
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition({
+            rates: [
+              {
+                unit: 'uncached_input_tokens',
+                amount_decimal: '1',
+                per_decimal: '3',
+              },
+              definition().rates[1],
+            ],
+          }),
+        ]),
+      ),
+    ).toThrow('non-terminating');
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition({
+            rates: [
+              ...definition().rates,
+              { unit: 'credits', amount_decimal: '1', per_decimal: '1' },
+            ],
+          }),
+        ]),
+      ),
+    ).toThrow('expected units');
+  });
+
+  it('rejects normalized identity collisions and conflicting definitions', () => {
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition(),
+          definition({
+            id: 'duplicate',
+            provider_id: 'TEST-PROVIDER',
+            effective_target: { kind: 'model', target_id: 'MODEL-A' },
+          }),
+        ]),
+      ),
+    ).toThrow('normalized identity collision');
+  });
+
+  it('rejects credential-bearing, query-bearing, and local source references', () => {
+    for (const source_reference of [
+      'https://user:secret@example.com/pricing?token=secret',
+      'official:example.com/pricing?api_key=secret',
+      '/Users/private/pricing.json',
+    ]) {
+      expect(() =>
+        validatePricingSnapshot(
+          snapshot([
+            definition({
+              provenance: {
+                ...definition().provenance,
+                source_reference,
+              },
+            }),
+          ]),
+        ),
+      ).toThrow('redacted public identifiers');
+    }
+  });
+
+  it('detects stale, future, malformed, and fingerprint-drifted snapshots', async () => {
+    const valid = snapshot();
+    expect(() =>
+      assertPricingSnapshotFresh(valid, '2026-08-14T00:00:00.000Z', 86_400_000),
+    ).not.toThrow();
+    expect(() =>
+      assertPricingSnapshotFresh(valid, '2026-08-14T00:00:00.001Z', 86_400_000),
+    ).toThrow('stale');
+    expect(() =>
+      assertPricingSnapshotFresh(valid, '2026-08-12T00:00:00.000Z', 86_400_000),
+    ).toThrow('future');
+    expect(() =>
+      validatePricingSnapshot(snapshot([], { reviewed_at: 'not-a-date' })),
+    ).toThrow();
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot(undefined, { reviewed_at: '2026-02-31T00:00:00.000Z' }),
+      ),
+    ).toThrow('real RFC 3339');
+    expect(() =>
+      validatePricingSnapshot(
+        snapshot([
+          definition({
+            provenance: {
+              ...definition().provenance,
+              retrieved_at: '2026-08-14T00:00:00.000Z',
+            },
+          }),
+        ]),
+      ),
+    ).toThrow('after the snapshot review');
+    const fingerprintDrifted = { ...valid, version: '2026-08-13-drifted' };
+    expect(() => verifyPricingSnapshotFingerprint(fingerprintDrifted)).toThrow(
+      'does not match',
+    );
+  });
+
+  it('has a stable order-independent SHA-256 fingerprint and detects price drift', async () => {
+    const original = snapshot();
+    const reordered = snapshot([
+      {
+        ...definition(),
+        expected_units: ['output_tokens', 'uncached_input_tokens'],
+        rates: [...definition().rates].reverse(),
+      },
+    ]);
+    const drifted = snapshot([
+      {
+        ...definition(),
+        rates: [
+          { ...definition().rates[0], amount_decimal: '0.300001' },
+          definition().rates[1],
+        ],
+      },
+    ]);
+
+    expect(pricingSnapshotFingerprint(original)).toBe(
+      pricingSnapshotFingerprint(reordered),
+    );
+    expect(pricingSnapshotFingerprint(drifted)).not.toBe(
+      pricingSnapshotFingerprint(original),
+    );
+    expect(priceDefinitionFingerprint(definition())).toBe(
+      priceDefinitionFingerprint({
+        ...definition(),
+        expected_units: [...definition().expected_units].reverse(),
+        rates: [...definition().rates].reverse(),
+      }),
+    );
+  });
+
+  it('pins and verifies the reviewed built-in fingerprint', async () => {
+    expect(BUILTIN_PRICING_SNAPSHOT.fingerprint).toBe(
+      'sha256:0a12e0c17f3d42ba5f4ba99ac919304d99f8b2e6bad48686cca8f582cb9dd00f',
+    );
+    expect(pricingSnapshotFingerprint(BUILTIN_PRICING_SNAPSHOT)).toBe(
+      'sha256:0a12e0c17f3d42ba5f4ba99ac919304d99f8b2e6bad48686cca8f582cb9dd00f',
+    );
+    expect(
+      `sha256:${createHash('sha256')
+        .update(canonicalJson(pricingSnapshotPayload(BUILTIN_PRICING_SNAPSHOT)))
+        .digest('hex')}`,
+    ).toBe(BUILTIN_PRICING_SNAPSHOT.fingerprint);
+    expect(() =>
+      verifyPricingSnapshotFingerprint(BUILTIN_PRICING_SNAPSHOT),
+    ).not.toThrow();
+  });
+});
+
+describe('exact pricing and quotes', () => {
+  it('calculates exact token costs without floating point arithmetic', () => {
+    const quote = new PricingCatalog(snapshot()).quote({
+      requested_identity: identity(),
+      quantities: {
+        uncached_input_tokens: '1000001',
+        output_tokens: '3',
+      },
+    });
+
+    expect(quote).toMatchObject({
+      status: 'complete',
+      amount_decimal: '0.3000078',
+      known_minimum_decimal: '0.3000078',
+      known_maximum_decimal: '0.3000078',
+      missing_units: [],
+    });
+    expect(budgetEstimateFromQuote(quote)?.estimated_cost_microusd).toBe(
+      '300008',
+    );
+  });
+
+  it('rounds only at the explicit microusd boundary', () => {
+    expect(usdDecimalToMicrousd('0.000001')).toBe('1');
+    expect(() => usdDecimalToMicrousd('0.0000001')).toThrow(
+      'explicit rounding',
+    );
+    expect(usdDecimalToMicrousd('0.0000001', 'ceil')).toBe('1');
+    expect(usdDecimalToMicrousd('0.0000009', 'floor')).toBe('0');
+  });
+
+  it('does not let estimate input reduce a frozen fixed quantity', () => {
+    const fixed = definition({
+      expected_units: ['requests'],
+      fixed_quantities: { requests: '2' },
+      rates: [{ unit: 'requests', amount_decimal: '0.004', per_decimal: '1' }],
+    });
+    const catalog = new PricingCatalog(snapshot([fixed]));
+    const estimate = catalog.quote({
+      requested_identity: identity(),
+      quantities: { requests: '1' },
+    });
+    const actual = catalog.quote({
+      requested_identity: identity(),
+      quantities: { requests: '1' },
+      quantity_source: 'provider_reported',
+    });
+
+    expect(estimate.amount_decimal).toBe('0.008');
+    expect(estimate.billable_quantities.requests).toBe('2');
+    expect(actual.amount_decimal).toBe('0.004');
+    expect(actual.billable_quantities.requests).toBe('1');
+  });
+
+  it('exposes complete, partial, and unavailable states and never maps unknown to zero', () => {
+    const catalog = new PricingCatalog(snapshot());
+    const partial = catalog.quote({
+      requested_identity: identity(),
+      quantities: { uncached_input_tokens: '10' },
+    });
+    const unavailable = catalog.quote({
+      requested_identity: identity('other-provider'),
+    });
+
+    expect(partial).toMatchObject({
+      status: 'partial',
+      amount_decimal: '0.000003',
+      known_minimum_decimal: '0.000003',
+      missing_units: ['output_tokens'],
+    });
+    expect(partial.known_maximum_decimal).toBeUndefined();
+    expect(budgetEstimateFromQuote(partial)).toBeUndefined();
+    expect(unavailable).toMatchObject({
+      status: 'unavailable',
+      confidence: 'unknown',
+    });
+    expect(unavailable.amount_decimal).toBeUndefined();
+    expect(budgetEstimateFromQuote(unavailable)).toBeUndefined();
+
+    const unexpectedUnit = catalog.quote({
+      requested_identity: identity(),
+      quantities: {
+        uncached_input_tokens: '10',
+        output_tokens: '10',
+        credits: '1',
+      },
+    });
+    expect(unexpectedUnit).toMatchObject({
+      status: 'partial',
+      missing_units: ['credits'],
+    });
+    expect(budgetEstimateFromQuote(unexpectedUnit)).toBeUndefined();
+
+    const zero = catalog.quote({
+      requested_identity: identity(),
+      quantities: { uncached_input_tokens: '0', output_tokens: '0' },
+    });
+    expect(zero).toMatchObject({
+      status: 'complete',
+      amount_decimal: '0',
+      known_minimum_decimal: '0',
+      known_maximum_decimal: '0',
+    });
+  });
+
+  it('prices the effective routed identity while preserving the requested identity', () => {
+    const requested = identity('test-provider', 'chat', 'router');
+    const catalog = new PricingCatalog(
+      snapshot([
+        definition(),
+        definition({
+          id: 'test-provider.chat.model-b',
+          effective_target: { kind: 'model', target_id: 'model-b' },
+          rates: definition().rates.map((entry) => ({
+            ...entry,
+            amount_decimal: entry.unit === 'uncached_input_tokens' ? '1' : '10',
+          })),
+        }),
+      ]),
+    );
+    const quote = catalog.quote({
+      requested_identity: requested,
+      effective_identity: {
+        provider_id: 'test-provider',
+        kind: 'model',
+        target_id: 'model-b',
+      },
+      quantities: {
+        uncached_input_tokens: '1000000',
+        output_tokens: '1000000',
+      },
+    });
+
+    expect(quote.amount_decimal).toBe('11');
+    expect(quote.requested_identity).toEqual(requested);
+    expect(quote.effective_identity?.target_id).toBe('model-b');
+  });
+
+  it('matches cross-provider effective routing and emits inferred effective identity', () => {
+    const routed = definition({
+      effective_target: {
+        provider_id: 'downstream-provider',
+        kind: 'model',
+        target_id: 'model-b',
+      },
+    });
+    const catalog = new PricingCatalog(snapshot([routed]));
+    const quote = catalog.quote({
+      requested_identity: identity(),
+      effective_identity: {
+        provider_id: 'downstream-provider',
+        kind: 'model',
+        target_id: 'model-b',
+      },
+      quantities: {
+        uncached_input_tokens: '1',
+        output_tokens: '1',
+      },
+    });
+    expect(quote.status).toBe('complete');
+    expect(quote.effective_identity?.provider_id).toBe('downstream-provider');
+
+    const inferred = new PricingCatalog(snapshot()).quote({
+      requested_identity: identity(),
+      quantities: {
+        uncached_input_tokens: '1',
+        output_tokens: '1',
+      },
+    });
+    expect(inferred.effective_identity).toMatchObject({
+      provider_id: 'test-provider',
+      target_id: 'model-a',
+    });
+  });
+
+  it('prevents cache double billing and includes tool, search, media, and research surcharges', () => {
+    const expected = [
+      'uncached_input_tokens',
+      'cache_read_tokens',
+      'output_tokens',
+      'searches',
+      'tool_calls',
+      'images',
+      'audio_seconds',
+      'research_requests',
+      'vendor:premium_results',
+    ] as const;
+    const rates = expected.map((unit) => ({
+      unit,
+      amount_decimal: unit === 'uncached_input_tokens' ? '2' : '1',
+      per_decimal: '1',
+    }));
+    const quote = new PricingCatalog(
+      snapshot([
+        definition({ expected_units: expected, rates, missing_units: [] }),
+      ]),
+    ).quote({
+      requested_identity: identity(),
+      quantities: {
+        // Uncached and cache-read units are disjoint; total input is never billed.
+        uncached_input_tokens: '2',
+        cache_read_tokens: '3',
+        output_tokens: '1',
+        searches: '1',
+        tool_calls: '1',
+        images: '1',
+        audio_seconds: '1',
+        research_requests: '1',
+        'vendor:premium_results': '1',
+      },
+    });
+
+    expect(quote.status).toBe('complete');
+    expect(quote.amount_decimal).toBe('14');
+  });
+
+  it('uses configured account rates before official and reviewed fallback rates', () => {
+    const official = definition();
+    const fallback = definition({
+      id: 'fallback',
+      provenance: {
+        ...official.provenance,
+        source_class: 'frozen_reviewed_fallback',
+        source_reference: 'reviewed:example.com/fallback',
+      },
+    });
+    const configured = definition({
+      id: 'configured',
+      provenance: {
+        ...official.provenance,
+        source_class: 'configured_account_rate',
+        source_reference: 'configured:account/rate-card',
+      },
+      rates: official.rates.map((entry) => ({
+        ...entry,
+        amount_decimal: '5',
+      })),
+    });
+    const catalog = new PricingCatalog(snapshot([fallback, official]), [
+      configured,
+    ]);
+    const quote = catalog.quote({
+      requested_identity: identity(),
+      quantities: {
+        uncached_input_tokens: '1',
+        output_tokens: '1',
+      },
+    });
+
+    expect(quote.provenance?.source_class).toBe('configured_account_rate');
+    expect(quote.amount_decimal).toBe('0.00001');
+    expect(quote.provenance?.definition_fingerprint).toBe(
+      priceDefinitionFingerprint(configured),
+    );
+    expect(quote.provenance?.definition_fingerprint).not.toBe(
+      priceDefinitionFingerprint(official),
+    );
+  });
+
+  it('keeps provider-reported actual above computed actual and labels computation truthfully', () => {
+    const catalog = new PricingCatalog(snapshot());
+    const lookup = {
+      requested_identity: identity(),
+      provider_reported_units: {
+        uncached_input_tokens: '1000000',
+        output_tokens: '1000000',
+      },
+    } as const;
+    expect(catalog.actual(lookup)).toMatchObject({
+      amount_decimal: '2.8',
+      source: 'computed_from_tokens',
+      source_class: 'frozen_official_snapshot',
+      requested_identity: identity(),
+      provenance: {
+        snapshot_fingerprint: expect.stringMatching(/^sha256:/),
+      },
+    });
+    expect(
+      catalog.actual({
+        ...lookup,
+        provider_reported_actual: {
+          amount_decimal: '1.234',
+          currency: 'USD',
+          observed_at: NOW,
+          source_reference: 'provider:example.com/usage',
+        },
+      }),
+    ).toMatchObject({
+      amount_decimal: '1.234',
+      source: 'provider_reported',
+      source_class: 'provider_reported_actual',
+      requested_identity: identity(),
+      provenance: {
+        observed_at: NOW,
+        source_reference: 'provider:example.com/usage',
+      },
+    });
+  });
+
+  it('freezes catalog inputs and keeps canonical output deterministic', () => {
+    const mutable = snapshot();
+    const catalog = new PricingCatalog(mutable);
+    expect(Object.isFrozen(catalog.snapshot)).toBe(true);
+    expect(Object.isFrozen(catalog.snapshot.definitions[0])).toBe(true);
+    expect(canonicalJson(catalog.snapshot)).toBe(canonicalJson(snapshot()));
+  });
+});

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -1272,30 +1272,39 @@ describe('provider catalog -- configuration-driven resolution', () => {
 describe('provider catalog -- network-free estimates', () => {
   const built = catalog();
 
-  it('records exact plan prices as microusd integers', () => {
-    expect(built.get('you-answer', 'grounded')?.estimate).toEqual({
-      estimated_cost_microusd: '5000',
-      billable_units: [{ unit: 'request', quantity: '1' }],
-    });
+  it('projects only complete bounded quotes to exact microusd reservations', () => {
     expect(built.get('brave-search', 'search')?.estimate).toEqual({
       estimated_cost_microusd: '5000',
-      billable_units: [{ unit: 'request', quantity: '1' }],
+      billable_units: [{ unit: 'requests', quantity: '1' }],
     });
-    expect(
-      built.get('searchapi-google-ai-overview', 'surface')?.estimate,
-    ).toEqual({
-      estimated_cost_microusd: '4000',
-      billable_units: [{ unit: 'request', quantity: '2' }],
+    expect(built.get('perplexity-search', 'search')?.estimate).toEqual({
+      estimated_cost_microusd: '5000',
+      billable_units: [{ unit: 'requests', quantity: '1' }],
+    });
+    expect(built.get('you-research', 'grounded')?.estimate).toEqual({
+      estimated_cost_microusd: '50000',
+      billable_units: [{ unit: 'research_requests', quantity: '1' }],
     });
   });
 
-  it('records credit units without inventing a dollar value', () => {
-    expect(built.get('tavily', 'search')?.estimate).toEqual({
-      billable_units: [{ unit: 'credit', quantity: '2' }],
-    });
+  it('does not establish hard budgets from stale or account-dependent prices', () => {
+    expect(built.get('you-answer', 'grounded')?.estimate).toBeUndefined();
+    expect(built.get('tavily', 'search')?.estimate).toBeUndefined();
     expect(
-      built.get('tavily', 'search')?.estimate?.estimated_cost_microusd,
+      built.get('searchapi-google-ai-overview', 'surface')?.estimate,
     ).toBeUndefined();
+  });
+
+  it('uses a reviewed fallback only under its explicit account conditions', () => {
+    const payg = catalog({
+      providerConfigs: enabledConfigs({
+        tavily: { pricingConditions: { account_plan: 'payg' } },
+      }),
+    });
+    expect(payg.get('tavily', 'search')?.estimate).toEqual({
+      estimated_cost_microusd: '16000',
+      billable_units: [{ unit: 'credits', quantity: '2' }],
+    });
   });
 
   it('omits volatile token and native prices entirely', () => {
@@ -1303,7 +1312,6 @@ describe('provider catalog -- network-free estimates', () => {
       ['perplexity-sonar-pro', 'grounded'],
       ['gemini-deep', 'research'],
       ['grok', 'web'],
-      ['exa', 'search'],
       ['brave-answers', 'grounded'],
       ['claude', 'chat'],
     ] as const) {
@@ -1434,6 +1442,44 @@ describe('provider catalog -- explicit and capability selection', () => {
     expect(result.issues).toContainEqual(
       expect.objectContaining({ code: 'explicit_profile_excluded' }),
     );
+  });
+
+  it('reserves both requests in configured Google AI Overview pricing', () => {
+    const configured = catalog({
+      configuredPricing: [
+        {
+          id: 'searchapi-google-ai-overview.account',
+          provider_id: 'searchapi-google-ai-overview',
+          profile_id: 'surface',
+          currency: 'USD',
+          completeness: 'complete',
+          confidence: 'confirmed',
+          expected_units: ['requests'],
+          fixed_quantities: { requests: '2' },
+          missing_units: [],
+          rates: [
+            {
+              unit: 'requests',
+              amount_decimal: '0.004',
+              per_decimal: '1',
+            },
+          ],
+          provenance: {
+            source_class: 'configured_account_rate',
+            source_reference: 'configured:searchapi/account-rate',
+            effective_at: '2026-08-13T00:00:00.000Z',
+            retrieved_at: '2026-08-13T00:00:00.000Z',
+          },
+        },
+      ],
+    });
+
+    expect(
+      configured.get('searchapi-google-ai-overview', 'surface')?.estimate,
+    ).toEqual({
+      estimated_cost_microusd: '8000',
+      billable_units: [{ unit: 'requests', quantity: '2' }],
+    });
   });
 
   it('returns every matching authenticated profile in deterministic order', () => {


### PR DESCRIPTION
## Summary

Wave 0A replaces loose provider-wide hard-budget estimates with a frozen, auditable, profile/model-aware pricing foundation. It uses exact decimal-string/BigInt arithmetic, preserves requested and effective identity, and fails closed whenever a complete bounded cost cannot be established.

PlanMode task: #2732

## Changes

- Add an immutable pricing snapshot covering all 42 implemented built-in profiles across 17 provider families with explicit `complete`, `partial`, or `unavailable` status and reviewed SHA-256 fingerprint `sha256:0a12e0c17f3d42ba5f4ba99ac919304d99f8b2e6bad48686cca8f582cb9dd00f`.
- Add exact normalized-unit calculation, amount/bounds quotes, requested/effective routing, definition and snapshot fingerprints, provenance, redacted source references, and provider-reported/computed source precedence.
- Project only complete bounded USD quotes into the existing canonical microusd/BigInt hard-budget path. Unknown, incomplete, account-dependent, routed, and private namespaced-unit costs remain unreservable rather than becoming zero.
- Add an explicit local-file-only sync → review → freeze workflow. Ordinary catalog planning remains synchronous, Worker-safe, and network-free.
- Keep the shared TypeScript/PHP terminal interchange contract unchanged.

## Official pricing evidence

Reviewed on 2026-08-13. Unsupported model, plan, region, billing-mode, failure/cancellation, or dynamic-quantity rules are held partial/unavailable.

- [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- [OpenAI API pricing](https://openai.com/api/pricing/)
- [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)
- [Perplexity pricing](https://docs.perplexity.ai/docs/getting-started/pricing)
- [OpenRouter pricing](https://openrouter.ai/pricing)
- [xAI pricing](https://docs.x.ai/developers/pricing)
- [Parallel pricing](https://docs.parallel.ai/getting-started/pricing)
- [Valyu pricing](https://docs.valyu.ai/pricing)
- [Exa pricing](https://exa.ai/pricing?tab=api)
- [Tavily pricing](https://www.tavily.com/pricing)
- [You.com billing](https://you.com/docs/administration/billing)
- [Brave Search API](https://brave.com/search/api/)
- [SearchAPI pricing](https://www.searchapi.io/pricing)
- [SerpApi pricing](https://serpapi.com/pricing)
- [Firecrawl pricing](https://www.firecrawl.dev/pricing)
- [Jina Reader](https://jina.ai/reader/)
- [Kagi FastGPT](https://help.kagi.com/kagi/api/fastgpt.html)

## Testing

Passed against commit `6c580293bfd1c03f2f29d5674e33cdf0ae809ec0`:

- `npx vitest run tests/pricing.test.ts tests/pricing-snapshot-workflow.test.ts tests/provider-catalog.test.ts` — 3 files, 144 passed
- `env -u OPENAI_API_KEY -u GEMINI_API_KEY -u PERPLEXITY_API_KEY npm test` — 111 files, 1,884 passed, 7 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:declarations`
- `npm run test:workers` — 8 files, 30 passed
- `npm run test:integration` — 2 files, 11 passed
- `npm run test:packed`
- `npm run test:pty` — 4 files, 5 passed
- `npm run benchmark:ci` with all provider secrets removed — 4 offline fixtures passed under the network guard
- `npm run benchmark:validate`
- `npm run benchmark:performance` — synthetic/offline
- `npm run contracts:generate` — no contract diff
- `git diff --check`

Environment limitations:

- SEA is disabled in the active Node 26.6.0 build; CI runs SEA under its supported Node runtime.
- Below-floor rejection requires Node 22.11.0; the active runtime is Node 26.6.0.
- An unchanged wizard keychain test is environment-sensitive when host provider keys are present. The hermetic full-unit command above passes.

## Review

The independent review panel did not reach quorum: two seats stalled, one route failed before inference, and the allowed substitute abstained without patch inspection. The lead financial/security, correctness, and testability pass found and fixed unexpected-unit underbilling, fixed-quantity under-reservation, configured-definition fingerprinting, non-terminating-rate validation, cross-provider identity, actual-cost provenance, UTC timestamp validation, and offline receipt/path validation. No Critical or High finding remains in that lead pass.

## Compatibility and risk

- No live or paid provider call was made.
- No credential, raw provider body, private source, or local path is persisted.
- Existing legacy metering and budget trackers remain unchanged in this wave.
- The pricing formulas and official references remain private runtime/catalog data and do not expand terminal interchange.
