### PR TITLE
Use standard Intel runner for RC macOS SEA

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -318,7 +318,7 @@ jobs:
             target: librarium-linux-x64
           - os: ubuntu-24.04-arm
             target: librarium-linux-arm64
-          - os: macos-14-large
+          - os: macos-15-intel
             target: librarium-macos-x64
           - os: macos-latest
             target: librarium-macos-arm64


### PR DESCRIPTION
## Summary

- replace the billing-gated macos-14-large runner with the standard macos-15-intel runner
- preserve the existing librarium-macos-x64 SEA target and immutable proof steps

## Verification

- 23 focused RC workflow tests
- Biome lint
- actionlint
- git diff check
- independent review: GO, no findings

## Context

The protected-main RC proof reached every other job, but GitHub refused to start the larger macOS runner because of the account billing/spending-limit state. This change uses GitHub’s documented standard Intel/x64 runner instead. It does not publish, tag, release, or call providers.