### PR TITLE
chore: lock 2.0.0-rc.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Lock the next immutable release-candidate version after the live-validation terminal-status fix.

## What changed

- set the package version to `2.0.0-rc.3`
- update both root package-lock version fields

## Test plan

- [x] package-lock dry-run
- [x] TypeScript verification
- [x] focused release and artifact tests (78 passed)
- [x] production build and declaration generation
- [x] CLI reports `2.0.0-rc.3`
- [x] diff check

No provider or network validation calls were made by this change.