### PR TITLE
Freeze Librarium 2.0.0-rc.1 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "1.4.1",
+  "version": "2.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "1.4.1",
+      "version": "2.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "1.4.1",
+  "version": "2.0.0-rc.1",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/generate-contract-snapshot.ts
+++ b/scripts/generate-contract-snapshot.ts
@@ -23,9 +23,7 @@ import { resolveSnapshotWritePath } from './contract-snapshot-path.js';
 const root =
   process.env.LIBRARIUM_CONTRACTS_OUTPUT ??
   join(process.cwd(), 'contracts', 'v1');
-const packageVersion = JSON.parse(
-  readFileSync(join(process.cwd(), 'package.json'), 'utf8'),
-) as { version: string };
+const TYPESCRIPT_FIXTURE_GENERATOR_VERSION = '1.4.1';
 
 function isRecognizedSnapshotManifest(path: string): boolean {
   try {
@@ -166,7 +164,7 @@ const result = {
 };
 const success = {
   generator: 'jkudish/librarium',
-  generator_version: packageVersion.version,
+  generator_version: TYPESCRIPT_FIXTURE_GENERATOR_VERSION,
   request_id: 'request-terminal-1',
   status: 'succeeded',
   completed_at: '2026-08-09T12:00:02Z',


### PR DESCRIPTION
## Summary

- freeze package.json and package-lock.json at 2.0.0-rc.1
- keep the accepted contracts/v1 fixture snapshot byte-stable across package releases
- enable the strict RC authority and no-publish proof workflow once this stack reaches protected main

## Compatibility

The contract schema and fixture inventory do not change. The TypeScript example generator version remains a stable fixture value, so downstream snapshot consumers do not need a semantic-no-op repin.

## Verification

- typecheck and lint
- 2,040 unit tests passed; 7 skipped
- 68 focused contract, RC workflow, and artifact tests
- build and declaration consumer fixtures
- Worker compatibility: 30 tests
- integration: 11 tests
- packed consumer and npm pack version/name checks
- PTY: 5 tests
- offline benchmark replay: 4 cases
- committed RC authority: exact version 2.0.0-rc.1 and SHA-qualified artifact prefix
- independent review: GO, no Critical/High/Medium findings

## Holdbacks

This PR does not publish packages, create tags or releases, update Homebrew, call providers, or spend money. The authoritative hosted RC proof must run only after the full stack reaches protected main.