### PR TITLE
fix: continue settled live validation

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -22,6 +22,7 @@ import {
   type FrozenAttemptReference,
   type FrozenCanonicalRequestContract,
   quoteCanonicalValidationTarget,
+  readPrivateRawEvidence,
   sanitizeCanonicalReceipt,
   validateCanonicalValidationCheckpoint,
   writePrivateRawEvidence,
@@ -666,13 +667,16 @@ export function installOfflineValidationSigint(
   return () => processLike.removeListener('SIGINT', onSignal);
 }
 
-/** Explicit human continuation after an interrupted run has no unsettled work. */
+/** Explicit human continuation after a run has no unsettled work. */
 export function continueFrozenValidationProtocol(
   repository: CanonicalValidationCheckpointRepository,
   gate: ApprovalGate,
   matrix: ReturnType<typeof buildCanonicalValidationMatrix>,
   confirmation: string,
   candidateAuthority: FrozenCandidateAuthority,
+  referenceAuthority: FrozenReferenceManifestAuthority = Object.freeze({
+    read: readTrustedFrozenReferenceManifest,
+  }),
 ): void {
   const checkpoint = repository.read();
   if (!checkpoint) {
@@ -711,6 +715,12 @@ export function continueFrozenValidationProtocol(
     checkpoint,
     matrix,
     gate.approval.candidate.fingerprint,
+    {
+      approved_unknown_targets: gate.approval.targets
+        .filter((target) => target.pricing.unknown_approved)
+        .map((target) => target.key),
+      aggregate_budget_microusd: gate.approval.aggregate_budget_microusd,
+    },
   );
   if (
     checkpoint.attempts.some((attempt) =>
@@ -721,13 +731,125 @@ export function continueFrozenValidationProtocol(
       'Exact reconciliation is required before continuation.',
     );
   }
-  if (!checkpoint.interrupted) return;
   if (
-    !repository.compareAndSwap(checkpoint, {
-      ...checkpoint,
-      interrupted: false,
-    })
+    checkpoint.attempts.some(
+      (attempt) =>
+        ['succeeded', 'failed', 'cancelled'].includes(attempt.status) &&
+        attempt.evidence_state !== 'complete',
+    )
   ) {
+    throw new CanonicalLiveValidationError(
+      'Complete terminal evidence is required before continuation.',
+    );
+  }
+  const byKey = new Map(matrix.targets.map((target) => [target.key, target]));
+  const protocolByKey = new Map(
+    gate.approval.targets.map((target) => [target.key, target]),
+  );
+  for (const attempt of checkpoint.attempts) {
+    if (!['succeeded', 'failed', 'cancelled'].includes(attempt.status))
+      continue;
+    const target = byKey.get(attempt.target_key);
+    const protocol = protocolByKey.get(attempt.target_key);
+    if (
+      !target ||
+      !protocol ||
+      !attempt.reference ||
+      !attempt.raw_evidence_name ||
+      !attempt.receipt_evidence_name
+    ) {
+      throw new CanonicalLiveValidationError(
+        'Continuation terminal evidence is incomplete.',
+      );
+    }
+    const manifest = referenceAuthority.read(
+      attempt.reference,
+      target,
+      'terminal',
+    );
+    const terminal = trustedTerminalOutcome(
+      target,
+      protocol,
+      attempt.reference,
+      {
+        status: 'terminal',
+        lifecycle:
+          manifest.coordination_state.status === 'succeeded'
+            ? 'succeeded'
+            : manifest.coordination_state.status === 'cancelled'
+              ? 'cancelled'
+              : 'failed',
+        request_id: manifest.request.request_id,
+        raw_manifest: JSON.stringify(manifest),
+      },
+      referenceAuthority,
+    );
+    const quality = frozenEvidenceQuality(target, terminal);
+    const expectedStatus =
+      terminal.lifecycle === 'succeeded' && quality.passed !== true
+        ? 'failed'
+        : terminal.lifecycle;
+    const rawEvidence = readPrivateRawEvidence(
+      gate.approval.raw_root,
+      attempt.raw_evidence_name,
+    );
+    let receipt: Record<string, unknown>;
+    try {
+      const receiptRoot = safeExistingDirectory(
+        gate.approval.receipt_root,
+        'Sanitized receipt root',
+      );
+      const receiptPath = resolve(receiptRoot, attempt.receipt_evidence_name);
+      const stat = lstatSync(receiptPath);
+      if (stat.isSymbolicLink() || !stat.isFile()) throw new Error('unsafe');
+      receipt = JSON.parse(readFileSync(receiptPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      throw new CanonicalLiveValidationError(
+        'Continuation sanitized receipt evidence is missing or invalid.',
+      );
+    }
+    const rebuilt = rebuildFrozenValidationEvidence(
+      gate,
+      target,
+      protocol,
+      { ...terminal, raw_manifest: rawEvidence },
+      expectedStatus,
+    );
+    if (
+      attempt.status !== expectedStatus ||
+      canonicalJson(JSON.parse(rawEvidence)) !== canonicalJson(manifest) ||
+      canonicalJson(receipt) !== canonicalJson(rebuilt.receipt) ||
+      canonicalJson(quality) !== canonicalJson(rebuilt.quality)
+    ) {
+      throw new CanonicalLiveValidationError(
+        `Continuation evidence drifted: ${attempt.target_key}.`,
+      );
+    }
+  }
+  const blocker = gate.approval.targets
+    .map((target) =>
+      checkpoint.attempts.find((attempt) => attempt.target_key === target.key),
+    )
+    .find(
+      (attempt) =>
+        attempt !== undefined &&
+        ['failed', 'cancelled'].includes(attempt.status) &&
+        !attempt.continuation_acknowledged,
+    );
+  if (!blocker && !checkpoint.interrupted) return;
+  const nextCheckpoint = {
+    ...checkpoint,
+    interrupted: false,
+    attempts: checkpoint.attempts.map((attempt) =>
+      blocker && attempt.target_key === blocker.target_key
+        ? { ...attempt, continuation_acknowledged: true as const }
+        : attempt,
+    ),
+  };
+  if (!repository.compareAndSwap(checkpoint, nextCheckpoint)) {
     throw new CanonicalLiveValidationError(
       'Checkpoint changed during continuation.',
     );
@@ -736,8 +858,41 @@ export function continueFrozenValidationProtocol(
 
 export interface FrozenExecutionState {
   readonly completed: readonly string[];
+  readonly failed: readonly string[];
+  readonly cancelled: readonly string[];
   readonly active?: string;
   readonly reserved_microusd: string;
+}
+
+export function terminalValidationCertification(
+  state: FrozenExecutionState,
+  targetCount: number,
+):
+  | undefined
+  | {
+      readonly mode: 'paid';
+      readonly certification: 'passed' | 'failed';
+      readonly target_count: number;
+      readonly succeeded: readonly string[];
+      readonly failed: readonly string[];
+      readonly cancelled: readonly string[];
+      readonly reserved_microusd: string;
+    } {
+  const settled =
+    state.completed.length + state.failed.length + state.cancelled.length;
+  if (state.active || settled !== targetCount) return undefined;
+  return Object.freeze({
+    mode: 'paid',
+    certification:
+      state.failed.length === 0 && state.cancelled.length === 0
+        ? 'passed'
+        : 'failed',
+    target_count: targetCount,
+    succeeded: state.completed,
+    failed: state.failed,
+    cancelled: state.cancelled,
+    reserved_microusd: state.reserved_microusd,
+  });
 }
 
 interface TrustedTerminalOutcome {
@@ -978,13 +1133,16 @@ function canonicalMeteringMetadata(
   return value as unknown as SafeCanonicalMetering;
 }
 
-function writeFrozenEvidence(
+export function rebuildFrozenValidationEvidence(
   gate: ApprovalGate,
   target: CanonicalValidationTarget,
   protocol: LiveValidationApproval['targets'][number],
   result: TrustedTerminalOutcome,
   lifecycleOverride?: 'succeeded' | 'failed' | 'cancelled',
-): { readonly passed: boolean; readonly reason?: string } {
+): {
+  readonly quality: Readonly<Record<string, boolean>>;
+  readonly receipt: Record<string, unknown>;
+} {
   const response = result.manifest.terminal_response;
   if (!response) {
     throw new CanonicalLiveValidationError(
@@ -1026,6 +1184,114 @@ function writeFrozenEvidence(
   const canonicalMetering = canonicalMeteringMetadata(providerMeta);
   const actualSource = canonicalMetering?.actual_cost_source ?? 'unknown';
   const quality = frozenEvidenceQuality(target, result);
+  const receipt = sanitizeCanonicalReceipt({
+    target,
+    candidate_fingerprint: gate.approval.candidate.fingerprint,
+    candidate_git_sha: gate.approval.candidate.git_sha,
+    candidate_version: gate.approval.candidate.version,
+    artifact_hashes: gate.approval.candidate.artifact_hashes,
+    pricing_quote: {
+      status: protocol.pricing.status,
+      reserved_microusd: protocol.pricing.reserved_microusd ?? '0',
+      ...(protocol.pricing.approved_maximum_microusd && {
+        approved_maximum_microusd: protocol.pricing.approved_maximum_microusd,
+      }),
+      currency: quote.currency,
+      completeness: quote.status,
+      missing_units: quote.missing_units,
+      source_class: quote.provenance?.source_class ?? 'unknown',
+      snapshot_fingerprint: quote.snapshot_fingerprint,
+    },
+    request_fingerprint: frozenRequestFingerprint(target, protocol),
+    run_evidence_sha256: `sha256:${createHash('sha256')
+      .update(result.raw_manifest)
+      .digest('hex')}`,
+    request_id: result.request_id,
+    account: protocol.account,
+    region: protocol.region,
+    lifecycle: lifecycleOverride ?? result.lifecycle,
+    response: {
+      content: resultBodies.join('\n'),
+      citations,
+    },
+    usage: response.usage,
+    // Namespaced canonical metering is authoritative even when a provider
+    // has no token/USD usage object. Unit-priced, token-computed, and
+    // account-delta evidence must survive the public receipt boundary.
+    metering:
+      primary?.usage || canonicalMetering
+        ? {
+            ...(canonicalMetering && { kind: canonicalMetering.kind }),
+            ...(canonicalMetering?.pricing_version && {
+              pricing_version: canonicalMetering.pricing_version,
+            }),
+            ...(primary?.usage?.actual_cost !== undefined && {
+              actual_cost: primary.usage.actual_cost,
+            }),
+            ...(primary?.usage?.estimated_cost !== undefined && {
+              estimated_cost: primary.usage.estimated_cost,
+            }),
+            ...(primary?.usage?.currency && {
+              currency: primary.usage.currency,
+            }),
+            source: actualSource,
+            source_class: canonicalMetering?.source_class ?? 'unknown',
+            completeness: canonicalMetering?.actual_completeness ?? 'unknown',
+            missing_units: canonicalMetering?.missing_units ?? [],
+            ...(canonicalMetering?.billable_units !== undefined && {
+              billable_units: canonicalMetering.billable_units,
+            }),
+            ...(canonicalMetering?.billable_unit && {
+              billable_unit: canonicalMetering.billable_unit,
+            }),
+            evidence_source: canonicalMetering
+              ? (canonicalMetering.actual_evidence ?? 'librarium_metering')
+              : 'unknown',
+            ...(primary?.usage?.prompt_tokens !== undefined && {
+              prompt_tokens: primary.usage.prompt_tokens,
+            }),
+            ...(primary?.usage?.completion_tokens !== undefined && {
+              completion_tokens: primary.usage.completion_tokens,
+            }),
+          }
+        : { completeness: 'unknown' },
+    provenance: provenance
+      ? {
+          result_kind: provenance.result_kind,
+          retrieval_methods_sha256: `sha256:${createHash('sha256')
+            .update(canonicalJson(provenance.retrieval_methods))
+            .digest('hex')}`,
+          corpora_sha256: `sha256:${createHash('sha256')
+            .update(canonicalJson(provenance.corpora))
+            .digest('hex')}`,
+          access_mode: profile?.access_mode ?? 'unverified',
+          operator_id: profile?.operator_id ?? 'unverified',
+          evidence_source: 'effective_profile',
+          ...(profile?.collector_id && {
+            collector_id: profile.collector_id,
+          }),
+          ...(profile?.surface_id && { surface_id: profile.surface_id }),
+        }
+      : undefined,
+    quality,
+  });
+  return { quality, receipt };
+}
+
+function writeFrozenEvidence(
+  gate: ApprovalGate,
+  target: CanonicalValidationTarget,
+  protocol: LiveValidationApproval['targets'][number],
+  result: TrustedTerminalOutcome,
+  lifecycleOverride?: 'succeeded' | 'failed' | 'cancelled',
+): { readonly passed: boolean; readonly reason?: string } {
+  const built = rebuildFrozenValidationEvidence(
+    gate,
+    target,
+    protocol,
+    result,
+    lifecycleOverride,
+  );
   writePrivateRawEvidence(
     gate.approval.raw_root,
     `${target.key.replace('/', '-')}.manifest`,
@@ -1034,99 +1300,9 @@ function writeFrozenEvidence(
   writeSanitizedCanonicalReceipt(
     gate.approval.receipt_root,
     `${target.key.replace('/', '-')}.json`,
-    sanitizeCanonicalReceipt({
-      target,
-      candidate_fingerprint: gate.approval.candidate.fingerprint,
-      candidate_git_sha: gate.approval.candidate.git_sha,
-      candidate_version: gate.approval.candidate.version,
-      artifact_hashes: gate.approval.candidate.artifact_hashes,
-      pricing_quote: {
-        status: protocol.pricing.status,
-        reserved_microusd: protocol.pricing.reserved_microusd ?? '0',
-        ...(protocol.pricing.approved_maximum_microusd && {
-          approved_maximum_microusd: protocol.pricing.approved_maximum_microusd,
-        }),
-        currency: quote.currency,
-        completeness: quote.status,
-        missing_units: quote.missing_units,
-        source_class: quote.provenance?.source_class ?? 'unknown',
-        snapshot_fingerprint: quote.snapshot_fingerprint,
-      },
-      request_fingerprint: frozenRequestFingerprint(target, protocol),
-      run_evidence_sha256: `sha256:${createHash('sha256')
-        .update(result.raw_manifest)
-        .digest('hex')}`,
-      request_id: result.request_id,
-      account: protocol.account,
-      region: protocol.region,
-      lifecycle: lifecycleOverride ?? result.lifecycle,
-      response: {
-        content: resultBodies.join('\n'),
-        citations,
-      },
-      usage: response.usage,
-      // Namespaced canonical metering is authoritative even when a provider
-      // has no token/USD usage object. Unit-priced, token-computed, and
-      // account-delta evidence must survive the public receipt boundary.
-      metering:
-        primary?.usage || canonicalMetering
-          ? {
-              ...(canonicalMetering && { kind: canonicalMetering.kind }),
-              ...(canonicalMetering?.pricing_version && {
-                pricing_version: canonicalMetering.pricing_version,
-              }),
-              ...(primary?.usage?.actual_cost !== undefined && {
-                actual_cost: primary.usage.actual_cost,
-              }),
-              ...(primary?.usage?.estimated_cost !== undefined && {
-                estimated_cost: primary.usage.estimated_cost,
-              }),
-              ...(primary?.usage?.currency && {
-                currency: primary.usage.currency,
-              }),
-              source: actualSource,
-              source_class: canonicalMetering?.source_class ?? 'unknown',
-              completeness: canonicalMetering?.actual_completeness ?? 'unknown',
-              missing_units: canonicalMetering?.missing_units ?? [],
-              ...(canonicalMetering?.billable_units !== undefined && {
-                billable_units: canonicalMetering.billable_units,
-              }),
-              ...(canonicalMetering?.billable_unit && {
-                billable_unit: canonicalMetering.billable_unit,
-              }),
-              evidence_source: canonicalMetering
-                ? (canonicalMetering.actual_evidence ?? 'librarium_metering')
-                : 'unknown',
-              ...(primary?.usage?.prompt_tokens !== undefined && {
-                prompt_tokens: primary.usage.prompt_tokens,
-              }),
-              ...(primary?.usage?.completion_tokens !== undefined && {
-                completion_tokens: primary.usage.completion_tokens,
-              }),
-            }
-          : { completeness: 'unknown' },
-      provenance: provenance
-        ? {
-            result_kind: provenance.result_kind,
-            retrieval_methods_sha256: `sha256:${createHash('sha256')
-              .update(canonicalJson(provenance.retrieval_methods))
-              .digest('hex')}`,
-            corpora_sha256: `sha256:${createHash('sha256')
-              .update(canonicalJson(provenance.corpora))
-              .digest('hex')}`,
-            access_mode: profile?.access_mode ?? 'unverified',
-            operator_id: profile?.operator_id ?? 'unverified',
-            evidence_source: 'effective_profile',
-            ...(profile?.collector_id && {
-              collector_id: profile.collector_id,
-            }),
-            ...(profile?.surface_id && { surface_id: profile.surface_id }),
-          }
-        : undefined,
-      quality,
-    }),
+    built.receipt,
   );
-  return quality.passed === true
+  return built.quality.passed === true
     ? { passed: true }
     : { passed: false, reason: 'deterministic_sensibility_failed' };
 }
@@ -1216,6 +1392,8 @@ export async function executeFrozenValidationProtocol(input: {
   )?.target_key;
   let state: FrozenExecutionState = {
     completed: [],
+    failed: [],
+    cancelled: [],
     ...(activeFromCheckpoint && { active: activeFromCheckpoint }),
     reserved_microusd: checkpoint.attempts
       .reduce(
@@ -1288,20 +1466,26 @@ export async function executeFrozenValidationProtocol(input: {
         referenceAuthority,
       );
       const quality = frozenEvidenceQuality(target, terminal);
+      const expectedStatus =
+        terminal.lifecycle === 'succeeded' && quality.passed !== true
+          ? 'failed'
+          : terminal.lifecycle;
       if (
         attempt.evidence_state === 'complete' &&
-        (attempt.status !== terminal.lifecycle ||
-          (attempt.status === 'succeeded' && quality.passed !== true))
+        attempt.status !== expectedStatus
       ) {
         throw new CanonicalLiveValidationError(
           `Terminal checkpoint differs from canonical lifecycle or quality: ${target.key}.`,
         );
       }
-      if (
-        attempt.status === 'succeeded' &&
-        attempt.evidence_state === 'complete'
-      ) {
-        state = { ...state, completed: [...state.completed, target.key] };
+      if (attempt.evidence_state === 'complete') {
+        if (attempt.status === 'succeeded') {
+          state = { ...state, completed: [...state.completed, target.key] };
+        } else if (attempt.status === 'failed') {
+          state = { ...state, failed: [...state.failed, target.key] };
+        } else if (attempt.status === 'cancelled') {
+          state = { ...state, cancelled: [...state.cancelled, target.key] };
+        }
       }
     }
   }
@@ -1553,7 +1737,7 @@ export async function executeFrozenValidationProtocol(input: {
   }
   const stopped = checkpoint.attempts.find(
     (attempt) =>
-      attempt.status !== 'succeeded' ||
+      (attempt.status !== 'succeeded' && !attempt.continuation_acknowledged) ||
       attempt.evidence_state === 'failed' ||
       (attempt.status === 'succeeded' && attempt.evidence_state !== 'complete'),
   );
@@ -1587,8 +1771,19 @@ export async function executeFrozenValidationProtocol(input: {
     checkpoint = interrupted;
     return { ...state };
   };
+  const settledTargetKeys = new Set(
+    checkpoint.attempts
+      .filter(
+        (attempt) =>
+          ['succeeded', 'failed', 'cancelled'].includes(attempt.status) &&
+          attempt.evidence_state === 'complete' &&
+          (attempt.status === 'succeeded' ||
+            attempt.continuation_acknowledged === true),
+      )
+      .map((attempt) => attempt.target_key),
+  );
   for (const protocol of input.gate.approval.targets) {
-    if (state.completed.includes(protocol.key)) continue;
+    if (settledTargetKeys.has(protocol.key)) continue;
     const target = byKey.get(protocol.key);
     if (!target)
       throw new CanonicalLiveValidationError(
@@ -1863,7 +2058,7 @@ export function registerLiveValidationCommand(
     .option('--paid', 'request execution of a frozen paid preregistration')
     .option(
       '--continue',
-      'continue an interrupted settled validation after repeating its approval',
+      'acknowledge one settled failure or continue an interrupted validation',
     )
     .option('--candidate-root <absolute-dir>', 'immutable candidate checkout')
     .option(
@@ -1891,6 +2086,11 @@ export function registerLiveValidationCommand(
         artifactRoot?: string;
         artifact?: string[];
       }) => {
+        if (options.continue && !options.paid) {
+          throw new CanonicalLiveValidationError(
+            '--continue requires explicit --paid validation mode.',
+          );
+        }
         if (!options.paid) {
           const restoreNetwork = (
             dependencies.installNetworkGuard ?? installOfflineNetworkGuard
@@ -2001,13 +2201,21 @@ export function registerLiveValidationCommand(
         const controller = new AbortController();
         const dispose = installOfflineValidationSigint(process, controller);
         try {
-          await executeFrozenValidationProtocol({
+          const state = await executeFrozenValidationProtocol({
             gate,
             matrix,
             executor,
             candidate_authority: candidateAuthority,
             signal: controller.signal,
           });
+          const certification = terminalValidationCertification(
+            state,
+            matrix.targets.length,
+          );
+          if (certification) {
+            process.stdout.write(`${JSON.stringify(certification, null, 2)}\n`);
+            if (certification.certification === 'failed') process.exitCode = 1;
+          }
         } finally {
           dispose();
         }

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -344,6 +344,8 @@ export interface CanonicalValidationAttempt {
   readonly raw_evidence_name?: string;
   readonly receipt_evidence_name?: string;
   readonly validation_failure_reason?: string;
+  /** Explicit durable operator acknowledgement of a settled non-success. */
+  readonly continuation_acknowledged?: true;
   readonly reference?: FrozenAttemptReference;
 }
 
@@ -458,6 +460,7 @@ const CheckpointSchema = z
             .regex(/^[a-z0-9._-]{1,128}$/)
             .optional(),
           validation_failure_reason: z.string().min(1).max(128).optional(),
+          continuation_acknowledged: z.literal(true).optional(),
           reference: z
             .strictObject({
               runs_root: z.string().min(1).max(512),
@@ -521,6 +524,18 @@ const CheckpointSchema = z
               message:
                 'Terminal evidence state, names, and failure reason are inconsistent',
               path: ['evidence_state'],
+            });
+          }
+          if (
+            attempt.continuation_acknowledged &&
+            (!['failed', 'cancelled'].includes(attempt.status) ||
+              attempt.evidence_state !== 'complete')
+          ) {
+            ctx.addIssue({
+              code: 'custom',
+              message:
+                'Continuation acknowledgement requires settled failed or cancelled evidence',
+              path: ['continuation_acknowledged'],
             });
           }
         })

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -2,6 +2,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  rmSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -26,7 +27,9 @@ import {
   frozenRequestFingerprint,
   installOfflineNetworkGuard,
   installOfflineValidationSigint,
+  rebuildFrozenValidationEvidence,
   registerLiveValidationCommand,
+  terminalValidationCertification,
 } from '../src/commands/live-validation.js';
 import type { PreparedResearchExecution } from '../src/core/execution-plan.js';
 import { profileIdentityKey } from '../src/core/execution-plan.js';
@@ -1175,6 +1178,27 @@ describe('canonical live-validation CLI protocol', () => {
         ?.options.map((option) => option.long),
     ).not.toContain('--providers');
   });
+
+  it('rejects continuation before entering unpaid offline mode', async () => {
+    let guarded = 0;
+    const program = new Command();
+    program.exitOverride();
+    registerLiveValidationCommand(program, {
+      installNetworkGuard: () => {
+        guarded += 1;
+        return () => {};
+      },
+    });
+    await expect(
+      program.parseAsync([
+        'node',
+        'librarium',
+        'live-validation',
+        '--continue',
+      ]),
+    ).rejects.toThrow('--continue requires explicit --paid');
+    expect(guarded).toBe(0);
+  });
 });
 
 describe('frozen paid protocol (injected, zero-network)', () => {
@@ -1449,6 +1473,40 @@ describe('frozen paid protocol (injected, zero-network)', () => {
           )
         : ({} as ReturnType<typeof CanonicalRunManifestV3Schema.parse>),
   };
+
+  it('reports terminal certification with success-only completed results', () => {
+    expect(
+      terminalValidationCertification(
+        {
+          completed: ['provider-a/profile'],
+          failed: ['provider-b/profile'],
+          cancelled: ['provider-c/profile'],
+          reserved_microusd: '123',
+        },
+        3,
+      ),
+    ).toStrictEqual({
+      mode: 'paid',
+      certification: 'failed',
+      target_count: 3,
+      succeeded: ['provider-a/profile'],
+      failed: ['provider-b/profile'],
+      cancelled: ['provider-c/profile'],
+      reserved_microusd: '123',
+    });
+    expect(
+      terminalValidationCertification(
+        {
+          completed: ['provider-a/profile'],
+          failed: [],
+          cancelled: [],
+          active: 'provider-b/profile',
+          reserved_microusd: '1',
+        },
+        2,
+      ),
+    ).toBeUndefined();
+  });
 
   it('performs every structural/drift/budget gate before the credential-capable prepare seam', async () => {
     const { gate: frozen, matrix, candidateAuthority } = gate();
@@ -2441,6 +2499,407 @@ describe('frozen paid protocol (injected, zero-network)', () => {
       status: 'failed',
       evidence_state: 'complete',
     });
+  });
+
+  it('continues past settled terminal receipts without resubmitting them', async () => {
+    const { gate: frozen, matrix, candidateAuthority } = gate();
+    const [succeeded, failed, cancelled, next] = matrix.targets;
+    const [succeededProtocol, failedProtocol, cancelledProtocol] =
+      frozen.approval.targets;
+    if (
+      !succeeded ||
+      !failed ||
+      !cancelled ||
+      !next ||
+      !succeededProtocol ||
+      !failedProtocol ||
+      !cancelledProtocol
+    ) {
+      throw new Error('missing continuation fixtures');
+    }
+    await canonicalManifest(
+      succeeded,
+      frozen.approval.raw_root,
+      'settled-succeeded',
+    );
+    await canonicalManifest(
+      failed,
+      frozen.approval.raw_root,
+      'settled-failed',
+      'failed',
+    );
+    const cancelledRaw = JSON.parse(
+      await canonicalManifest(
+        cancelled,
+        frozen.approval.raw_root,
+        'settled-cancelled',
+        'failed',
+      ),
+    );
+    cancelledRaw.coordination_state.status = 'cancelled';
+    fixtureManifests.set('settled-cancelled', JSON.stringify(cancelledRaw));
+    const settledReferenceAuthority = {
+      read: (
+        reference: { readonly request_id: string },
+        _target: unknown,
+        phase: string,
+      ) =>
+        (phase === 'terminal'
+          ? JSON.parse(fixtureManifests.get(reference.request_id)!)
+          : {}) as ReturnType<typeof CanonicalRunManifestV3Schema.parse>,
+    };
+    const terminalAttempt = (
+      target: typeof succeeded,
+      protocol: typeof succeededProtocol,
+      status: 'succeeded' | 'failed' | 'cancelled',
+      requestId: string,
+    ) => ({
+      target_key: target.key,
+      credential_family: protocol.credential_reference,
+      status,
+      reserved_microusd:
+        protocol.pricing.reserved_microusd ??
+        protocol.pricing.approved_maximum_microusd,
+      request_fingerprint: frozenRequestFingerprint(target, protocol),
+      reference: attemptReference(
+        target,
+        protocol,
+        frozen.approval.raw_root,
+        requestId,
+      ),
+      evidence_state: 'complete' as const,
+      raw_evidence_name: `${target.key.replace('/', '-')}.manifest`,
+      receipt_evidence_name: `${target.key.replace('/', '-')}.json`,
+    });
+    const settledAttempts = [
+      terminalAttempt(
+        succeeded,
+        succeededProtocol,
+        'succeeded',
+        'settled-succeeded',
+      ),
+      terminalAttempt(failed, failedProtocol, 'failed', 'settled-failed'),
+      terminalAttempt(
+        cancelled,
+        cancelledProtocol,
+        'cancelled',
+        'settled-cancelled',
+      ),
+    ];
+    for (const [attempt, target, protocol, raw] of [
+      [
+        settledAttempts[0]!,
+        succeeded,
+        succeededProtocol,
+        fixtureManifests.get('settled-succeeded')!,
+      ],
+      [
+        settledAttempts[1]!,
+        failed,
+        failedProtocol,
+        fixtureManifests.get('settled-failed')!,
+      ],
+      [
+        settledAttempts[2]!,
+        cancelled,
+        cancelledProtocol,
+        fixtureManifests.get('settled-cancelled')!,
+      ],
+    ] as const) {
+      const evidence = rebuildFrozenValidationEvidence(
+        frozen,
+        target,
+        protocol,
+        {
+          status: 'terminal',
+          lifecycle: attempt.status,
+          request_id: attempt.reference.request_id,
+          raw_manifest: raw,
+          manifest: JSON.parse(raw),
+        },
+        attempt.status,
+      );
+      writeFileSync(
+        join(frozen.approval.raw_root, attempt.raw_evidence_name),
+        raw,
+      );
+      writeFileSync(
+        join(frozen.approval.receipt_root, attempt.receipt_evidence_name),
+        JSON.stringify(evidence.receipt),
+      );
+    }
+    const repository = new CanonicalValidationCheckpointRepository(
+      frozen.approval.raw_root,
+    );
+    repository.create({
+      schema_version: 1,
+      pins: {
+        matrix_fingerprint: matrix.fingerprint,
+        catalog_digest: matrix.catalog_digest,
+        pricing_snapshot_fingerprint: matrix.pricing_snapshot_fingerprint,
+        candidate_fingerprint: frozen.approval.candidate.fingerprint,
+        approval_fingerprint: frozen.fingerprint,
+        target_protocols_digest: approvalTargetProtocolsDigest(frozen.approval),
+      },
+      target_order: frozen.approval.targets.map((target) => target.key),
+      attempts: settledAttempts,
+      interrupted: false,
+    });
+    const prepared: string[] = [];
+    const executed: string[] = [];
+    const executor = {
+      prepare: async (
+        target: typeof succeeded,
+        protocol: typeof succeededProtocol,
+      ) => {
+        prepared.push(target.key);
+        return attemptReference(target, protocol, frozen.approval.raw_root);
+      },
+      execute: async (target: typeof succeeded) => {
+        executed.push(target.key);
+        return {
+          status: 'reconcile' as const,
+          request_id: `request-${target.key.replace('/', '-')}`,
+          raw_manifest: '',
+        };
+      },
+      reconcile: async () => {
+        throw new Error('must not reconcile settled attempts');
+      },
+    };
+
+    await expect(
+      executeFrozenValidationProtocol({
+        gate: frozen,
+        matrix,
+        candidate_authority: candidateAuthority,
+        reference_manifest_authority: settledReferenceAuthority,
+        repository,
+        executor,
+      }),
+    ).rejects.toThrow(`stopped by terminal state: ${failed.key}`);
+    expect({ prepared, executed }).toStrictEqual({
+      prepared: [],
+      executed: [],
+    });
+
+    const failedReceiptPath = join(
+      frozen.approval.receipt_root,
+      settledAttempts[1]!.receipt_evidence_name,
+    );
+    const failedReceipt = readFileSync(failedReceiptPath, 'utf8');
+    writeFileSync(failedReceiptPath, '{}');
+    expect(() =>
+      continueFrozenValidationProtocol(
+        repository,
+        frozen,
+        matrix,
+        frozen.fingerprint,
+        candidateAuthority,
+        settledReferenceAuthority,
+      ),
+    ).toThrow(`Continuation evidence drifted: ${failed.key}`);
+    expect(repository.read()?.attempts[1]).not.toHaveProperty(
+      'continuation_acknowledged',
+    );
+    writeFileSync(failedReceiptPath, failedReceipt);
+    writeFileSync(
+      failedReceiptPath,
+      JSON.stringify({ ...JSON.parse(failedReceipt), unexpected: true }),
+    );
+    expect(() =>
+      continueFrozenValidationProtocol(
+        repository,
+        frozen,
+        matrix,
+        frozen.fingerprint,
+        candidateAuthority,
+        settledReferenceAuthority,
+      ),
+    ).toThrow(`Continuation evidence drifted: ${failed.key}`);
+    writeFileSync(failedReceiptPath, failedReceipt);
+    rmSync(failedReceiptPath);
+    expect(() =>
+      continueFrozenValidationProtocol(
+        repository,
+        frozen,
+        matrix,
+        frozen.fingerprint,
+        candidateAuthority,
+        settledReferenceAuthority,
+      ),
+    ).toThrow('sanitized receipt evidence is missing or invalid');
+    writeFileSync(failedReceiptPath, failedReceipt);
+
+    continueFrozenValidationProtocol(
+      repository,
+      frozen,
+      matrix,
+      frozen.fingerprint,
+      candidateAuthority,
+      settledReferenceAuthority,
+    );
+    expect(repository.read()?.attempts[1]).toMatchObject({
+      status: 'failed',
+      continuation_acknowledged: true,
+    });
+    expect(repository.read()?.attempts[2]).not.toHaveProperty(
+      'continuation_acknowledged',
+    );
+    await expect(
+      executeFrozenValidationProtocol({
+        gate: frozen,
+        matrix,
+        candidate_authority: candidateAuthority,
+        reference_manifest_authority: settledReferenceAuthority,
+        repository,
+        executor,
+      }),
+    ).rejects.toThrow(`stopped by terminal state: ${cancelled.key}`);
+    expect({ prepared, executed }).toStrictEqual({
+      prepared: [],
+      executed: [],
+    });
+
+    continueFrozenValidationProtocol(
+      repository,
+      frozen,
+      matrix,
+      frozen.fingerprint,
+      candidateAuthority,
+      settledReferenceAuthority,
+    );
+    const result = await executeFrozenValidationProtocol({
+      gate: frozen,
+      matrix,
+      candidate_authority: candidateAuthority,
+      reference_manifest_authority: settledReferenceAuthority,
+      repository,
+      executor,
+    });
+    expect({ prepared, executed }).toStrictEqual({
+      prepared: [next.key],
+      executed: [next.key],
+    });
+    expect(result.completed).toContain(succeeded.key);
+    expect(result.active).toBe(next.key);
+    expect(repository.read()?.attempts.slice(0, 3)).toStrictEqual([
+      settledAttempts[0],
+      { ...settledAttempts[1], continuation_acknowledged: true },
+      { ...settledAttempts[2], continuation_acknowledged: true },
+    ]);
+  });
+
+  it.each([
+    ['running', 'running', undefined],
+    ['ambiguous', 'ambiguous', undefined],
+    ['pending terminal evidence', 'failed', 'pending'],
+    ['failed terminal evidence', 'failed', 'failed'],
+  ] as const)(
+    'blocks explicit continuation for %s state',
+    (_label, status, evidenceState) => {
+      const { gate: frozen, matrix, candidateAuthority } = gate();
+      const target = matrix.targets[0]!;
+      const protocol = frozen.approval.targets[0]!;
+      const repository = new CanonicalValidationCheckpointRepository(
+        frozen.approval.raw_root,
+      );
+      repository.create({
+        schema_version: 1,
+        pins: {
+          matrix_fingerprint: matrix.fingerprint,
+          catalog_digest: matrix.catalog_digest,
+          pricing_snapshot_fingerprint: matrix.pricing_snapshot_fingerprint,
+          candidate_fingerprint: frozen.approval.candidate.fingerprint,
+          approval_fingerprint: frozen.fingerprint,
+          target_protocols_digest: approvalTargetProtocolsDigest(
+            frozen.approval,
+          ),
+        },
+        target_order: frozen.approval.targets.map((entry) => entry.key),
+        attempts: [
+          {
+            target_key: target.key,
+            credential_family: protocol.credential_reference,
+            status,
+            reserved_microusd:
+              protocol.pricing.reserved_microusd ??
+              protocol.pricing.approved_maximum_microusd,
+            request_fingerprint: frozenRequestFingerprint(target, protocol),
+            reference: attemptReference(
+              target,
+              protocol,
+              frozen.approval.raw_root,
+              `blocked-${status}`,
+            ),
+            ...(evidenceState && {
+              evidence_state: evidenceState,
+              raw_evidence_name: `${target.key.replace('/', '-')}.manifest`,
+              receipt_evidence_name: `${target.key.replace('/', '-')}.json`,
+              ...(evidenceState === 'failed' && {
+                evidence_error: 'fixture_evidence_failed',
+              }),
+            }),
+          },
+        ],
+        interrupted: false,
+      });
+      expect(() =>
+        continueFrozenValidationProtocol(
+          repository,
+          frozen,
+          matrix,
+          frozen.fingerprint,
+          candidateAuthority,
+        ),
+      ).toThrow(
+        evidenceState
+          ? 'Complete terminal evidence is required'
+          : status === 'ambiguous'
+            ? 'Ambiguous billable submission requires exact reconciliation'
+            : 'Exact reconciliation is required',
+      );
+    },
+  );
+
+  it('blocks explicit continuation when approval continuity drifts', () => {
+    const { gate: frozen, matrix, candidateAuthority } = gate();
+    const repository = new CanonicalValidationCheckpointRepository(
+      frozen.approval.raw_root,
+    );
+    repository.create({
+      schema_version: 1,
+      pins: {
+        matrix_fingerprint: matrix.fingerprint,
+        catalog_digest: matrix.catalog_digest,
+        pricing_snapshot_fingerprint: matrix.pricing_snapshot_fingerprint,
+        candidate_fingerprint: frozen.approval.candidate.fingerprint,
+        approval_fingerprint: frozen.fingerprint,
+        target_protocols_digest: approvalTargetProtocolsDigest(frozen.approval),
+      },
+      target_order: frozen.approval.targets.map((target) => target.key),
+      attempts: [],
+      interrupted: false,
+    });
+    const approval = {
+      ...frozen.approval,
+      targets: frozen.approval.targets.map((target, index) =>
+        index === 0 ? { ...target, query: 'drifted query' } : target,
+      ),
+    };
+    const drifted = {
+      approval,
+      fingerprint: approvalFingerprint(approval),
+    };
+    expect(() =>
+      continueFrozenValidationProtocol(
+        repository,
+        drifted,
+        matrix,
+        drifted.fingerprint,
+        candidateAuthority,
+      ),
+    ).toThrow('approval protocol continuity drifted');
   });
 
   it('fails closed on a stale checkpoint CAS before the execute seam', async () => {


### PR DESCRIPTION
## Summary

Add an explicit, durable continuation path for a paid validation that has a settled failed or cancelled profile. The default remains fail-fast, and continuation never retries or certifies the unsuccessful profile.

## What's New

- CAS-acknowledge exactly one settled failure or cancellation per repeated approval
- Rebuild and compare the complete sanitized receipt before acknowledgement
- Keep unsuccessful reservations in the aggregate budget
- Skip acknowledged targets without prepare, execute, reconcile, retry, or duplicate reservation
- Reject active custody, incomplete evidence, tampering, and approval drift
- Report success, failure, and cancellation separately; aggregate failures exit nonzero
- Reject --continue unless paid mode is active

## Test Plan

- [x] 125 combined live-validation, Brave, and execution-runtime tests
- [x] Full suite: 2,053 passed, 7 skipped before stacking
- [x] Typecheck
- [x] Lint
- [x] Diff check
- [x] Independent architecture closure review: GO

No live provider calls were made for this change.