### PR TITLE
fix: trust canonical failure terminals

### DIFF
--- a/src/node-live-validation-binding.ts
+++ b/src/node-live-validation-binding.ts
@@ -181,9 +181,12 @@ export function readTrustedFrozenReferenceManifest(
       );
     }
   } else if (phase === 'resume') {
-    const terminalCustody = ['succeeded', 'failed', 'cancelled'].includes(
-      manifest.coordination_state.status,
-    );
+    const terminalCustody = [
+      'succeeded',
+      'unsuccessful',
+      'cancelled',
+      'failed',
+    ].includes(manifest.coordination_state.status);
     const activeCustody =
       manifest.coordination_state.status === 'running' && attempts.length > 0;
     const undispatched =
@@ -194,9 +197,12 @@ export function readTrustedFrozenReferenceManifest(
       );
     }
   } else if (phase === 'active' || phase === 'cancellable') {
-    const terminalCustody = ['succeeded', 'failed', 'cancelled'].includes(
-      manifest.coordination_state.status,
-    );
+    const terminalCustody = [
+      'succeeded',
+      'unsuccessful',
+      'cancelled',
+      'failed',
+    ].includes(manifest.coordination_state.status);
     if (
       !terminalCustody &&
       (manifest.coordination_state.status !== 'running' ||
@@ -208,7 +214,7 @@ export function readTrustedFrozenReferenceManifest(
     }
   } else if (
     !manifest.terminal_response ||
-    !['succeeded', 'failed', 'cancelled'].includes(
+    !['succeeded', 'unsuccessful', 'cancelled', 'failed'].includes(
       manifest.coordination_state.status,
     )
   ) {

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -788,6 +788,64 @@ describe('canonical v3 live validation persisted fixture lane', () => {
       readTrustedFrozenReferenceManifest(reference, target, 'terminal').request
         .request_id,
     ).toBe('materialize-only');
+
+    const manifestPath = join(runDirectory, 'run.json');
+    const unsuccessful = JSON.parse(
+      readFileSync(manifestPath, 'utf8'),
+    ) as Record<string, any>;
+    unsuccessful.coordination_state.status = 'unsuccessful';
+    unsuccessful.coordination_state.slots[0].status = 'failed';
+    unsuccessful.coordination_state.attempts[0].status = 'failed';
+    unsuccessful.coordination_state.attempts[0].error = {
+      code: 'provider_reported_error',
+      message: 'The provider returned an error.',
+      category: 'provider',
+      retryable: false,
+      fallback_allowed: false,
+    };
+    unsuccessful.provider_outputs_by_attempt = {};
+    unsuccessful.terminal_response = {
+      ...unsuccessful.terminal_response,
+      status: 'failed',
+      results: [],
+      errors: [
+        {
+          code: 'librarium.provider_reported_error',
+          message: 'The provider returned an error.',
+          profile: target.key,
+        },
+      ],
+    };
+    writeFileSync(manifestPath, `${JSON.stringify(unsuccessful)}\n`);
+    for (const phase of [
+      'resume',
+      'active',
+      'cancellable',
+      'terminal',
+    ] as const) {
+      expect(
+        readTrustedFrozenReferenceManifest(reference, target, phase)
+          .coordination_state.status,
+      ).toBe('unsuccessful');
+    }
+    unsuccessful.coordination_state.status = 'failed';
+    unsuccessful.coordination_state.lifecycle.at(-1).event_kind =
+      'request_failed';
+    unsuccessful.coordination_state.lifecycle.at(-1).data = {
+      error: unsuccessful.coordination_state.attempts[0].error,
+    };
+    writeFileSync(manifestPath, `${JSON.stringify(unsuccessful)}\n`);
+    for (const phase of [
+      'resume',
+      'active',
+      'cancellable',
+      'terminal',
+    ] as const) {
+      expect(
+        readTrustedFrozenReferenceManifest(reference, target, phase)
+          .coordination_state.status,
+      ).toBe('failed');
+    }
   });
 
   it('rejects active and unsettled terminal checkpoints without an exact run reference', () => {


### PR DESCRIPTION
## Summary

Accept canonical provider-exhaustion and infrastructure-failure terminal coordinator states during live-validation resume and evidence recovery. This lets the harness reconcile a failed provider call without treating the run as invalid custody.

## What changed

- accept `unsuccessful` for provider exhaustion
- preserve `failed` for infrastructure failures
- require a terminal response before terminal evidence is trusted
- cover resume, active, cancellable, and terminal phases for both states

## Test plan

- [x] focused live-validation and canonical runtime tests (107 passed)
- [x] TypeScript verification
- [x] Biome lint
- [x] diff check
- [x] independent security review: GO
- [x] independent architecture closure review: GO

## Validation note

The immutable RC2 candidate remains a no-go for continued live validation. One Brave Answers request was made before this defect surfaced; it failed at the provider and was not retried. No other provider requests were made.