### PR TITLE
chore: lock v2 rc6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.5",
+      "version": "2.0.0-rc.6",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Lock v2.0.0-rc.6 on top of the reviewed live-validation safety fixes. The exact 40-profile inventory and all catalog, pricing, matrix, contract, and artifact authorities remain unchanged.

## What's New

- Set package and lockfile versions to 2.0.0-rc.6
- Preserve the exact 40-profile immutable matrix
- Preserve the reviewed safe-failure and durable-continuation behavior

## Test Plan

- [x] Full unit suite: 2,056 passed, 7 skipped
- [x] Focused RC and live validation: 154 tests
- [x] Workers: 29 tests
- [x] Integration: 11 tests
- [x] PTY: 5 tests
- [x] Live fixtures: 91 tests
- [x] Typecheck, lint, build, declarations, packed consumer, benchmark, workflow policy
- [x] Immutable package build and verification
- [x] Independent security and architecture reviews: GO

Local SEA generation is unavailable in the installed Node 26.6 build. The protected multi-platform RC workflow remains the authority. No provider calls, publication, tags, or releases were performed.