### PR TITLE
chore: bump version to 2.0.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Advance the immutable release-candidate version after RC1 failed its first live-validation materialization gate. RC1 remains unchanged and archived as a NO-GO candidate.

## Test Plan

- [x] Exact package and lockfile root versions
- [x] 101 focused release, artifact, install, upgrade, and live-binding tests
- [x] Typecheck and lint
- [x] Build and declarations
- [x] CLI reports 2.0.0-rc.2
- [x] Independent read-only review, GO

## Holdbacks

No provider calls or spend occurred. The immutable RC2 candidate and paid validation must run only after this PR merges.