### PR TITLE
fix: use valid live validation extension key

### DIFF
--- a/src/node-live-validation-binding.ts
+++ b/src/node-live-validation-binding.ts
@@ -16,6 +16,7 @@ import {
   CanonicalLiveValidationError,
   type CanonicalValidationTarget,
   type FrozenAttemptReference,
+  LIVE_VALIDATION_CONTRACT_EXTENSION_KEY,
 } from './node-live-validation.js';
 import { RUN_JSON_FILE } from './node-run-json-lock.js';
 
@@ -134,9 +135,8 @@ export function readTrustedFrozenReferenceManifest(
   if (
     requestHash !== reference.request_fingerprint ||
     (reference.persisted_protocol_contract === true &&
-      manifest.request.extensions?.[
-        'librarium:live_validation_contract_sha256'
-      ] !== reference.protocol_contract_hash) ||
+      manifest.request.extensions?.[LIVE_VALIDATION_CONTRACT_EXTENSION_KEY] !==
+        reference.protocol_contract_hash) ||
     manifest.coordination_state.request_deadline_at <=
       manifest.coordination_state.created_at
   ) {

--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -37,6 +37,7 @@ import {
   CanonicalLiveValidationError,
   type CanonicalValidationTarget,
   type FrozenAttemptReference,
+  LIVE_VALIDATION_CONTRACT_EXTENSION_KEY,
 } from './node-live-validation.js';
 import { readTrustedFrozenReferenceManifest } from './node-live-validation-binding.js';
 import {
@@ -354,7 +355,7 @@ export function createProductionFrozenCanonicalExecutor(
         ...admittedPrepared.request,
         extensions: {
           ...admittedPrepared.request.extensions,
-          'librarium:live_validation_contract_sha256':
+          [LIVE_VALIDATION_CONTRACT_EXTENSION_KEY]:
             frozenProtocolContractHash(contract),
         },
       },

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -60,6 +60,10 @@ export interface CanonicalValidationProviderConfig {
   readonly options?: unknown;
 }
 
+/** Namespaced canonical request extension binding a run to its frozen live protocol. */
+export const LIVE_VALIDATION_CONTRACT_EXTENSION_KEY =
+  'build.librarium:liveValidationContractSha256';
+
 export interface CanonicalValidationTarget {
   readonly key: string;
   readonly adapter_id: string;

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -9,13 +9,17 @@ import {
   type LiveValidationApproval,
   registerLiveValidationCommand,
 } from '../src/commands/live-validation.js';
+import { NamespacedKeySchema } from '../src/contracts/common.js';
 import { loadConfig } from '../src/core/config.js';
 import type { CredentialContext } from '../src/core/credentials.js';
 import {
   type PreparedResearchExecution,
   profileIdentityKey,
 } from '../src/core/execution-plan.js';
-import { buildCanonicalValidationMatrix } from '../src/node-live-validation.js';
+import {
+  buildCanonicalValidationMatrix,
+  LIVE_VALIDATION_CONTRACT_EXTENSION_KEY,
+} from '../src/node-live-validation.js';
 import {
   createProductionFrozenCanonicalExecutor,
   productionValidationMatrix,
@@ -123,6 +127,12 @@ function executorDependencies(
       counters.materialize += 1;
       expect(received.policy.limits.max_concurrency).toBe(1);
       expect(received.request.fallback_reserve).toStrictEqual([]);
+      expect(
+        NamespacedKeySchema.parse(LIVE_VALIDATION_CONTRACT_EXTENSION_KEY),
+      ).toBe(LIVE_VALIDATION_CONTRACT_EXTENSION_KEY);
+      expect(received.request.extensions).toHaveProperty(
+        LIVE_VALIDATION_CONTRACT_EXTENSION_KEY,
+      );
       return {} as any;
     },
     resume: async () => {


### PR DESCRIPTION
## Summary

Fix the canonical live-validation request extension key so it satisfies the namespaced-key schema before materialization. The writer and trusted reader now share one constant.

## Test Plan

- [x] Focused live-validation and canonical tests, 107 passed
- [x] Typecheck and lint
- [x] Build and declaration fixtures
- [x] Live-validation fixture, 83 passed
- [x] Integration, 11 passed
- [x] Packed consumer
- [x] PTY, 5 passed
- [x] Independent deep review, GO

## Holdbacks

RC1 remains immutable and is a NO-GO. A replacement candidate must be assembled after this fix merges before paid provider validation resumes. No provider calls or spend occurred.