### PR TITLE
fix: preserve safe provider failures

### DIFF
--- a/src/adapters/brave-answers.ts
+++ b/src/adapters/brave-answers.ts
@@ -2,6 +2,7 @@ import { MAX_RESPONSE_SIZE } from '../constants.js';
 import { getBuiltinProviderDefaultModel } from '../core/provider-descriptor.js';
 import type {
   Citation,
+  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -49,6 +50,7 @@ export class BraveAnswersProvider extends BaseProvider {
       options.timeout * 1000,
     );
     const abortFromCaller = () => controller.abort();
+    let requestStarted = false;
 
     if (options.signal) {
       if (options.signal.aborted) controller.abort();
@@ -61,6 +63,7 @@ export class BraveAnswersProvider extends BaseProvider {
 
     try {
       const apiKey = this.getApiKey();
+      requestStarted = true;
       const response = await fetch(BRAVE_ANSWERS_URL, {
         method: 'POST',
         headers: {
@@ -121,7 +124,12 @@ export class BraveAnswersProvider extends BaseProvider {
         content: '',
         citations: [],
         durationMs: Math.round(performance.now() - start),
-        error: this.formatCatchError(err),
+        error: 'Brave Answers request failed.',
+        failureDiagnostic: this.catchDiagnostic(
+          err,
+          controller.signal.aborted,
+          requestStarted,
+        ),
       };
     } finally {
       clearTimeout(timeoutId);
@@ -148,7 +156,13 @@ export class BraveAnswersProvider extends BaseProvider {
       content: '',
       citations: [],
       durationMs,
-      error: this.formatBraveError(status, body),
+      error: 'Brave Answers request failed.',
+      failureDiagnostic: {
+        kind: this.classifyBraveFailure(status, body),
+        ...(this.validHttpStatus(status) !== undefined && {
+          httpStatus: status,
+        }),
+      },
     };
   }
 
@@ -546,42 +560,45 @@ export class BraveAnswersProvider extends BaseProvider {
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
   }
 
-  private formatBraveError(status: number, body: unknown): string {
-    const detail = this.braveErrorDetail(body);
-    const base = `Brave Answers API returned ${status}: ${detail}`;
-
+  private classifyBraveFailure(
+    status: number,
+    body: unknown,
+  ): ProviderFailureDiagnostic['kind'] {
     // Live-verified: Brave reports an invalid key as 422 and a key whose plan
-    // lacks the Answers option as 400, so route hints by error code first.
+    // lacks the Answers option as 400, so classify by code first. The code is
+    // inspected in memory but is never returned or persisted.
     const code = this.braveErrorCode(body);
     if (code === 'SUBSCRIPTION_TOKEN_INVALID') {
-      return `${base} — check that ${this.envVar} is a valid Brave Search API key`;
+      return 'authentication';
     }
     if (code === 'OPTION_NOT_IN_PLAN') {
-      return `${base} — your Brave plan does not include the Answers API; upgrade at https://api-dashboard.search.brave.com`;
+      return 'plan_required';
     }
+    if (status === 401 || status === 403) return 'authentication';
+    if (status === 402) return 'billing';
+    if (status === 408 || status === 504) return 'timeout';
+    if (status === 429) return 'rate_limit';
+    if (status >= 400 && status < 500) return 'invalid_request';
+    return 'provider';
+  }
 
-    if (status === 401) {
-      return `${base} — check that ${this.envVar} is valid and enabled for the Brave Answers plan`;
+  private catchDiagnostic(
+    err: unknown,
+    aborted: boolean,
+    requestStarted: boolean,
+  ): ProviderFailureDiagnostic {
+    if (!requestStarted) return { kind: 'authentication' };
+    if (aborted || (err instanceof DOMException && err.name === 'AbortError')) {
+      return { kind: 'timeout' };
     }
-    if (status === 402) {
-      return `${base} — Payment Required; check your Brave billing and Answers plan`;
-    }
-    if (status === 403) {
-      return `${base} — API key may lack permission for the Answers API`;
-    }
-    if (status === 404) {
-      return `${base} — confirm the Brave Answers API endpoint is available for your plan`;
-    }
-    if (status === 422) {
-      return `${base} — request validation failed; review the request and try a shorter query`;
-    }
-    if (status === 429) {
-      return `${base} — rate limit reached; reduce request rate and retry`;
-    }
-    if (status === 400) {
-      return `${base} — check the request parameters`;
-    }
-    return base;
+    if (err instanceof TypeError) return { kind: 'network' };
+    return { kind: 'provider' };
+  }
+
+  private validHttpStatus(status: number): number | undefined {
+    return Number.isInteger(status) && status >= 100 && status <= 599
+      ? status
+      : undefined;
   }
 
   private braveErrorCode(body: unknown): string | undefined {
@@ -589,32 +606,6 @@ export class BraveAnswersProvider extends BaseProvider {
     const error = body.error;
     if (!this.isRecord(error)) return undefined;
     return this.firstString(error.code);
-  }
-
-  private braveErrorDetail(body: unknown): string {
-    if (this.isRecord(body)) {
-      const error = body.error;
-      if (this.isRecord(error)) {
-        const detail = this.firstString(error.detail);
-        if (detail) return detail;
-        const code = this.firstString(error.code);
-        if (code) return code;
-      }
-      const type = this.firstString(body.type);
-      if (type) return type;
-      if (typeof error === 'string' && error.trim()) return error;
-    }
-    return this.truncateBody(body);
-  }
-
-  private truncateBody(body: unknown): string {
-    let serialized: string;
-    try {
-      serialized = typeof body === 'string' ? body : JSON.stringify(body);
-    } catch {
-      serialized = String(body);
-    }
-    return (serialized || 'unknown error response').slice(0, 200);
   }
 
   private isRecord(value: unknown): value is JsonRecord {

--- a/src/core-entry.ts
+++ b/src/core-entry.ts
@@ -183,6 +183,8 @@ export type {
   MeteringKind,
   Provider,
   ProviderCommon,
+  ProviderFailureDiagnostic,
+  ProviderFailureKind,
   ProviderMetering,
   ProviderOptions,
   ProviderResult,

--- a/src/core/provider-attempt-bridge.ts
+++ b/src/core/provider-attempt-bridge.ts
@@ -7,7 +7,13 @@ import {
   ExecutionProfileSchema,
   executionProfilesEqual,
 } from '../contracts/domain/index.js';
-import type { AsyncTaskHandle, Provider, ProviderResult } from '../types.js';
+import type {
+  AsyncTaskHandle,
+  Provider,
+  ProviderFailureDiagnostic,
+  ProviderFailureKind,
+  ProviderResult,
+} from '../types.js';
 import type { AttemptLaunch } from './coordinator.js';
 import type { AdapterBindingIdentity } from './execution-plan.js';
 import type {
@@ -53,6 +59,100 @@ function providerFailure(
     category,
     retryable,
     fallback_allowed: fallbackAllowed,
+  };
+}
+
+const PROVIDER_FAILURE_KINDS = new Set<ProviderFailureKind>([
+  'authentication',
+  'plan_required',
+  'billing',
+  'rate_limit',
+  'invalid_request',
+  'network',
+  'timeout',
+  'provider',
+]);
+
+function validatedFailureDiagnostic(
+  value: unknown,
+): ProviderFailureDiagnostic | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.kind !== 'string' ||
+    !PROVIDER_FAILURE_KINDS.has(candidate.kind as ProviderFailureKind)
+  ) {
+    return undefined;
+  }
+  const httpStatus = candidate.httpStatus;
+  return {
+    kind: candidate.kind as ProviderFailureKind,
+    ...(typeof httpStatus === 'number' &&
+      Number.isInteger(httpStatus) &&
+      httpStatus >= 100 &&
+      httpStatus <= 599 && { httpStatus }),
+  };
+}
+
+function diagnosedProviderFailure(
+  diagnostic: ProviderFailureDiagnostic | undefined,
+  fallbackAllowed: boolean,
+): StructuredError {
+  const mapped: Record<
+    ProviderFailureKind,
+    Pick<StructuredError, 'code' | 'category' | 'retryable'>
+  > = {
+    authentication: {
+      code: 'provider_authentication_failed',
+      category: 'authentication',
+      retryable: false,
+    },
+    plan_required: {
+      code: 'provider_plan_required',
+      category: 'authorization',
+      retryable: false,
+    },
+    billing: {
+      code: 'provider_billing_failed',
+      category: 'budget',
+      retryable: false,
+    },
+    rate_limit: {
+      code: 'provider_rate_limited',
+      category: 'rate_limit',
+      retryable: true,
+    },
+    invalid_request: {
+      code: 'provider_invalid_request',
+      category: 'validation',
+      retryable: false,
+    },
+    network: {
+      code: 'provider_network_failed',
+      category: 'network',
+      retryable: true,
+    },
+    timeout: {
+      code: 'provider_timeout',
+      category: 'timeout',
+      retryable: true,
+    },
+    provider: {
+      code: 'provider_reported_error',
+      category: 'provider',
+      retryable: true,
+    },
+  };
+  const selected = mapped[diagnostic?.kind ?? 'provider'];
+  return {
+    ...selected,
+    message: 'The provider returned an error.',
+    fallback_allowed: fallbackAllowed,
+    ...(diagnostic?.httpStatus !== undefined && {
+      provider_code: `http_${diagnostic.httpStatus}`,
+    }),
   };
 }
 
@@ -115,13 +215,13 @@ function resultOutcome(
   completedHandle?: DurableHandle,
 ): AttemptExecutionResult {
   if (result.error) {
+    const diagnostic = validatedFailureDiagnostic(result.failureDiagnostic);
     return {
       kind: 'finished',
       finished: {
         outcome: 'failed',
-        error: providerFailure(
-          'provider_reported_error',
-          'The provider returned an error.',
+        error: diagnosedProviderFailure(
+          diagnostic,
           result.preventFallback !== true,
         ),
         ...(completedHandle && { durable_handle: completedHandle }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,23 @@ export interface Citation {
 }
 
 // Result from any provider execution
+export type ProviderFailureKind =
+  | 'authentication'
+  | 'plan_required'
+  | 'billing'
+  | 'rate_limit'
+  | 'invalid_request'
+  | 'network'
+  | 'timeout'
+  | 'provider';
+
+/** Bounded, non-secret facts about a provider failure. */
+export interface ProviderFailureDiagnostic {
+  kind: ProviderFailureKind;
+  /** Valid HTTP response status (100-599), when a response was received. */
+  httpStatus?: number;
+}
+
 export interface ProviderResult {
   provider: string;
   tier: ProviderTier;
@@ -160,6 +177,8 @@ export interface ProviderResult {
   /** Safe, allowlisted provider facts projected into canonical provider_meta. */
   providerMeta?: Record<string, unknown>;
   error?: string;
+  /** Safe diagnostic only. Never include provider payloads or raw errors. */
+  failureDiagnostic?: ProviderFailureDiagnostic;
   /** Fail closed when this result must not trigger a configured fallback. */
   preventFallback?: true;
 }

--- a/tests/adapters/brave-answers.test.ts
+++ b/tests/adapters/brave-answers.test.ts
@@ -323,7 +323,7 @@ describe('Brave Answers provider', () => {
     expect(result.usage).toBeUndefined();
   });
 
-  it('normalizes 401 errors from the nested Brave error envelope', async () => {
+  it('classifies 401 errors without retaining the Brave error envelope', async () => {
     globalThis.fetch = vi.fn().mockResolvedValueOnce(
       errorResponse(401, {
         error: { code: 'SUBSCRIPTION_TOKEN_INVALID', detail: 'Token rejected' },
@@ -332,9 +332,13 @@ describe('Brave Answers provider', () => {
 
     const result = await provider().execute('auth failure', { timeout: 10 });
 
-    expect(result.error).toContain('401');
-    expect(result.error).toContain('Token rejected');
-    expect(result.error).toContain('valid Brave Search API key');
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'authentication',
+      httpStatus: 401,
+    });
+    expect(JSON.stringify(result)).not.toContain('Token rejected');
+    expect(JSON.stringify(result)).not.toContain('SUBSCRIPTION_TOKEN_INVALID');
   });
 
   it('gives the key hint for a live-shaped 422 invalid-token rejection', async () => {
@@ -353,9 +357,11 @@ describe('Brave Answers provider', () => {
 
     const result = await provider().execute('bad key', { timeout: 10 });
 
-    expect(result.error).toContain('422');
-    expect(result.error).toContain('valid Brave Search API key');
-    expect(result.error).not.toContain('shorter query');
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'authentication',
+      httpStatus: 422,
+    });
   });
 
   it('gives the plan-upgrade hint for a live-shaped 400 option-not-in-plan rejection', async () => {
@@ -376,9 +382,13 @@ describe('Brave Answers provider', () => {
 
     const result = await provider().execute('no plan', { timeout: 10 });
 
-    expect(result.error).toContain('400');
-    expect(result.error).toContain('not subscribed');
-    expect(result.error).toContain('does not include the Answers API');
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'plan_required',
+      httpStatus: 400,
+    });
+    expect(JSON.stringify(result)).not.toContain('not subscribed');
+    expect(JSON.stringify(result)).not.toContain('api-dashboard');
   });
 
   it('normalizes 402 errors from the top-level Brave error envelope', async () => {
@@ -391,9 +401,12 @@ describe('Brave Answers provider', () => {
 
     const result = await provider().execute('billing failure', { timeout: 10 });
 
-    expect(result.error).toContain('402');
-    expect(result.error).toContain('payment_required');
-    expect(result.error).toContain('Payment Required');
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'billing',
+      httpStatus: 402,
+    });
+    expect(JSON.stringify(result)).not.toContain('Billing needed');
   });
 
   it('does not truncate a long query and normalizes a 422 validation rejection', async () => {
@@ -410,9 +423,11 @@ describe('Brave Answers provider', () => {
     expect(
       JSON.parse(fetchMock.mock.calls[0][1].body as string).messages[0],
     ).toEqual({ role: 'user', content: longQuery });
-    expect(result.error).toContain('422');
-    expect(result.error).toContain('VALIDATION');
-    expect(result.error).toContain('shorter query');
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'invalid_request',
+      httpStatus: 422,
+    });
   });
 
   it('normalizes 429 errors from the top-level Brave error envelope', async () => {
@@ -425,9 +440,11 @@ describe('Brave Answers provider', () => {
 
     const result = await provider().execute('rate limited', { timeout: 10 });
 
-    expect(result.error).toContain('429');
-    expect(result.error).toContain('rate_limit_exceeded');
-    expect(result.error).toContain('rate limit');
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'rate_limit',
+      httpStatus: 429,
+    });
   });
 
   it('returns a normalized result for network errors', async () => {
@@ -439,8 +456,30 @@ describe('Brave Answers provider', () => {
 
     expect(result.content).toBe('');
     expect(result.citations).toEqual([]);
-    expect(result.error).toContain(
-      'Network error connecting to Brave AI Answers',
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({ kind: 'network' });
+  });
+
+  it('does not retain secrets or arbitrary provider failure text', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      errorResponse(500, {
+        error: {
+          code: 'Bearer secret-token',
+          detail: 'raw response body https://private.example/token',
+        },
+        authorization: 'X-Subscription-Token secret-token',
+      }),
+    );
+
+    const result = await provider().execute('safe failure', { timeout: 10 });
+    const serialized = JSON.stringify(result);
+
+    expect(result).toMatchObject({
+      error: 'Brave Answers request failed.',
+      failureDiagnostic: { kind: 'provider', httpStatus: 500 },
+    });
+    expect(serialized).not.toMatch(
+      /Bearer|secret-token|raw response body|private\.example|X-Subscription-Token/,
     );
   });
 
@@ -568,7 +607,8 @@ describe('Brave Answers provider — stream robustness', () => {
 
     const result = await provider().execute('q', { timeout: 10 });
 
-    expect(result.error).toMatch(/exceeds/i);
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({ kind: 'provider' });
     expect(result.content).toBe('');
   });
 
@@ -594,7 +634,8 @@ describe('Brave Answers provider — stream robustness', () => {
       signal: abortController.signal,
     });
 
-    expect(result.error).toMatch(/abort/i);
+    expect(result.error).toBe('Brave Answers request failed.');
+    expect(result.failureDiagnostic).toEqual({ kind: 'timeout' });
     expect(result.content).toBe('');
   });
 });

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -1458,4 +1458,79 @@ describe('private prepared execution runtime', () => {
     );
     expect(JSON.stringify(result.state)).not.toContain('secret-token');
   });
+
+  it('maps only allowlisted provider failure diagnostics into canonical state', async () => {
+    const provider: Provider = {
+      id: 'adapter-primary',
+      displayName: 'Primary',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => ({
+        ...successfulResult('adapter-primary'),
+        error: 'Bearer secret-token raw response body',
+        failureDiagnostic: {
+          kind: 'authentication',
+          httpStatus: 422,
+          providerCode: 'SUBSCRIPTION_TOKEN_INVALID',
+          body: 'https://private.example Bearer secret-token',
+        },
+      })),
+    } as Provider;
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: coordinatorDependencies(),
+      attempts: createProviderAttemptBridge({
+        resolveExactBinding: () => resolvedBinding('primary', provider),
+        now: () => start,
+      }),
+    });
+
+    expect(result.state.attempts[0]?.error).toEqual({
+      code: 'provider_authentication_failed',
+      message: 'The provider returned an error.',
+      category: 'authentication',
+      retryable: false,
+      fallback_allowed: true,
+      provider_code: 'http_422',
+    });
+    expect(JSON.stringify(result.state)).not.toMatch(
+      /Bearer|secret-token|raw response body|SUBSCRIPTION_TOKEN_INVALID|private\.example/,
+    );
+  });
+
+  it('drops invalid provider failure diagnostic values', async () => {
+    const provider: Provider = {
+      id: 'adapter-primary',
+      displayName: 'Primary',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => ({
+        ...successfulResult('adapter-primary'),
+        error: 'failed',
+        failureDiagnostic: {
+          kind: 'Bearer secret-token',
+          httpStatus: 999,
+        },
+      })),
+    } as Provider;
+    const result = await runPreparedExecution(prepared([profile('primary')]), {
+      store: new InMemoryCoordinationStateStore(),
+      coordinator: coordinatorDependencies(),
+      attempts: createProviderAttemptBridge({
+        resolveExactBinding: () => resolvedBinding('primary', provider),
+        now: () => start,
+      }),
+    });
+
+    expect(result.state.attempts[0]?.error).toEqual({
+      code: 'provider_reported_error',
+      message: 'The provider returned an error.',
+      category: 'provider',
+      retryable: true,
+      fallback_allowed: true,
+    });
+    expect(JSON.stringify(result.state)).not.toContain('secret-token');
+  });
 });


### PR DESCRIPTION
## Summary

Preserve bounded provider failure diagnostics without exposing raw provider responses or credentials. This gives live validation enough safe evidence to distinguish authentication, plan, billing, rate-limit, request, network, timeout, and generic provider failures.

## What's New

- Add an allowlisted provider failure kind and validated HTTP status
- Classify Brave Answers failures without retaining provider text or bodies
- Revalidate diagnostics at the provider bridge boundary
- Keep the public error message fixed and generate bounded canonical codes
- Add secret-leak and classification regression tests

## Test Plan

- [x] 53 focused Brave and execution-runtime tests
- [x] Typecheck
- [x] Declaration build
- [x] Lint
- [x] Diff check
- [x] Independent security review: GO, no Critical/High/Medium findings

No live provider calls were made for this change.