### PR TITLE
Fix live validation RC version binding

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -39,6 +39,8 @@ import {
 } from '../node-live-validation-production.js';
 
 const SAFE_ID = /^[a-z][a-z0-9._-]{0,127}$/;
+const RC_VERSION =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:0|[1-9]\d*)$/;
 const SHA256 = /^sha256:[a-f0-9]{64}$/;
 const MICROUSD = /^(?:0|[1-9]\d*)$/;
 const DECIMAL = /^(?:0|[1-9]\d*)(?:\.\d{1,36})?$/;
@@ -132,7 +134,7 @@ const ApprovalSchema = z
     candidate: z.strictObject({
       git_sha: z.string().regex(/^[a-f0-9]{40}$/),
       fingerprint: z.string().regex(SHA256),
-      version: z.string().regex(SAFE_ID),
+      version: z.string().regex(RC_VERSION),
       artifact_hashes: z.record(
         z.string().regex(SAFE_ID),
         z.string().regex(SHA256),

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -1370,7 +1370,7 @@ const FORBIDDEN_RECEIPT_TEXT =
   /(?:bearer\s+|(?:sk|rk|pk)[_-][A-Za-z0-9_-]{12,}|akia[A-Z0-9]{12,}|ghp_[A-Za-z0-9]{12,}|xox[baprs]-[A-Za-z0-9-]{12,}|aiza[A-Za-z0-9_-]{12,}|api[_-]?key|access[_-]?token|authorization|secret|signed(?:[_-]?url)?|x-amz-(?:credential|signature|security-token)|https?:\/\/|(?:^|["'])(?:\/?(?:Users|home|tmp|private|opt|var|etc|mnt|srv|proc|dev)|[A-Za-z]:[\\/]))/i;
 
 const SAFE_RECEIPT_STRING =
-  /^(?:USD|[a-z][a-z0-9._-]{0,127}(?:\/[a-z][a-z0-9._-]{0,127})?|(?:0|[1-9]\d*)(?:\.\d{1,36})?|[a-f0-9]{40}|sha256:[a-f0-9]{64}|fnv1a64\.1:[a-f0-9]{16})$/;
+  /^(?:USD|[a-z][a-z0-9._-]{0,127}(?:\/[a-z][a-z0-9._-]{0,127})?|(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:0|[1-9]\d*)|(?:0|[1-9]\d*)(?:\.\d{1,36})?|[a-f0-9]{40}|sha256:[a-f0-9]{64}|fnv1a64\.1:[a-f0-9]{16})$/;
 
 function assertSafeReceiptValue(value: unknown, path = 'receipt'): void {
   if (

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -436,7 +436,7 @@ describe('paid command gates remain before production composition', () => {
       candidate: {
         git_sha: 'a'.repeat(40),
         fingerprint: `sha256:${'a'.repeat(64)}`,
-        version: 'candidate-v1',
+        version: '2.0.0-rc.1',
         artifact_hashes: Object.fromEntries(
           [
             'declarations',

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -1307,7 +1307,7 @@ describe('frozen paid protocol (injected, zero-network)', () => {
         git_sha: 'a'.repeat(40),
         fingerprint:
           'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        version: 'candidate-v1',
+        version: '2.0.0-rc.1',
         artifact_hashes: {
           declarations:
             'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',


### PR DESCRIPTION
Fixes paid live validation so the frozen preregistration accepts the strict RC version already required by the release workflow.\n\n- binds candidate versions to strict X.Y.Z-rc.N syntax\n- permits that same bounded syntax in sanitized public receipts\n- keeps secret, URL, path, size, and other receipt restrictions unchanged\n- updates live-validation fixtures to the real RC1 version\n\nValidation:\n- 82 focused live-validation tests\n- full unit suite: 117 files, 2,041 passed, 7 skipped\n- TypeScript typecheck\n- Biome lint\n- git diff --check\n\nIndependent security/correctness review: GO, no findings.\n\nNo credentials, network requests, provider calls, or paid calls were made.