### PR TITLE
Fix live validation catalog authority

### DIFF
--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -15,8 +15,13 @@ import {
   frozenRequestFingerprint,
   type LiveValidationApproval,
 } from './commands/live-validation.js';
-import { loadConfig, loadProjectConfig, mergeConfigs } from './core/config.js';
-import { buildProviderCatalog } from './core/profile-catalog.js';
+import {
+  configGroupProvenance,
+  loadConfig,
+  loadProjectConfig,
+  mergeConfigs,
+} from './core/config.js';
+import { mapConfiguration } from './core/configuration-mapping.js';
 import { getBuiltinProviderDefinition } from './core/provider-descriptor.js';
 import { INTERNAL_ADAPTER_PUBLIC_PROVIDER_IDS } from './internal-adapter-ids.js';
 import {
@@ -97,11 +102,8 @@ function exactInput(
   };
 }
 
-/** Build the config-aware public matrix before any credential context exists. */
-export function productionValidationMatrix(config: Config) {
+function normalizedProductionProviders(config: Config): Config['providers'] {
   const expected = buildCanonicalValidationMatrix();
-  // A paid matrix is a complete fixed audit. An explicit disabled public
-  // family must fail admission; it must never silently remove that family.
   for (const target of expected.targets) {
     if (config.providers[publicConfigId(target)]?.enabled === false) {
       throw new CanonicalLiveValidationError(
@@ -114,14 +116,28 @@ export function productionValidationMatrix(config: Config) {
     const id = publicConfigId(target);
     providers[id] = { ...providers[id], enabled: true };
   }
-  const catalog = buildProviderCatalog({
-    providerConfigs: providers,
-    groups: config.groups,
+  return providers;
+}
+
+/** Build the config-aware public matrix before any credential context exists. */
+export function productionValidationMatrix(config: Config) {
+  const expected = buildCanonicalValidationMatrix();
+  // A paid matrix is a complete fixed audit. An explicit disabled public
+  // family must fail admission; it must never silently remove that family.
+  const providers = normalizedProductionProviders(config);
+  const normalizedConfig = { ...config, providers };
+  const mapped = mapConfiguration(normalizedConfig, {
+    authoredGroups: configGroupProvenance(normalizedConfig),
     assumeCredentialAvailability: true,
   });
+  if (mapped.preflight.issues.length > 0) {
+    throw new CanonicalLiveValidationError(
+      'Production paid validation configuration cannot build a canonical catalog.',
+    );
+  }
   const matrix = buildCanonicalValidationMatrix({
     provider_config: providers,
-    catalog_authority: catalog,
+    catalog_authority: mapped.catalog,
   });
   const expectedInventory = expected.targets.map(
     (target) => `${target.key}:${target.binding_id}:${target.adapter_id}`,
@@ -198,6 +214,7 @@ export function createProductionFrozenCanonicalExecutor(
   config: Config,
   dependencies: ProductionLiveValidationDependencies = {},
 ): FrozenCanonicalExecutor {
+  const productionProviders = normalizedProductionProviders(config);
   const initialize = dependencies.initializeProviders ?? initializeProviders;
   const resolveProvider = dependencies.resolveExactProvider ?? getExactProvider;
   const createDirectory = dependencies.createRunDirectory ?? createRunDir;
@@ -235,9 +252,9 @@ export function createProductionFrozenCanonicalExecutor(
     const configured: Config = {
       ...config,
       providers: {
-        ...config.providers,
+        ...productionProviders,
         [publicConfigId(target)]: {
-          ...config.providers[publicConfigId(target)],
+          ...productionProviders[publicConfigId(target)],
           enabled: true,
           options: protocol.options,
         },

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -18,7 +18,10 @@ import {
   canonicalJson,
   catalogFingerprint,
 } from './core/catalog-fingerprint.js';
-import type { PreparedResearchExecution } from './core/execution-plan.js';
+import {
+  type PreparedResearchExecution,
+  profileIdentityKey,
+} from './core/execution-plan.js';
 import { safeWriteFile } from './core/fs-utils.js';
 import {
   budgetEstimateFromQuote,
@@ -1288,9 +1291,7 @@ export function assertCanonicalValidationPreparedExecution(
     );
   }
   const plan =
-    prepared.profile_plans_by_identity[
-      `${profile.identity.provider_id}/${profile.identity.profile_id}`
-    ];
+    prepared.profile_plans_by_identity[profileIdentityKey(profile.identity)];
   if (
     !plan ||
     plan.binding.adapter_id !== target.adapter_id ||

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -9,8 +9,12 @@ import {
   type LiveValidationApproval,
   registerLiveValidationCommand,
 } from '../src/commands/live-validation.js';
+import { loadConfig } from '../src/core/config.js';
 import type { CredentialContext } from '../src/core/credentials.js';
-import type { PreparedResearchExecution } from '../src/core/execution-plan.js';
+import {
+  type PreparedResearchExecution,
+  profileIdentityKey,
+} from '../src/core/execution-plan.js';
 import { buildCanonicalValidationMatrix } from '../src/node-live-validation.js';
 import {
   createProductionFrozenCanonicalExecutor,
@@ -68,13 +72,12 @@ function prepared(target: Target): PreparedResearchExecution {
     },
     catalog: { digest: target.catalog_digest },
     profile_plans_by_identity: {
-      [`${target.expected_effective_identity.provider_id}/${target.expected_effective_identity.profile_id}`]:
-        {
-          binding: {
-            adapter_id: target.adapter_id,
-            binding_id: target.binding_id,
-          },
+      [profileIdentityKey(target.expected_effective_identity)]: {
+        binding: {
+          adapter_id: target.adapter_id,
+          binding_id: target.binding_id,
         },
+      },
     },
   } as unknown as PreparedResearchExecution;
 }
@@ -243,6 +246,37 @@ describe('production live-validation binding (injected, offline)', () => {
     });
   });
 
+  it('uses the same all-enabled catalog authority for the frozen matrix and exact structural preflight', async () => {
+    const config = loadConfig(
+      join(tmpdir(), 'librarium-missing-live-validation-config.json'),
+    );
+    const target = productionValidationMatrix(config).targets[0]!;
+    const observed = counters();
+    const injected = executorDependencies(target, observed);
+    const {
+      preflightStructure: _useProductionStructuralPreflight,
+      ...dependencies
+    } = injected;
+    const binding = createProductionFrozenCanonicalExecutor(
+      {
+        raw_root: mkdtempSync(join(tmpdir(), 'librarium-binding-')),
+      } as LiveValidationApproval,
+      config,
+      dependencies,
+    );
+
+    await expect(
+      binding.prepare(target, protocol(target)),
+    ).resolves.toMatchObject({
+      catalog_digest: target.catalog_digest,
+    });
+    expect(observed).toMatchObject({
+      credential: 1,
+      initialize: 1,
+      materialize: 1,
+    });
+  });
+
   it('initializes only a private durable adapter while retaining its public configuration authority', async () => {
     const target = buildCanonicalValidationMatrix().targets.find(
       (candidate) => candidate.key === 'exa/research',
@@ -263,7 +297,7 @@ describe('production live-validation binding (injected, offline)', () => {
       {
         raw_root: mkdtempSync(join(tmpdir(), 'librarium-binding-')),
       } as LiveValidationApproval,
-      { providers: { exa: { enabled: false } } } as Config,
+      { providers: { exa: { enabled: true } } } as Config,
       dependencies,
     );
     await binding.prepare(target, protocol(target));
@@ -372,7 +406,9 @@ describe('production live-validation binding (injected, offline)', () => {
 
 describe('production paid matrix and candidate attribution', () => {
   it('requires the exact canonical 42-target binding inventory', () => {
-    const matrix = productionValidationMatrix({ providers: {} } as Config);
+    const matrix = productionValidationMatrix(
+      loadConfig(join(tmpdir(), 'librarium-missing-matrix-config.json')),
+    );
     expect(matrix.targets).toHaveLength(42);
     expect(matrix.targets.map((target) => target.key)).toStrictEqual(
       buildCanonicalValidationMatrix().targets.map((target) => target.key),
@@ -380,10 +416,17 @@ describe('production paid matrix and candidate attribution', () => {
   });
 
   it('rejects an explicitly disabled canonical family before provider construction', () => {
+    const config = loadConfig(
+      join(tmpdir(), 'librarium-missing-disabled-config.json'),
+    );
     expect(() =>
       productionValidationMatrix({
-        providers: { exa: { enabled: false } },
-      } as Config),
+        ...config,
+        providers: {
+          ...config.providers,
+          exa: { ...config.providers.exa, enabled: false },
+        },
+      }),
     ).toThrow('disabled canonical provider');
   });
 

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -130,7 +130,7 @@ describe('canonical v3 live validation matrix', () => {
       },
       catalog: { digest: target.catalog_digest },
       profile_plans_by_identity: {
-        [target.key]: {
+        [profileIdentityKey(target.expected_effective_identity)]: {
           binding: {
             adapter_id: target.adapter_id,
             binding_id: target.binding_id,
@@ -945,7 +945,7 @@ describe('canonical v3 live validation persisted fixture lane', () => {
       },
       catalog: { digest: target.catalog_digest },
       profile_plans_by_identity: {
-        [target.key]: {
+        [profileIdentityKey(target.expected_effective_identity)]: {
           binding: {
             adapter_id: target.adapter_id,
             binding_id: target.binding_id,


### PR DESCRIPTION
Fixes production live validation so its frozen 42-profile matrix and exact per-target preflight use the same canonical catalog authority.\n\n- normalizes the all-enabled validation-only provider map once\n- derives the matrix from the same configuration mapping used by structural preflight\n- keeps explicitly disabled families fail-closed before credentials\n- looks up execution plans with the canonical full profile identity key\n- adds an offline real-structural-preflight regression\n\nValidation:\n- 83 focused live-validation tests\n- full unit suite: 117 files, 2,042 passed, 7 skipped\n- TypeScript typecheck\n- Biome lint (413 files)\n- git diff --check\n\nIndependent security/correctness review: GO, no findings.\n\nTwo attempted live runs stopped at zero attempts before any provider dispatch. No provider or paid call occurred.