### PR TITLE
chore: lock v2 rc7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.6",
+  "version": "2.0.0-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.6",
+      "version": "2.0.0-rc.7",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.6",
+  "version": "2.0.0-rc.7",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Locks Librarium v2 RC7 after the pricing-unit receipt recovery fix. The provider matrix and release authorities remain unchanged.

## Changes

- Set the package version to `2.0.0-rc.7`.
- Keep package and lockfile version authorities in exact agreement.
- Preserve the exact 40-profile catalog, pricing snapshot, and validation matrix.

## Test Plan

- [x] Focused RC and live-validation tests: 188 passed in final review.
- [x] Full unit suite: 2,057 passed, 7 skipped.
- [x] TypeScript typecheck and declaration build.
- [x] Biome lint and diff check.
- [x] Worker, integration, PTY, fixture, benchmark, workflow-policy, and packed-consumer gates.
- [x] Immutable package generation and verification.
- [ ] Protected multi-platform workflow must provide SEA proof; the local Homebrew Node 26.6 build disables SEA generation.

## Audit

Independent security and architecture reviews found no actionable Critical, High, or Medium issues.