### PR TITLE
Fix RC Homebrew distribution proof

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -541,14 +541,22 @@ jobs:
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_ENV_HINTS: 1
         run: |
+          TAP_NAME=librarium/rc-proof
+          FORMULA_NAME=librarium-rc-proof
           cleanup_brew() {
-            if brew list --formula librarium-rc-proof >/dev/null 2>&1; then
-              brew uninstall --formula librarium-rc-proof >/dev/null
+            if brew list --formula "$FORMULA_NAME" >/dev/null 2>&1; then
+              brew uninstall --formula "$FORMULA_NAME" >/dev/null
+            fi
+            if brew --repository "$TAP_NAME" >/dev/null 2>&1; then
+              brew untap "$TAP_NAME" >/dev/null
             fi
           }
           trap cleanup_brew EXIT
-          brew install --formula "$RUNNER_TEMP/distribution-proof/librarium-rc-proof.rb"
-          BREW_BIN="$(brew --prefix librarium-rc-proof)/bin/librarium"
+          brew tap-new "$TAP_NAME"
+          TAP_ROOT="$(brew --repository "$TAP_NAME")"
+          cp "$RUNNER_TEMP/distribution-proof/librarium-rc-proof.rb" "$TAP_ROOT/Formula/$FORMULA_NAME.rb"
+          brew install --formula "$TAP_NAME/$FORMULA_NAME"
+          BREW_BIN="$(brew --prefix "$FORMULA_NAME")/bin/librarium"
           EXPECTED_VERSION="$(jq -r '.candidate.version' "$RUNNER_TEMP/distribution-proof/proof.json")"
           EXPECTED_SHA="$(jq -r '.homebrew.selections[] | select(.platform == "darwin" and .arch == "arm64") | .sha256' "$RUNNER_TEMP/distribution-proof/proof.json")"
           test "$(shasum -a 256 "$BREW_BIN" | awk '{print "sha256:" $1}')" = "$EXPECTED_SHA"
@@ -563,6 +571,8 @@ jobs:
             --binary "$BREW_BIN"
           test -f "$RUNNER_TEMP/distribution-proof/homebrew-result.json"
           test ! -e "$BREW_BIN"
+          brew untap "$TAP_NAME"
+          ! brew --repository "$TAP_NAME" >/dev/null 2>&1
           trap - EXIT
 
       - name: Exercise installer rollback fixtures

--- a/src/node-release-workflow.ts
+++ b/src/node-release-workflow.ts
@@ -179,7 +179,7 @@ const FORBIDDEN_WORKFLOW_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\bgh\s+release\b/i, 'GitHub release command'],
   [/\bgit\s+tag\b/i, 'Git tag command'],
   [/\bgit\s+push\b/i, 'Git push command'],
-  [/\bbrew\s+tap\b/i, 'Homebrew tap command'],
+  [/\bbrew\s+tap(?!-new)\b/i, 'Homebrew tap command'],
   [/HOMEBREW_TAP_TOKEN/, 'Homebrew tap credential'],
   [/\b--clobber\b/, 'artifact clobber flag'],
   [/\b--force(?:-with-lease)?\b/, 'force flag'],

--- a/tests/release-candidate-workflow.test.ts
+++ b/tests/release-candidate-workflow.test.ts
@@ -84,6 +84,10 @@ describe('release-candidate workflow policy', () => {
       (source: string) => `${source}\n# git tag -f v2.0.0-rc.1\n`,
     ],
     [
+      'remote Homebrew tap command',
+      (source: string) => `${source}\n# brew tap example/release\n`,
+    ],
+    [
       'overwritable output',
       (source: string) => source.replace('overwrite: false', 'overwrite: true'),
     ],
@@ -153,6 +157,10 @@ describe('release-candidate workflow policy', () => {
 
   it('records the real Homebrew install result after local execution', () => {
     const source = readFileSync(workflowPath, 'utf8');
+    expect(source).toContain('brew tap-new "$TAP_NAME"');
+    expect(source).toContain('"$TAP_ROOT/Formula/$FORMULA_NAME.rb"');
+    expect(source).toContain('"$TAP_NAME/$FORMULA_NAME"');
+    expect(source).toContain('brew untap "$TAP_NAME"');
     expect(source).toContain('finalize-homebrew');
     expect(source).toContain('homebrew-result.json');
     expect(source.indexOf('brew install --formula')).toBeLessThan(


### PR DESCRIPTION
Fixes the RC distribution proof on current Homebrew versions by creating a temporary local tap before installing the generated formula.\n\n- installs the proof formula through a qualified local tap\n- removes the formula and tap on both success and failure\n- keeps remote tap changes forbidden by the release workflow policy\n- adds regression coverage for the local tap flow and remote tap prohibition\n\nValidation:\n- 24 focused workflow policy tests\n- TypeScript typecheck\n- Biome lint (413 files)\n- actionlint\n- git diff --check\n\nIndependent release-safety review: GO, no findings.\n\nNo package publication, tag, release, provider call, or paid call is performed by this change.