### PR TITLE
fix: preserve safe pricing units

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -1489,28 +1489,43 @@ export async function executeFrozenValidationProtocol(input: {
       }
     }
   }
-  // A prior process can crash after terminal custody is persisted but before
-  // public/private evidence finishes. Reconcile again (never submit) and
-  // regenerate deterministic evidence before scheduling or continuation.
+  // A prior process can crash, or a local evidence write can fail, after
+  // terminal custody is persisted. Rebuild only from the verified terminal
+  // manifest; recovery must never enter a credential-capable executor seam.
   for (const pending of checkpoint.attempts.filter(
     (attempt) =>
       ['succeeded', 'failed', 'cancelled'].includes(attempt.status) &&
-      attempt.evidence_state === 'pending',
+      (attempt.evidence_state === 'pending' ||
+        attempt.evidence_state === 'failed'),
   )) {
     const target = byKey.get(pending.target_key);
     const protocol = protocolByKey.get(pending.target_key);
     if (!target || !protocol || !pending.reference) {
       throw new CanonicalLiveValidationError(
-        'Pending evidence lacks its exact frozen canonical reference.',
+        'Recoverable evidence lacks its exact frozen canonical reference.',
       );
     }
-    referenceAuthority.read(pending.reference, target, 'active');
+    const manifest = referenceAuthority.read(
+      pending.reference,
+      target,
+      'terminal',
+    );
     verifyCandidate();
     const terminal = trustedTerminalOutcome(
       target,
       protocol,
       pending.reference,
-      await input.executor.reconcile(target, protocol, pending.reference),
+      {
+        status: 'terminal',
+        lifecycle:
+          manifest.coordination_state.status === 'succeeded'
+            ? 'succeeded'
+            : manifest.coordination_state.status === 'cancelled'
+              ? 'cancelled'
+              : 'failed',
+        request_id: manifest.request.request_id,
+        raw_manifest: JSON.stringify(manifest),
+      },
       referenceAuthority,
     );
     const quality = frozenEvidenceQuality(target, terminal);
@@ -1555,6 +1570,7 @@ export async function executeFrozenValidationProtocol(input: {
                 validation_failure_reason: 'deterministic_sensibility_failed',
               }),
               evidence_state: 'complete' as const,
+              evidence_error: undefined,
             }
           : attempt,
       ),

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -1391,8 +1391,16 @@ const FORBIDDEN_RECEIPT_TEXT =
 
 const SAFE_RECEIPT_STRING =
   /^(?:USD|[a-z][a-z0-9._-]{0,127}(?:\/[a-z][a-z0-9._-]{0,127})?|(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:0|[1-9]\d*)|(?:0|[1-9]\d*)(?:\.\d{1,36})?|[a-f0-9]{40}|sha256:[a-f0-9]{64}|fnv1a64\.1:[a-f0-9]{16})$/;
+const SAFE_PROVIDER_PRICING_UNIT =
+  /^[a-z][a-z0-9-]{0,62}:[a-z][a-z0-9_]{0,62}$/;
+const PRICING_UNIT_RECEIPT_PATH =
+  /^receipt\.pricing_quote\.missing_units\[\d+\]$/;
 
-function assertSafeReceiptValue(value: unknown, path = 'receipt'): void {
+function assertSafeReceiptValue(
+  value: unknown,
+  path = 'receipt',
+  frozenPricingUnits: ReadonlySet<string> = new Set(),
+): void {
   if (
     value === null ||
     typeof value === 'boolean' ||
@@ -1401,9 +1409,13 @@ function assertSafeReceiptValue(value: unknown, path = 'receipt'): void {
     return;
   }
   if (typeof value === 'string') {
+    const isFrozenProviderPricingUnit =
+      PRICING_UNIT_RECEIPT_PATH.test(path) &&
+      SAFE_PROVIDER_PRICING_UNIT.test(value) &&
+      frozenPricingUnits.has(value);
     if (
       value.length > 256 ||
-      !SAFE_RECEIPT_STRING.test(value) ||
+      (!SAFE_RECEIPT_STRING.test(value) && !isFrozenProviderPricingUnit) ||
       FORBIDDEN_RECEIPT_TEXT.test(value)
     ) {
       throw new CanonicalLiveValidationError(
@@ -1419,7 +1431,7 @@ function assertSafeReceiptValue(value: unknown, path = 'receipt'): void {
       );
     }
     value.forEach((item, index) => {
-      assertSafeReceiptValue(item, `${path}[${index}]`);
+      assertSafeReceiptValue(item, `${path}[${index}]`, frozenPricingUnits);
     });
     return;
   }
@@ -1443,7 +1455,7 @@ function assertSafeReceiptValue(value: unknown, path = 'receipt'): void {
         `Public receipt has a prohibited field at ${path}.`,
       );
     }
-    assertSafeReceiptValue(child, `${path}.${key}`);
+    assertSafeReceiptValue(child, `${path}.${key}`, frozenPricingUnits);
   }
 }
 
@@ -1521,6 +1533,9 @@ export function sanitizeCanonicalReceipt(input: {
     quality: input.quality,
   };
   const serialized = canonicalJson(receipt);
-  assertSafeReceiptValue(JSON.parse(serialized));
+  const frozenPricingUnits = new Set(
+    quoteCanonicalValidationTarget(input.target).quote.missing_units,
+  );
+  assertSafeReceiptValue(JSON.parse(serialized), 'receipt', frozenPricingUnits);
   return JSON.parse(serialized) as Record<string, unknown>;
 }

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -557,6 +557,46 @@ describe('canonical v3 live validation evidence boundary', () => {
     ).toThrow('prohibited material');
   });
 
+  it('admits only frozen provider-namespaced pricing units', () => {
+    const target = buildCanonicalValidationMatrix().targets.find(
+      (candidate) => candidate.key === 'exa/research',
+    );
+    if (!target) throw new Error('missing Exa research target');
+    const base = {
+      target,
+      candidate_fingerprint:
+        'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      request_id: 'request-1',
+      account: 'reviewed-account',
+      region: 'us',
+      lifecycle: 'succeeded' as const,
+    };
+
+    expect(
+      sanitizeCanonicalReceipt({
+        ...base,
+        pricing_quote: { missing_units: ['exa:agent_compute_units'] },
+      }),
+    ).toMatchObject({
+      pricing_quote: { missing_units: ['exa:agent_compute_units'] },
+    });
+
+    for (const unsafeUnit of [
+      'secret:value',
+      'https://example.com/unit',
+      '/private/tmp/unit',
+      'exa:unknown_unit',
+      'unknown:unit',
+    ]) {
+      expect(() =>
+        sanitizeCanonicalReceipt({
+          ...base,
+          pricing_quote: { missing_units: [unsafeUnit] },
+        }),
+      ).toThrow('prohibited material');
+    }
+  });
+
   it('uses deterministic sensibility checks and never treats semantic judgment as a gate', () => {
     const target = buildCanonicalValidationMatrix().targets[0];
     if (!target) throw new Error('missing fixture target');
@@ -2361,7 +2401,7 @@ describe('frozen paid protocol (injected, zero-network)', () => {
     const { gate: frozen, matrix, candidateAuthority } = gate();
     const target = matrix.targets[0]!;
     const protocol = frozen.approval.targets[0]!;
-    const rawManifest = await canonicalManifest(
+    await canonicalManifest(
       target,
       frozen.approval.raw_root,
       'evidence-recovery',
@@ -2396,7 +2436,8 @@ describe('frozen paid protocol (injected, zero-network)', () => {
             protocol.pricing.reserved_microusd ??
             protocol.pricing.approved_maximum_microusd,
           request_fingerprint: frozenRequestFingerprint(target, protocol),
-          evidence_state: 'pending',
+          evidence_state: 'failed',
+          evidence_error: 'evidence_write_failed',
           reference: attemptReference(
             target,
             protocol,
@@ -2431,19 +2472,18 @@ describe('frozen paid protocol (injected, zero-network)', () => {
         },
         reconcile: async () => {
           reconciles += 1;
-          return {
-            status: 'terminal',
-            lifecycle: 'succeeded',
-            request_id: 'evidence-recovery',
-            raw_manifest: rawManifest,
-          };
+          throw new Error('must not reconcile terminal custody');
         },
       },
     });
     expect(prepares).toBe(0);
     expect(executes).toBe(0);
-    expect(reconciles).toBe(1);
-    expect(repository.read()?.attempts[0]?.evidence_state).toBe('complete');
+    expect(reconciles).toBe(0);
+    expect(repository.read()?.attempts[0]).toMatchObject({
+      status: 'succeeded',
+      evidence_state: 'complete',
+    });
+    expect(repository.read()?.attempts[0]?.evidence_error).toBeUndefined();
     expect(
       readPrivateRawEvidence(
         frozen.approval.raw_root,


### PR DESCRIPTION
## Summary

Allow trusted provider-namespaced pricing units in sanitized live-validation receipts and recover failed local evidence writes from terminal canonical custody without contacting the provider.

## What's New

- Accept a namespaced pricing unit only inside pricing quote missing units
- Bind every accepted unit to the exact frozen pricing authority for the target
- Keep global secret, URL, path, and raw-material rejection unchanged
- Recover pending or failed evidence from the trusted terminal run manifest
- Use zero prepare, execute, reconcile, credential, provider-init, or transport calls during evidence repair

## Test Plan

- [x] Focused live validation: 154 tests
- [x] Full unit suite: 2,057 passed, 7 skipped
- [x] Typecheck, lint, build, diff check
- [x] Security closure review: GO
- [x] Architecture closure review: GO

No live provider calls were made for this change.