### PR TITLE
fix: split Brave credentials

### DIFF
--- a/benchmark/lib/guard.mjs
+++ b/benchmark/lib/guard.mjs
@@ -4,6 +4,7 @@ import net from 'node:net';
 
 export const secretEnvironmentVariables = [
   'ANTHROPIC_API_KEY',
+  'BRAVE_ANSWERS_API_KEY',
   'BRAVE_API_KEY',
   'EXA_API_KEY',
   'FIRECRAWL_API_KEY',

--- a/benchmark/targets.json
+++ b/benchmark/targets.json
@@ -142,7 +142,7 @@
     {
       "id": "brave-answers",
       "tier": "ai-grounded",
-      "envVar": "BRAVE_API_KEY",
+      "envVar": "BRAVE_ANSWERS_API_KEY",
       "estimatedCostUsd": 0.012,
       "costConfidence": "estimated",
       "pricingVersion": "2026-08"

--- a/src/core/config-v2.ts
+++ b/src/core/config-v2.ts
@@ -822,15 +822,47 @@ function legacyProviderLayer(
         ),
       );
     }
+    const apiKey = migrateBraveAnswersCredentialReference(
+      canonical,
+      provider.apiKey,
+      appendPointer(basePath, id, 'apiKey'),
+      notices,
+    );
     result.set(canonical, {
       ...(provider.enabled !== undefined && { enabled: provider.enabled }),
-      ...(provider.apiKey !== undefined && { api_key: provider.apiKey }),
+      ...(apiKey !== undefined && { api_key: apiKey }),
       ...(provider.model !== undefined && { model: provider.model }),
       ...(provider.options !== undefined && { options: provider.options }),
       ...(fallback !== undefined && { fallback }),
     });
   }
   return Object.fromEntries(result);
+}
+
+function migrateBraveAnswersCredentialReference(
+  providerId: string,
+  reference: string | undefined,
+  path: string,
+  notices: PreparationNotice[],
+): string | undefined {
+  if (providerId !== 'brave-answers' || reference === undefined) {
+    return reference;
+  }
+  const migrated =
+    reference === '$BRAVE_API_KEY'
+      ? '$BRAVE_ANSWERS_API_KEY'
+      : reference === 'keychain:BRAVE_API_KEY'
+        ? 'keychain:BRAVE_ANSWERS_API_KEY'
+        : undefined;
+  if (migrated === undefined) return reference;
+  notices.push(
+    notice(
+      'config_credential_reference_migrated',
+      path,
+      `Brave Answers credential reference was migrated from "${reference}" to "${migrated}".`,
+    ),
+  );
+  return migrated;
 }
 
 function legacyExecutionDefaults(
@@ -933,11 +965,29 @@ function normalizeLegacy(
 
 function normalizeV2(
   input: LibrariumConfigV2 | LibrariumProjectConfigV2,
+  prefix: 'global' | 'project',
 ): NormalizedLayer {
+  const notices: PreparationNotice[] = [];
+  const providers = Object.fromEntries(
+    Object.entries(input.providers ?? {}).map(([id, provider]) => [
+      id,
+      {
+        ...provider,
+        ...(provider.api_key !== undefined && {
+          api_key: migrateBraveAnswersCredentialReference(
+            id,
+            provider.api_key,
+            `/${prefix}/providers/${id}/api_key`,
+            notices,
+          ),
+        }),
+      },
+    ]),
+  );
   return {
     version: 2,
     execution_defaults: input.execution_defaults,
-    providers: input.providers ?? {},
+    providers,
     custom_providers: input.custom_providers ?? {},
     trusted_provider_ids: [...(input.trusted_provider_ids ?? [])],
     groups: Object.fromEntries(
@@ -947,7 +997,7 @@ function normalizeV2(
       ]),
     ),
     runtime: input.runtime,
-    notices: [],
+    notices,
   };
 }
 
@@ -1000,7 +1050,10 @@ function parseLayer(
         prefix,
         issues,
       )
-    : normalizeV2(parsed.data as LibrariumConfigV2 | LibrariumProjectConfigV2);
+    : normalizeV2(
+        parsed.data as LibrariumConfigV2 | LibrariumProjectConfigV2,
+        prefix,
+      );
 }
 
 function mergeObject<T extends object>(base: T, override?: Partial<T>): T {

--- a/src/core/provider-descriptor.ts
+++ b/src/core/provider-descriptor.ts
@@ -708,7 +708,7 @@ export const BUILTIN_PROVIDER_DEFINITIONS = [
     id: 'brave-answers',
     registrationOrder: 10,
     tier: 'ai-grounded',
-    envVar: 'BRAVE_API_KEY',
+    envVar: 'BRAVE_ANSWERS_API_KEY',
     defaultModel: 'brave',
     display: {
       family: 'Brave',

--- a/src/core/provider-profiles.ts
+++ b/src/core/provider-profiles.ts
@@ -616,7 +616,11 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
       best_for: 'A Brave-backed synthesized answer layer.',
       setup_url: BRAVE_SETUP_URL,
     },
-    credential: { env_var: 'BRAVE_API_KEY', required: true, auto_enable: true },
+    credential: {
+      env_var: 'BRAVE_ANSWERS_API_KEY',
+      required: true,
+      auto_enable: true,
+    },
     profiles: [
       declare({
         profile_id: 'grounded',

--- a/tests/adapters/base-error-helpers.test.ts
+++ b/tests/adapters/base-error-helpers.test.ts
@@ -37,7 +37,7 @@ describe('BaseProvider error helpers', () => {
     it('adds hint for 401', () => {
       const result = provider.testFormatError(401, { error: 'unauthorized' });
       expect(result).toContain('401');
-      expect(result).toContain('BRAVE_API_KEY');
+      expect(result).toContain('BRAVE_ANSWERS_API_KEY');
       expect(result).toContain('set and valid');
     });
 

--- a/tests/adapters/brave-answers.test.ts
+++ b/tests/adapters/brave-answers.test.ts
@@ -34,7 +34,7 @@ function streamEvent(content: string, model = 'brave'): string {
 
 function provider(): BraveAnswersProvider {
   return new BraveAnswersProvider({
-    credentials: { env: { BRAVE_API_KEY: 'mock-brave-key' } },
+    credentials: { env: { BRAVE_ANSWERS_API_KEY: 'mock-brave-key' } },
   });
 }
 

--- a/tests/config-v2.test.ts
+++ b/tests/config-v2.test.ts
@@ -115,6 +115,70 @@ function nestedObjects(count: number): Record<string, unknown> {
 }
 
 describe('public v2 configuration migration', () => {
+  it.each([
+    ['$BRAVE_API_KEY', '$BRAVE_ANSWERS_API_KEY'],
+    ['keychain:BRAVE_API_KEY', 'keychain:BRAVE_ANSWERS_API_KEY'],
+  ])(
+    'migrates the legacy Brave Answers credential reference %s',
+    (reference, expected) => {
+      const result = migrateConfig({
+        global: v1({
+          providers: {
+            'brave-answers': { enabled: true, apiKey: reference },
+            'brave-search': { enabled: true, apiKey: reference },
+          },
+        }),
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.config.providers['brave-answers']?.api_key).toBe(expected);
+      expect(result.config.providers['brave-search']?.api_key).toBe(reference);
+      expect(result.notices).toContainEqual(
+        expect.objectContaining({
+          code: 'config_credential_reference_migrated',
+          path: '/global/providers/brave-answers/apiKey',
+        }),
+      );
+    },
+  );
+
+  it('migrates the exact old Brave Answers reference in native v2 config only', () => {
+    const result = migrateConfig({
+      global: v2({
+        providers: {
+          'brave-answers': {
+            enabled: true,
+            api_key: 'keychain:BRAVE_API_KEY',
+          },
+          'brave-search': {
+            enabled: true,
+            api_key: 'keychain:BRAVE_API_KEY',
+          },
+          exa: { enabled: true, api_key: 'keychain:custom-exa-key' },
+        },
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.providers['brave-answers']?.api_key).toBe(
+      'keychain:BRAVE_ANSWERS_API_KEY',
+    );
+    expect(result.config.providers['brave-search']?.api_key).toBe(
+      'keychain:BRAVE_API_KEY',
+    );
+    expect(result.config.providers.exa?.api_key).toBe(
+      'keychain:custom-exa-key',
+    );
+    expect(result.notices).toContainEqual(
+      expect.objectContaining({
+        code: 'config_credential_reference_migrated',
+        path: '/global/providers/brave-answers/api_key',
+      }),
+    );
+  });
+
   it('never grants trust to custom providers during v1 migration', () => {
     const custom = customSource('acme');
     const source = v1({

--- a/tests/provider-descriptors.test.ts
+++ b/tests/provider-descriptors.test.ts
@@ -17,6 +17,7 @@ import {
 import type { HttpStreamClient } from '../src/core/http-client.js';
 import { getMeteringKind } from '../src/core/metering.js';
 import { PROVIDER_CATALOG } from '../src/core/provider-catalog.js';
+import { BUILTIN_PROVIDER_CATALOG } from '../src/core/provider-profiles.js';
 import { RETIRED_PROVIDER_REPLACEMENTS } from '../src/core/retired-provider-ids.js';
 import { searchApiOptionsSchema } from '../src/core/searchapi.js';
 import {
@@ -153,6 +154,41 @@ describe('built-in provider descriptors', () => {
         ({ id }) => id === 'perplexity-sonar-pro',
       )?.credential.autoEnable,
     ).toBe(true);
+  });
+
+  it('keeps Brave Answers and Brave Search credentials distinct', () => {
+    expect(PROVIDER_ENV_VARS['brave-answers']).toBe('BRAVE_ANSWERS_API_KEY');
+    expect(PROVIDER_ENV_VARS['brave-search']).toBe('BRAVE_API_KEY');
+    expect(
+      BUILTIN_PROVIDER_CATALOG.find(
+        ({ provider_id }) => provider_id === 'brave-answers',
+      )?.credential.env_var,
+    ).toBe(PROVIDER_ENV_VARS['brave-answers']);
+    expect(
+      BUILTIN_PROVIDER_CATALOG.find(
+        ({ provider_id }) => provider_id === 'brave-search',
+      )?.credential.env_var,
+    ).toBe(PROVIDER_ENV_VARS['brave-search']);
+
+    const answerOnly = computeInitProviderChoices({
+      BRAVE_ANSWERS_API_KEY: 'answers-fixture-key',
+    }).filter(({ id }) => id.startsWith('brave-'));
+    const searchOnly = computeInitProviderChoices({
+      BRAVE_API_KEY: 'search-fixture-key',
+    }).filter(({ id }) => id.startsWith('brave-'));
+
+    expect(
+      answerOnly.map(({ id, enableByDefault }) => ({ id, enableByDefault })),
+    ).toEqual([
+      { id: 'brave-answers', enableByDefault: true },
+      { id: 'brave-search', enableByDefault: false },
+    ]);
+    expect(
+      searchOnly.map(({ id, enableByDefault }) => ({ id, enableByDefault })),
+    ).toEqual([
+      { id: 'brave-answers', enableByDefault: false },
+      { id: 'brave-search', enableByDefault: true },
+    ]);
   });
 
   it('keeps every Parallel profile opt-in when its shared key is present', () => {


### PR DESCRIPTION
## Summary

Separate Brave AI Answers and Brave Web Search credential families so each product uses its own API key. Migrate only the two exact historical Brave Answers references to the new family.

## What changed

- use `BRAVE_ANSWERS_API_KEY` for Brave Answers
- keep `BRAVE_API_KEY` for Brave Search
- keep descriptor, canonical profile catalog, benchmark inventory, and CI secret guard in lockstep
- migrate exact `$BRAVE_API_KEY` and `keychain:BRAVE_API_KEY` Brave Answers references with a notice
- leave Brave Search and arbitrary custom references unchanged
- add cross-authority, admission, and migration regression tests

## Test plan

- [x] focused credential/catalog/config/live-validation suite: 375 passed
- [x] full unit suite with provider variables unset: 2,046 passed, 7 skipped
- [x] typecheck and lint
- [x] build and declarations
- [x] Workers: 30 passed
- [x] integration: 11 passed
- [x] packed consumer
- [x] PTY: 5 passed
- [x] diff check
- [x] independent security and architecture closure reviews: GO

## Live-validation context

The immutable RC3 candidate proved Brave Answers successfully with its dedicated key. Brave Search then returned no results under that key, and the validation harness stopped before any other provider. A new candidate is required after this fix; this PR itself makes no provider calls.