### PR TITLE
fix: harden perplexity agent parsing

### DIFF
--- a/src/adapters/perplexity-agent-base.ts
+++ b/src/adapters/perplexity-agent-base.ts
@@ -4,10 +4,16 @@ import type {
   HttpRequestOptions,
   HttpResponse,
 } from '../core/http-client.js';
+import {
+  HttpRequestAbortedError,
+  HttpRequestTimeoutError,
+  HttpResponseTooLargeError,
+} from '../core/http-client.js';
 import type {
   AsyncPollResult,
   AsyncTaskHandle,
   Citation,
+  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderUsage,
@@ -16,7 +22,7 @@ import type { BaseProviderOptions } from './base.js';
 import { BackgroundBaseProvider, BaseProvider } from './base.js';
 
 const AGENT_API_URL = 'https://api.perplexity.ai/v1/agent';
-const AGENT_PRESETS = new Set(['low', 'medium', 'high']);
+const AGENT_PRESETS = new Set(['fast', 'low', 'medium', 'high', 'xhigh']);
 const AGENT_STATUSES = new Set([
   'queued',
   'in_progress',
@@ -36,7 +42,8 @@ const SOURCE_TYPES = new Set([
   'forum',
 ]);
 const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,254}$/;
-const SAFE_MODEL_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$/;
+const SAFE_MODEL_IDENTIFIER =
+  /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}\/[A-Za-z0-9][A-Za-z0-9._-]{0,189}$/;
 const DOCUMENTED_NON_CONTENT_OUTPUT_TYPES = new Set([
   'fetch_url_results',
   'finance_results',
@@ -65,7 +72,7 @@ export interface AgentInputPart {
 export type AgentInput = string | readonly AgentInputPart[];
 
 export interface AgentSearchResult {
-  readonly id: string;
+  readonly id: string | number;
   readonly url: string;
   readonly title?: string;
   readonly snippet?: string;
@@ -101,6 +108,7 @@ interface AgentTransport {
 
 interface AgentResponseError extends Error {
   readonly kind: 'agent_response' | 'agent_http';
+  readonly httpStatus?: number;
 }
 
 function responseError(
@@ -121,6 +129,13 @@ function record(value: unknown): Record<string, unknown> | undefined {
 
 function safeIdentifier(value: unknown, field: string): string {
   if (typeof value !== 'string' || !SAFE_IDENTIFIER.test(value)) {
+    throw responseError(`Perplexity Agent ${field} was malformed.`);
+  }
+  return value;
+}
+
+function safeModelIdentifier(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !SAFE_MODEL_IDENTIFIER.test(value)) {
     throw responseError(`Perplexity Agent ${field} was malformed.`);
   }
   return value;
@@ -282,11 +297,15 @@ function parseUsage(value: unknown): ParsedAgentUsage {
   };
 }
 
-function safeSearchResultId(value: unknown): string {
+function safeSearchResultId(value: unknown): string | number {
   if (typeof value === 'number') {
-    return String(nonNegativeNumber(value, 'search result id'));
+    return nonNegativeNumber(value, 'search result id');
   }
   return safeIdentifier(value, 'search result id');
+}
+
+function searchResultKey(value: string | number): string {
+  return String(value);
 }
 
 function parseSearchResult(value: unknown): AgentSearchResult {
@@ -361,20 +380,19 @@ function parseOutput(value: unknown): {
       }
       for (const resultValue of item.results) {
         const result = parseSearchResult(resultValue);
-        if (resultIds.has(result.id)) {
+        const resultKey = searchResultKey(result.id);
+        if (resultIds.has(resultKey)) {
           throw responseError(
             'Perplexity Agent search result ids were duplicated.',
           );
         }
-        resultIds.add(result.id);
+        resultIds.add(resultKey);
         searchResults.push(result);
       }
       continue;
     }
     if (!DOCUMENTED_NON_CONTENT_OUTPUT_TYPES.has(item.type)) {
-      throw responseError(
-        `Perplexity Agent output type was unsupported: ${item.type}.`,
-      );
+      throw responseError('Perplexity Agent output type was unsupported.');
     }
   }
   return { messages, searchResults };
@@ -384,7 +402,9 @@ function citedResultIds(
   messages: readonly string[],
   results: readonly AgentSearchResult[],
 ): ReadonlySet<string> {
-  const byId = new Map(results.map((result) => [result.id, result]));
+  const byId = new Map(
+    results.map((result) => [searchResultKey(result.id), result]),
+  );
   const cited = new Set<string>();
   const markerPattern = /\[([a-z][a-z0-9_-]*:)?(\d+)\]/gi;
   for (const message of messages) {
@@ -411,7 +431,7 @@ function citedResultIds(
           );
         }
       }
-      cited.add(result.id);
+      cited.add(searchResultKey(result.id));
     }
   }
   return cited;
@@ -435,7 +455,12 @@ export function parseAgentResponse(
     throw responseError('Perplexity Agent response status was unknown.');
   }
   const model =
-    root.model === undefined ? undefined : safeIdentifier(root.model, 'model');
+    root.model === undefined
+      ? undefined
+      : safeModelIdentifier(root.model, 'model');
+  if (status === 'completed' && model === undefined) {
+    throw responseError('Perplexity Agent completed response omitted model.');
+  }
   const output =
     root.output === undefined ? undefined : parseOutput(root.output);
   if (status === 'completed' && output === undefined) {
@@ -458,14 +483,12 @@ export function parseAgentResponse(
     const code =
       errorRecord.code === undefined
         ? undefined
-        : safeText(errorRecord.code, 'error code');
-    const message =
-      errorRecord.message === undefined
-        ? undefined
-        : redactPerplexityError(safeText(errorRecord.message, 'error message'));
+        : safeIdentifier(errorRecord.code, 'error code');
     error = {
       ...(code === undefined ? {} : { code }),
-      ...(message === undefined ? {} : { message }),
+      ...(errorRecord.message === undefined
+        ? {}
+        : { message: 'Perplexity Agent request failed.' }),
     };
   }
   const usage = root.usage === undefined ? undefined : parseUsage(root.usage);
@@ -474,7 +497,9 @@ export function parseAgentResponse(
     status: status as AgentStatus,
     ...(model === undefined ? {} : { model }),
     messages,
-    searchResults: searchResults.filter((result) => cited.has(result.id)),
+    searchResults: searchResults.filter((result) =>
+      cited.has(searchResultKey(result.id)),
+    ),
     ...(usage === undefined ? {} : { usage }),
     ...(error === undefined ? {} : { error }),
   };
@@ -485,6 +510,75 @@ function diagnostic(error: unknown): string {
   return redactPerplexityError(message).slice(0, 240);
 }
 
+function failureKindForStatus(
+  status: number,
+): ProviderFailureDiagnostic['kind'] {
+  if (status === 401) return 'authentication';
+  if (status === 402) return 'billing';
+  if (status === 403) return 'plan_required';
+  if (status === 408) return 'timeout';
+  if (status === 429) return 'rate_limit';
+  if ([400, 404, 409, 422].includes(status)) return 'invalid_request';
+  return 'provider';
+}
+
+function failureDiagnostic(error: unknown): ProviderFailureDiagnostic {
+  if (error instanceof HttpRequestTimeoutError) {
+    return { kind: 'timeout' };
+  }
+  if (error instanceof HttpResponseTooLargeError) {
+    return { kind: 'provider' };
+  }
+  if (
+    error instanceof Error &&
+    'kind' in error &&
+    error.kind === 'agent_http' &&
+    'httpStatus' in error &&
+    typeof error.httpStatus === 'number'
+  ) {
+    return {
+      kind: failureKindForStatus(error.httpStatus),
+      httpStatus: error.httpStatus,
+    };
+  }
+  if (
+    error instanceof Error &&
+    /fetch failed|failed to fetch|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT/i.test(
+      error.message,
+    )
+  ) {
+    return { kind: 'network' };
+  }
+  if (error instanceof TypeError) return { kind: 'invalid_request' };
+  return { kind: 'provider' };
+}
+
+const FAILURE_CODE_KINDS: Readonly<
+  Record<string, ProviderFailureDiagnostic['kind']>
+> = Object.freeze({
+  authentication_error: 'authentication',
+  invalid_api_key: 'authentication',
+  unauthorized: 'authentication',
+  permission_denied: 'plan_required',
+  forbidden: 'plan_required',
+  plan_required: 'plan_required',
+  billing_error: 'billing',
+  insufficient_credits: 'billing',
+  payment_required: 'billing',
+  rate_limit_error: 'rate_limit',
+  rate_limit_exceeded: 'rate_limit',
+  invalid_request_error: 'invalid_request',
+  validation_error: 'invalid_request',
+  bad_request: 'invalid_request',
+});
+
+function responseFailureDiagnostic(
+  response: ParsedAgentResponse,
+): ProviderFailureDiagnostic {
+  const code = response.error?.code?.toLowerCase();
+  return { kind: (code && FAILURE_CODE_KINDS[code]) || 'provider' };
+}
+
 export function redactPerplexityError(text: string, secret?: string): string {
   let redacted = text;
   if (secret) redacted = redacted.replaceAll(secret, '[REDACTED]');
@@ -493,13 +587,24 @@ export function redactPerplexityError(text: string, secret?: string): string {
     /((?:api[_-]?key|access[_-]?token|authorization|token|secret)\s*[:=]\s*["']?)[^\s,"'}]+/gi,
     '$1[REDACTED]',
   );
+  redacted = redacted.replace(
+    /(?:https?|file):\/\/[^\s,)}\]]+/gi,
+    '[REDACTED_URL]',
+  );
+  redacted = redacted.replace(
+    /(^|\s)(?:\/[A-Za-z0-9._~!$&'()*+,;=:@%/-]+|[A-Za-z]:\\[^\s,)}\]]+)/g,
+    '$1[REDACTED_PATH]',
+  );
   return redacted.replace(/\s+/g, ' ').trim();
 }
 
 function httpError(status: number): AgentResponseError {
-  return responseError(
-    `Perplexity Agent API returned HTTP ${status}.`,
-    'agent_http',
+  return Object.assign(
+    responseError(
+      `Perplexity Agent API returned HTTP ${status}.`,
+      'agent_http',
+    ),
+    { httpStatus: status },
   );
 }
 
@@ -537,18 +642,17 @@ async function postAgent(
   signal: AbortSignal | undefined,
   timeoutMs: number,
 ): Promise<ParsedAgentResponse> {
+  const value = await postAgentPayload(
+    transport,
+    input,
+    preset,
+    model,
+    background,
+    signal,
+    timeoutMs,
+  );
   try {
-    return parseAgentResponse(
-      await postAgentPayload(
-        transport,
-        input,
-        preset,
-        model,
-        background,
-        signal,
-        timeoutMs,
-      ),
-    );
+    return parseAgentResponse(value);
   } catch (error) {
     throw responseError(
       `Perplexity Agent response was malformed: ${diagnostic(error)}`,
@@ -563,7 +667,11 @@ async function submitAgent(
   model: string | undefined,
   signal: AbortSignal | undefined,
   timeoutMs: number,
-): Promise<{ readonly id: string; readonly status?: AgentStatus }> {
+): Promise<{
+  readonly id: string;
+  readonly status?: AgentStatus;
+  readonly failureDiagnostic?: ProviderFailureDiagnostic;
+}> {
   const value = await postAgentPayload(
     transport,
     input,
@@ -581,7 +689,21 @@ async function submitAgent(
     typeof root.status === 'string' && AGENT_STATUSES.has(root.status)
       ? (root.status as AgentStatus)
       : undefined;
-  return { id, ...(status === undefined ? {} : { status }) };
+  const diagnostic =
+    status === 'failed' || status === 'incomplete'
+      ? (() => {
+          try {
+            return responseFailureDiagnostic(parseAgentResponse(value));
+          } catch {
+            return { kind: 'provider' as const };
+          }
+        })()
+      : undefined;
+  return {
+    id,
+    ...(status === undefined ? {} : { status }),
+    ...(diagnostic === undefined ? {} : { failureDiagnostic: diagnostic }),
+  };
 }
 
 async function getAgent(
@@ -673,8 +795,7 @@ function resultFromResponse(
     const statusMessage =
       response.status === 'incomplete'
         ? 'Perplexity Agent task was incomplete.'
-        : (response.error?.message ??
-          `Perplexity Agent task was not completed (status: ${response.status}).`);
+        : `Perplexity Agent task was not completed (status: ${response.status}).`;
     return {
       provider,
       tier,
@@ -682,6 +803,7 @@ function resultFromResponse(
       citations: [],
       durationMs,
       error: redactPerplexityError(statusMessage),
+      failureDiagnostic: responseFailureDiagnostic(response),
     };
   }
   return {
@@ -692,7 +814,7 @@ function resultFromResponse(
       (result): Citation => ({
         url: result.url,
         provider,
-        providerReference: result.id,
+        providerReference: String(result.id),
         ...(result.title === undefined ? {} : { title: result.title }),
         ...(result.snippet === undefined ? {} : { snippet: result.snippet }),
       }),
@@ -725,19 +847,21 @@ function pollResult(response: ParsedAgentResponse): AsyncPollResult {
       return {
         status: 'cancelled',
         rawStatus: response.status,
-        message: response.error?.message,
+        message: 'Perplexity Agent task was cancelled.',
       };
     case 'incomplete':
       return {
         status: 'failed',
         rawStatus: response.status,
         message: 'Perplexity Agent task was incomplete.',
+        failureDiagnostic: responseFailureDiagnostic(response),
       };
     case 'failed':
       return {
         status: 'failed',
         rawStatus: response.status,
-        message: response.error?.message,
+        message: 'Perplexity Agent task failed.',
+        failureDiagnostic: responseFailureDiagnostic(response),
       };
   }
 }
@@ -817,13 +941,15 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         Math.round(performance.now() - started),
       );
     } catch (error) {
+      if (error instanceof HttpRequestAbortedError) throw error;
       return {
         provider: this.id,
         tier: this.tier,
         content: '',
         citations: [],
         durationMs: Math.round(performance.now() - started),
-        error: diagnostic(error),
+        error: 'Perplexity Agent request failed.',
+        failureDiagnostic: failureDiagnostic(error),
       };
     }
   }
@@ -857,14 +983,26 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         submittedAt: Date.now(),
         status,
         providerStatus: response.status ?? 'accepted_unknown',
+        ...(response.failureDiagnostic === undefined
+          ? {}
+          : { failureDiagnostic: response.failureDiagnostic }),
       };
     } catch (error) {
-      throw new UnsafeToRetrySubmissionError(diagnostic(error));
+      void error;
+      throw new UnsafeToRetrySubmissionError(
+        'Perplexity Agent submission outcome is unknown.',
+      );
     }
   }
 
   async poll(handle: AsyncTaskHandle): Promise<AsyncPollResult> {
-    return pollResult(await getAgent(this.transport(), handle.taskId, 15_000));
+    try {
+      return pollResult(
+        await getAgent(this.transport(), handle.taskId, 15_000),
+      );
+    } catch {
+      throw responseError('Perplexity Agent status check failed.');
+    }
   }
 
   async retrieve(handle: AsyncTaskHandle): Promise<ProviderResult> {
@@ -878,19 +1016,25 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         Math.round(performance.now() - started),
       );
     } catch (error) {
+      if (error instanceof HttpRequestAbortedError) throw error;
       return {
         provider: this.id,
         tier: this.tier,
         content: '',
         citations: [],
         durationMs: Math.round(performance.now() - started),
-        error: diagnostic(error),
+        error: 'Perplexity Agent retrieval failed.',
+        failureDiagnostic: failureDiagnostic(error),
       };
     }
   }
 
   async cancel(handle: AsyncTaskHandle): Promise<AsyncPollResult> {
-    return pollResult(await cancelAgent(this.transport(), handle.taskId));
+    try {
+      return pollResult(await cancelAgent(this.transport(), handle.taskId));
+    } catch {
+      throw responseError('Perplexity Agent cancellation failed.');
+    }
   }
 
   async test(): Promise<{ ok: boolean; error?: string }> {
@@ -912,8 +1056,8 @@ export abstract class PerplexityAgentBaseProvider extends BackgroundBaseProvider
         };
       }
       return { ok: true };
-    } catch (error) {
-      return { ok: false, error: diagnostic(error) };
+    } catch {
+      return { ok: false, error: 'Perplexity Agent health check failed.' };
     }
   }
 }
@@ -958,13 +1102,15 @@ export abstract class PerplexityAgentInlineProvider extends BaseProvider {
         Math.round(performance.now() - started),
       );
     } catch (error) {
+      if (error instanceof HttpRequestAbortedError) throw error;
       return {
         provider: this.id,
         tier: this.tier,
         content: '',
         citations: [],
         durationMs: Math.round(performance.now() - started),
-        error: diagnostic(error),
+        error: 'Perplexity Agent request failed.',
+        failureDiagnostic: failureDiagnostic(error),
       };
     }
   }
@@ -987,8 +1133,8 @@ export abstract class PerplexityAgentInlineProvider extends BaseProvider {
             ok: false,
             error: 'Perplexity Agent health check was not completed.',
           };
-    } catch (error) {
-      return { ok: false, error: diagnostic(error) };
+    } catch {
+      return { ok: false, error: 'Perplexity Agent health check failed.' };
     }
   }
 }

--- a/src/core/provider-attempt-bridge.ts
+++ b/src/core/provider-attempt-bridge.ts
@@ -156,6 +156,20 @@ function diagnosedProviderFailure(
   };
 }
 
+function durableProviderFailure(
+  diagnostic: unknown,
+  fallbackAllowed: boolean,
+): StructuredError {
+  const validated = validatedFailureDiagnostic(diagnostic);
+  return validated
+    ? diagnosedProviderFailure(validated, fallbackAllowed)
+    : providerFailure(
+        'provider_task_failed',
+        'The durable provider task failed.',
+        fallbackAllowed,
+      );
+}
+
 type DeadlineResult<T> =
   | { readonly kind: 'value'; readonly value: T }
   | { readonly kind: 'error'; readonly error: unknown }
@@ -470,11 +484,7 @@ export function createProviderAttemptBridge(
             kind: 'finished',
             finished: {
               outcome: 'failed',
-              error: providerFailure(
-                'provider_task_failed',
-                'The durable provider task failed.',
-                true,
-              ),
+              error: durableProviderFailure(poll.failureDiagnostic, true),
               durable_handle: observedHandle(latestHandle, 'failed', now),
             },
           };
@@ -650,11 +660,7 @@ export function createProviderAttemptBridge(
           kind: 'finished',
           finished: {
             outcome: 'failed',
-            error: providerFailure(
-              'provider_task_failed',
-              'The durable provider task failed.',
-              true,
-            ),
+            error: durableProviderFailure(task.failureDiagnostic, true),
             durable_handle: observedHandle(handle, 'failed', now),
           },
         };
@@ -751,11 +757,7 @@ export function createProviderAttemptBridge(
             kind: 'finished',
             finished: {
               outcome: 'failed',
-              error: providerFailure(
-                'provider_task_failed',
-                'The durable provider task failed.',
-                true,
-              ),
+              error: durableProviderFailure(poll.failureDiagnostic, true),
               durable_handle: observedHandle(latestHandle, 'failed', now),
             },
           };

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,8 @@ export interface AsyncTaskHandle {
   providerStatus?: string;
   /** Safe diagnostic from the most recent poll; never credentials or headers. */
   lastPollError?: string;
+  /** Safe, allowlisted facts for an immediately failed accepted task. */
+  failureDiagnostic?: ProviderFailureDiagnostic;
   outputDir?: string;
 }
 
@@ -225,6 +227,8 @@ export interface AsyncPollResult {
   message?: string;
   /** Provider-native state, persisted separately from Librarium's mapped state. */
   rawStatus?: string;
+  /** Safe, allowlisted facts when the observed task state is failed. */
+  failureDiagnostic?: ProviderFailureDiagnostic;
 }
 
 // Fields shared by every provider implementation.

--- a/tests/adapters/perplexity-agent.test.ts
+++ b/tests/adapters/perplexity-agent.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
-import { parseAgentResponse } from '../../src/adapters/perplexity-agent-base.js';
+import {
+  buildAgentRequest,
+  parseAgentResponse,
+  redactPerplexityError,
+} from '../../src/adapters/perplexity-agent-base.js';
 import { PerplexityDeepResearchProvider } from '../../src/adapters/perplexity-deep-research.js';
 import { PerplexitySonarDeepProvider } from '../../src/adapters/perplexity-sonar-deep.js';
 import { PerplexitySonarProProvider } from '../../src/adapters/perplexity-sonar-pro.js';
 import { UnsafeToRetrySubmissionError } from '../../src/core/errors.js';
-import type { HttpClient, HttpResponse } from '../../src/core/http-client.js';
+import {
+  type HttpClient,
+  HttpRequestAbortedError,
+  type HttpResponse,
+} from '../../src/core/http-client.js';
 import type { AsyncTaskHandle } from '../../src/types.js';
 
 function response<T>(data: unknown, status = 200): HttpResponse<T> {
@@ -31,11 +39,15 @@ function queuedClient(values: Array<{ data: unknown; status?: number }>): {
   return { client, calls };
 }
 
-function completed(id: string, text = 'Agent answer [web:1]') {
+function completed(
+  id: string,
+  text = 'Agent answer [web:1]',
+  model = 'openai/gpt-5.6-luna',
+) {
   return {
     id,
     status: 'completed',
-    model: 'agent-model',
+    model,
     output: [
       {
         type: 'search_results',
@@ -70,6 +82,12 @@ function completed(id: string, text = 'Agent answer [web:1]') {
         name: 'documented_but_not_persisted',
         arguments: '{}',
       },
+      { type: 'finance_results', results: [] },
+      { type: 'people_search_results', results: [] },
+      { type: 'sandbox_results', results: [] },
+      { type: 'mcp_list_tools', tools: [] },
+      { type: 'mcp_call', output: null },
+      { type: 'tool_search', tools: [] },
       {
         type: 'message',
         content: [
@@ -102,6 +120,17 @@ function handle(taskId: string): AsyncTaskHandle {
   };
 }
 
+function failed(id: string, code: string) {
+  return {
+    id,
+    status: 'failed',
+    error: {
+      code,
+      message: 'Bearer secret-value https://private.example.test/error',
+    },
+  };
+}
+
 describe('Perplexity Agent API adapters', () => {
   it('uses the strict low preset request and preserves typed evidence and reported usage', async () => {
     const { client, calls } = queuedClient([{ data: completed('inline-1') }]);
@@ -116,7 +145,7 @@ describe('Perplexity Agent API adapters', () => {
       provider: 'perplexity-sonar-pro',
       tier: 'ai-grounded',
       content: 'Agent answer [web:1]',
-      model: 'agent-model',
+      model: 'openai/gpt-5.6-luna',
       tokenUsage: { input: 10, output: 20 },
       usage: {
         inputTokens: 10,
@@ -159,6 +188,37 @@ describe('Perplexity Agent API adapters', () => {
     });
   });
 
+  it.each(['fast', 'low', 'medium', 'high', 'xhigh'])(
+    'accepts the documented dynamic %s preset without pinning a model',
+    (preset) => {
+      expect(buildAgentRequest('question', preset, undefined, false)).toEqual({
+        input: 'question',
+        preset,
+      });
+    },
+  );
+
+  it.each(['openai/gpt-5.6-luna', 'openai/gpt-5.6-sol', 'xai/grok-4.6'])(
+    'accepts the current bounded provider/model identifier %s',
+    (model) => {
+      expect(
+        parseAgentResponse(completed('model-task', 'Answer [1]', model)).model,
+      ).toBe(model);
+    },
+  );
+
+  it('preserves numeric search-result ids while projecting string citation references', async () => {
+    const parsed = parseAgentResponse(completed('numeric-id'));
+    expect(parsed.searchResults[0]?.id).toBe(1);
+
+    const result = await new PerplexitySonarProProvider({
+      apiKey: 'synthetic-perplexity-key',
+      httpClient: queuedClient([{ data: completed('numeric-provider') }])
+        .client,
+    }).execute('question', { timeout: 10 });
+    expect(result.citations[0]?.providerReference).toBe('1');
+  });
+
   it('submits medium background work, polls, retrieves, and never resubmits on retrieval', async () => {
     const { client, calls } = queuedClient([
       { data: { id: 'task-123', status: 'queued' } },
@@ -195,6 +255,7 @@ describe('Perplexity Agent API adapters', () => {
     });
     const retrieved = await provider.retrieve(submitted);
     expect(retrieved.content).toBe('Research result [1]');
+    expect(retrieved.model).toBe('openai/gpt-5.6-luna');
     expect(calls.map(({ url, options }) => [url, options.method])).toEqual([
       ['https://api.perplexity.ai/v1/agent', 'POST'],
       ['https://api.perplexity.ai/v1/agent/task-123', 'GET'],
@@ -257,6 +318,111 @@ describe('Perplexity Agent API adapters', () => {
     });
   });
 
+  it.each([
+    ['invalid_api_key', 'authentication'],
+    ['payment_required', 'billing'],
+    ['rate_limit_exceeded', 'rate_limit'],
+    ['validation_error', 'invalid_request'],
+  ] as const)(
+    'carries an immediate %s failure as a bounded %s diagnostic',
+    async (code, kind) => {
+      const provider = new PerplexityDeepResearchProvider({
+        apiKey: 'synthetic-perplexity-key',
+        httpClient: queuedClient([{ data: failed('immediate-failed', code) }])
+          .client,
+      });
+
+      const submitted = await provider.submit('question', { timeout: 10 });
+
+      expect(submitted).toMatchObject({
+        taskId: 'immediate-failed',
+        status: 'failed',
+        failureDiagnostic: { kind },
+      });
+      expect(JSON.stringify(submitted)).not.toMatch(
+        /secret-value|private\.example|Bearer/,
+      );
+    },
+  );
+
+  it.each([
+    ['invalid_api_key', 'authentication'],
+    ['payment_required', 'billing'],
+    ['rate_limit_exceeded', 'rate_limit'],
+    ['validation_error', 'invalid_request'],
+  ] as const)(
+    'carries a polled %s failure as a bounded %s diagnostic',
+    async (code, kind) => {
+      const provider = new PerplexityDeepResearchProvider({
+        apiKey: 'synthetic-perplexity-key',
+        httpClient: queuedClient([{ data: failed('polled-failed', code) }])
+          .client,
+      });
+
+      const polled = await provider.poll(handle('polled-failed'));
+
+      expect(polled).toEqual({
+        status: 'failed',
+        rawStatus: 'failed',
+        message: 'Perplexity Agent task failed.',
+        failureDiagnostic: { kind },
+      });
+      expect(JSON.stringify(polled)).not.toMatch(
+        /secret-value|private\.example|Bearer/,
+      );
+    },
+  );
+
+  it('requires an observed provider/model only for completed results', async () => {
+    const queued = parseAgentResponse({
+      id: 'queued-without-model',
+      status: 'queued',
+    });
+    expect(queued).toMatchObject({ status: 'queued' });
+    expect(queued).not.toHaveProperty('model');
+
+    const syncCompleted = completed('sync-without-model');
+    delete syncCompleted.model;
+    const syncResult = await new PerplexitySonarProProvider({
+      apiKey: 'synthetic-perplexity-key',
+      httpClient: queuedClient([{ data: syncCompleted }]).client,
+    }).execute('question', { timeout: 10 });
+    expect(syncResult).toMatchObject({
+      error: 'Perplexity Agent request failed.',
+      failureDiagnostic: { kind: 'provider' },
+    });
+
+    const durableCompleted = completed('durable-without-model');
+    delete durableCompleted.model;
+    const durableResult = await new PerplexityDeepResearchProvider({
+      apiKey: 'synthetic-perplexity-key',
+      httpClient: queuedClient([{ data: durableCompleted }]).client,
+    }).retrieve(handle('durable-without-model'));
+    expect(durableResult).toMatchObject({
+      error: 'Perplexity Agent retrieval failed.',
+      failureDiagnostic: { kind: 'provider' },
+    });
+  });
+
+  it('propagates caller aborts instead of classifying them as timeouts', async () => {
+    const abortedClient = vi.fn<HttpClient>(async () => {
+      throw new HttpRequestAbortedError();
+    });
+
+    await expect(
+      new PerplexitySonarProProvider({
+        apiKey: 'synthetic-perplexity-key',
+        httpClient: abortedClient,
+      }).execute('question', { timeout: 10 }),
+    ).rejects.toBeInstanceOf(HttpRequestAbortedError);
+    await expect(
+      new PerplexityDeepResearchProvider({
+        apiKey: 'synthetic-perplexity-key',
+        httpClient: abortedClient,
+      }).execute('question', { timeout: 10 }),
+    ).rejects.toBeInstanceOf(HttpRequestAbortedError);
+  });
+
   it('fails closed for unknown statuses, malformed usage, invalid URLs, and unmatched citation markers', async () => {
     expect(() =>
       parseAgentResponse({ id: 'task-1', status: 'mystery' }),
@@ -265,6 +431,7 @@ describe('Perplexity Agent API adapters', () => {
       parseAgentResponse({
         id: 'task-1',
         status: 'completed',
+        model: 'openai/gpt-5.6-luna',
         output: [
           { type: 'unknown_future_item' },
           {
@@ -278,6 +445,7 @@ describe('Perplexity Agent API adapters', () => {
       parseAgentResponse({
         id: 'task-1',
         status: 'completed',
+        model: 'openai/gpt-5.6-luna',
         output: [
           {
             type: 'message',
@@ -299,7 +467,10 @@ describe('Perplexity Agent API adapters', () => {
       httpClient: malformedClient.client,
     }).execute('question', { timeout: 10 });
     expect(malformedResult.content).toBe('');
-    expect(malformedResult.error).toContain('response was malformed');
+    expect(malformedResult).toMatchObject({
+      error: 'Perplexity Agent request failed.',
+      failureDiagnostic: { kind: 'provider' },
+    });
 
     const invalidUrl = completed('inline-3');
     invalidUrl.output[0]!.results[0]!.url = 'file:///etc/passwd';
@@ -307,7 +478,36 @@ describe('Perplexity Agent API adapters', () => {
       apiKey: 'synthetic-perplexity-key',
       httpClient: queuedClient([{ data: invalidUrl }]).client,
     }).execute('question', { timeout: 10 });
-    expect(invalidUrlResult.error).toContain('not HTTP(S)');
+    expect(invalidUrlResult).toMatchObject({
+      error: 'Perplexity Agent request failed.',
+      failureDiagnostic: { kind: 'provider' },
+    });
+  });
+
+  it.each([
+    'agent-model',
+    'https://api.perplexity.ai/v1/agent',
+    '/etc/passwd',
+    'openai/gpt/5.6',
+    `openai/${'x'.repeat(191)}`,
+  ])('rejects unsafe observed model identifier %s', (model) => {
+    expect(() =>
+      parseAgentResponse(completed('unsafe-model', 'Answer [1]', model)),
+    ).toThrow('model was malformed');
+  });
+
+  it('redacts secrets, URLs, and paths from bounded error text', () => {
+    const secret = 'synthetic-secret';
+    const redacted = redactPerplexityError(
+      `Bearer ${secret} at https://private.example.test/key and /etc/passwd`,
+      secret,
+    );
+    expect(redacted).toBe(
+      'Bearer [REDACTED] at [REDACTED_URL] and [REDACTED_PATH]',
+    );
+    expect(redacted).not.toContain(secret);
+    expect(redacted).not.toContain('private.example');
+    expect(redacted).not.toContain('/etc/passwd');
   });
 
   it('does not expose secrets or raw response bodies and does not retry ambiguous submit', async () => {
@@ -322,21 +522,89 @@ describe('Perplexity Agent API adapters', () => {
       apiKey: secret,
       httpClient: unauthorized,
     }).execute('question', { timeout: 10 });
-    expect(result.error).not.toContain(secret);
-    expect(result.error).not.toContain('api_key');
-    expect(result.error).not.toContain('Bearer');
+    expect(result).toMatchObject({
+      error: 'Perplexity Agent request failed.',
+      failureDiagnostic: { kind: 'authentication', httpStatus: 401 },
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain('api_key');
+    expect(JSON.stringify(result)).not.toContain('Bearer');
 
     const ambiguous = vi.fn<HttpClient>(async () => {
-      throw new Error(`socket failed with Bearer ${secret}`);
+      throw new Error(
+        `socket failed with Bearer ${secret} at https://api.perplexity.ai/private`,
+      );
     });
-    await expect(
+    const submission = expect(
       new PerplexityDeepResearchProvider({
         apiKey: secret,
         httpClient: ambiguous,
       }).submit('question', { timeout: 10 }),
-    ).rejects.toBeInstanceOf(UnsafeToRetrySubmissionError);
+    ).rejects;
+    await submission.toBeInstanceOf(UnsafeToRetrySubmissionError);
+    await submission.toThrow('submission outcome is unknown');
+    await submission.not.toThrow(secret);
+    await submission.not.toThrow('https://');
     expect(ambiguous).toHaveBeenCalledTimes(1);
   });
+
+  it('maps allowlisted terminal failure codes without exposing provider text', async () => {
+    const secret = 'synthetic-perplexity-key';
+    const result = await new PerplexitySonarProProvider({
+      apiKey: secret,
+      httpClient: queuedClient([
+        {
+          data: {
+            id: 'failed-task',
+            status: 'failed',
+            model: 'xai/grok-4.6',
+            error: {
+              code: 'rate_limit_exceeded',
+              message: `Bearer ${secret} https://private.example.test/path`,
+            },
+          },
+        },
+      ]).client,
+    }).execute('question', { timeout: 10 });
+
+    expect(result).toMatchObject({
+      error: 'Perplexity Agent task was not completed (status: failed).',
+      failureDiagnostic: { kind: 'rate_limit' },
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain('https://private');
+  });
+
+  it.each([
+    [400, 'invalid_request'],
+    [402, 'billing'],
+    [403, 'plan_required'],
+    [408, 'timeout'],
+    [429, 'rate_limit'],
+    [500, 'provider'],
+  ] as const)(
+    'maps HTTP %s to the bounded %s diagnostic without retaining the body',
+    async (status, kind) => {
+      const secret = `secret-${status}`;
+      const result = await new PerplexitySonarProProvider({
+        apiKey: secret,
+        httpClient: queuedClient([
+          {
+            status,
+            data: {
+              error: {
+                message: `Bearer ${secret} https://private.example.test`,
+              },
+            },
+          },
+        ]).client,
+      }).execute('question', { timeout: 10 });
+
+      expect(result.failureDiagnostic).toEqual({ kind, httpStatus: status });
+      expect(JSON.stringify(result)).not.toContain(secret);
+      expect(JSON.stringify(result)).not.toContain('private.example');
+    },
+  );
 
   it('validates input and timeout before resolving credentials or using the transport', async () => {
     const client = vi.fn<HttpClient>();
@@ -344,7 +612,10 @@ describe('Perplexity Agent API adapters', () => {
       httpClient: client,
     });
     const result = await provider.execute('', { timeout: 0 });
-    expect(result.error).toContain('input must be a non-empty string');
+    expect(result).toMatchObject({
+      error: 'Perplexity Agent request failed.',
+      failureDiagnostic: { kind: 'invalid_request' },
+    });
     expect(client).not.toHaveBeenCalled();
   });
 });

--- a/tests/adapters/usage-extraction.test.ts
+++ b/tests/adapters/usage-extraction.test.ts
@@ -39,7 +39,7 @@ describe('usage extraction', () => {
       jsonResponse(200, {
         id: 'resp-1',
         status: 'completed',
-        model: 'agent-model',
+        model: 'openai/gpt-5.6-luna',
         output: [
           {
             type: 'message',
@@ -81,6 +81,7 @@ describe('usage extraction', () => {
       jsonResponse(200, {
         id: 'resp-2',
         status: 'completed',
+        model: 'openai/gpt-5.6-luna',
         output: [
           {
             type: 'message',
@@ -106,7 +107,7 @@ describe('usage extraction', () => {
       jsonResponse(200, {
         id: 'agent-1',
         status: 'completed',
-        model: 'deep-research',
+        model: 'openai/gpt-5.6-sol',
         output: [
           {
             type: 'message',

--- a/tests/claim-verification.test.ts
+++ b/tests/claim-verification.test.ts
@@ -838,6 +838,7 @@ describe('claim verification boundaries', () => {
           JSON.stringify({
             id: 'verification-agent',
             status: 'completed',
+            model: 'openai/gpt-5.6-luna',
             output: [
               {
                 type: 'message',

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -985,6 +985,117 @@ describe('private prepared execution runtime', () => {
     },
   );
 
+  it.each([
+    [
+      'authentication',
+      'provider_authentication_failed',
+      'authentication',
+      false,
+    ],
+    ['billing', 'provider_billing_failed', 'budget', false],
+    ['rate_limit', 'provider_rate_limited', 'rate_limit', true],
+    ['invalid_request', 'provider_invalid_request', 'validation', false],
+  ] as const)(
+    'classifies an immediate durable %s failure through the canonical mapper',
+    async (kind, code, category, retryable) => {
+      const durable: Provider = {
+        id: 'adapter-durable',
+        displayName: 'Durable',
+        tier: 'deep-research',
+        envVar: '',
+        execution: 'background',
+        execute: vi.fn(),
+        submit: vi.fn(async () => ({
+          provider: 'adapter-durable',
+          taskId: `immediate-${kind}`,
+          query: 'runtime query',
+          submittedAt: start,
+          status: 'failed' as const,
+          failureDiagnostic: { kind },
+        })),
+        poll: vi.fn(),
+        retrieve: vi.fn(),
+      };
+
+      const result = await runPreparedExecution(
+        prepared([profile('durable', 'background')], [], 'async'),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: coordinatorDependencies(),
+          attempts: createProviderAttemptBridge({
+            resolveExactBinding: () => resolvedBinding('durable', durable),
+            now: () => start,
+          }),
+        },
+      );
+
+      expect(result.state.attempts[0]).toMatchObject({
+        status: 'failed',
+        error: { code, category, retryable },
+        durable_handle: { status: 'failed' },
+      });
+      expect(durable.poll).not.toHaveBeenCalled();
+      expect(durable.retrieve).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [
+      'authentication',
+      'provider_authentication_failed',
+      'authentication',
+      false,
+    ],
+    ['billing', 'provider_billing_failed', 'budget', false],
+    ['rate_limit', 'provider_rate_limited', 'rate_limit', true],
+    ['invalid_request', 'provider_invalid_request', 'validation', false],
+  ] as const)(
+    'classifies a polled durable %s failure through the canonical mapper',
+    async (kind, code, category, retryable) => {
+      const durable: Provider = {
+        id: 'adapter-durable',
+        displayName: 'Durable',
+        tier: 'deep-research',
+        envVar: '',
+        execution: 'background',
+        execute: vi.fn(),
+        submit: vi.fn(async () => ({
+          provider: 'adapter-durable',
+          taskId: `polled-${kind}`,
+          query: 'runtime query',
+          submittedAt: start,
+          status: 'pending' as const,
+        })),
+        poll: vi.fn(async () => ({
+          status: 'failed' as const,
+          failureDiagnostic: { kind },
+        })),
+        retrieve: vi.fn(),
+      };
+
+      const result = await runPreparedExecution(
+        prepared([profile('durable', 'background')]),
+        {
+          store: new InMemoryCoordinationStateStore(),
+          coordinator: coordinatorDependencies(),
+          attempts: createProviderAttemptBridge({
+            resolveExactBinding: () => resolvedBinding('durable', durable),
+            now: () => start,
+            wait: async () => {},
+          }),
+        },
+      );
+
+      expect(result.state.attempts[0]).toMatchObject({
+        status: 'failed',
+        error: { code, category, retryable },
+        durable_handle: { status: 'failed' },
+      });
+      expect(durable.poll).toHaveBeenCalledOnce();
+      expect(durable.retrieve).not.toHaveBeenCalled();
+    },
+  );
+
   it('retains accepted durable work after a local execution exception', async () => {
     const result = await runPreparedExecution(
       prepared([profile('durable', 'background')], [], 'async'),

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -267,6 +267,7 @@ describe('callWithCascade', () => {
             JSON.stringify({
               id: 'agent-llm-test',
               status: 'completed',
+              model: 'openai/gpt-5.6-luna',
               output: [
                 {
                   type: 'message',


### PR DESCRIPTION
## Summary

Harden Perplexity Agent parsing for current dynamic presets, provider-qualified model identifiers, durable responses, and safe failures.

## Changes

- Accept bounded `provider/model` identifiers returned by current Agent presets.
- Support numeric search-result IDs and the documented output union.
- Require observed model identity on completed responses.
- Carry bounded failure diagnostics through inline and durable execution without leaking provider text.
- Preserve caller cancellation and no-retry durable custody semantics.

## Testing

- [x] Added / updated unit tests (`npm test`)
- [ ] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Typecheck and declarations pass
- [x] No provider calls were made
