### PR TITLE
fix: preserve Parallel chat configuration

### DIFF
--- a/src/core/configuration-mapping.ts
+++ b/src/core/configuration-mapping.ts
@@ -23,7 +23,10 @@ import {
   type CustomCatalogProfile,
   type ProviderCatalog,
 } from './profile-catalog.js';
-import { BUILTIN_PROVIDER_DEFINITIONS } from './provider-descriptor.js';
+import {
+  BUILTIN_PROVIDER_DEFINITIONS,
+  getBuiltinProviderDefinition,
+} from './provider-descriptor.js';
 import {
   BUILTIN_PROVIDER_CATALOG,
   type ProviderCatalogEntry,
@@ -618,17 +621,20 @@ function materializeProviderConfigs(config: Config): {
   notices: PreparationNotice[];
 } {
   const byAdapter = safeRecord<ProviderConfig>();
-  const bindings = adapterProfileBindings();
   const normalized = canonicalizeProviderConfigs(config.providers);
 
   for (const [adapterId, providerConfig] of Object.entries(
     normalized.providerConfigs,
   )) {
-    const binding = bindings.get(adapterId);
+    const definition = getBuiltinProviderDefinition(adapterId);
     const options = { ...(providerConfig.options ?? {}) };
-    // v1 applies this global only to LLM/chat providers, and only when the
-    // provider did not make an explicit per-provider choice.
-    if (binding?.profile_id === 'chat' && options.webSearch === undefined) {
+    // v1 applies this global only to adapters whose descriptor declares web
+    // search configurable, and only when the provider made no explicit choice.
+    // A `chat` profile may instead have always-on search and a strict option bag.
+    if (
+      definition?.capabilities.webSearch === 'optional' &&
+      options.webSearch === undefined
+    ) {
       options.webSearch = config.defaults.llmWebSearch;
     }
     byAdapter[adapterId] = {

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -703,31 +703,146 @@ describe('configuration mapping', () => {
     });
   });
 
-  it('materializes defaults.llmWebSearch only for chat adapters lacking an explicit option', () => {
-    const defaultsOff = map(
-      config({
-        defaults: { llmWebSearch: false },
-        providers: { 'openrouter-chat': { enabled: true } },
-      }),
-      { requestDeadlineMs: 2_000_000, credentials: credentials() },
-    );
-    expect(
-      defaultsOff.catalog.get('openrouter', 'chat')?.profile.result_kind,
-    ).toBe('model_answer');
+  it.each([true, false])(
+    'does not inject llmWebSearch=%s into Parallel Chat',
+    (llmWebSearch) => {
+      const mapped = map(
+        config({
+          defaults: { llmWebSearch },
+          providers: { 'parallel-chat': { enabled: true } },
+        }),
+        { requestDeadlineMs: 2_000_000, credentials: credentials() },
+      );
 
-    const providerOverride = map(
-      config({
-        defaults: { llmWebSearch: false },
-        providers: {
-          'openrouter-chat': { enabled: true, options: { webSearch: true } },
+      const parallelChat = mapped.catalog.get('parallel', 'chat');
+      expect(parallelChat?.availability.configuration_valid).toBe(true);
+      expect(parallelChat?.profile.result_kind).toBe('grounded_answer');
+    },
+  );
+
+  it.each([true, false])(
+    'still rejects an explicit unsupported Parallel Chat webSearch=%s option',
+    (webSearch) => {
+      const mapped = map(
+        config({
+          providers: {
+            'parallel-chat': { enabled: true, options: { webSearch } },
+          },
+        }),
+        { requestDeadlineMs: 2_000_000, credentials: credentials() },
+      );
+
+      const parallelChat = mapped.catalog.get('parallel', 'chat');
+      expect(parallelChat?.availability.configuration_valid).toBe(false);
+      expect(parallelChat?.availability.reasons).toContain(
+        'configuration_invalid',
+      );
+    },
+  );
+
+  it.each([
+    ['claude', 'claude'],
+    ['openai-chat', 'openai-chat'],
+    ['gemini-chat', 'gemini-chat'],
+    ['openrouter-chat', 'openrouter'],
+  ] as const)(
+    'preserves llmWebSearch defaults and overrides for %s',
+    (adapterId, providerId) => {
+      const defaultsOff = map(
+        config({
+          defaults: { llmWebSearch: false },
+          providers: { [adapterId]: { enabled: true } },
+        }),
+        { requestDeadlineMs: 2_000_000, credentials: credentials() },
+      );
+      expect(
+        defaultsOff.catalog.get(providerId, 'chat')?.profile.result_kind,
+      ).toBe('model_answer');
+
+      const defaultsOn = map(
+        config({
+          defaults: { llmWebSearch: true },
+          providers: { [adapterId]: { enabled: true } },
+        }),
+        { requestDeadlineMs: 2_000_000, credentials: credentials() },
+      );
+      expect(
+        defaultsOn.catalog.get(providerId, 'chat')?.profile.result_kind,
+      ).toBe('grounded_answer');
+
+      const providerOverrideOn = map(
+        config({
+          defaults: { llmWebSearch: false },
+          providers: {
+            [adapterId]: { enabled: true, options: { webSearch: true } },
+          },
+        }),
+        { requestDeadlineMs: 2_000_000, credentials: credentials() },
+      );
+      expect(
+        providerOverrideOn.catalog.get(providerId, 'chat')?.profile.result_kind,
+      ).toBe('grounded_answer');
+
+      const providerOverrideOff = map(
+        config({
+          defaults: { llmWebSearch: true },
+          providers: {
+            [adapterId]: { enabled: true, options: { webSearch: false } },
+          },
+        }),
+        { requestDeadlineMs: 2_000_000, credentials: credentials() },
+      );
+      expect(
+        providerOverrideOff.catalog.get(providerId, 'chat')?.profile
+          .result_kind,
+      ).toBe('model_answer');
+    },
+  );
+
+  it.each([true, false])(
+    'does not inject built-in llmWebSearch=%s behavior into a custom chat provider',
+    (llmWebSearch) => {
+      const source = customProviderConfig({
+        defaults: { llmWebSearch },
+      });
+      const custom = source.customProviders['acme-adapter'];
+      if (!custom?.executionProfile) throw new Error('missing custom fixture');
+      source.customProviders['acme-adapter'] = {
+        ...custom,
+        executionProfile: {
+          ...custom.executionProfile,
+          bindingId: 'acme.chat.v1',
+          profile: {
+            ...custom.executionProfile.profile,
+            identity: {
+              ...custom.executionProfile.profile.identity,
+              profile_id: 'chat',
+              target: {
+                primary: {
+                  model_selection: 'provider_managed',
+                  kind: 'model',
+                },
+              },
+            },
+            result_kind: 'model_answer',
+            grounding_policy: 'none',
+            corpora: [],
+            retrieval_method: 'model_only',
+          },
         },
-      }),
-      { requestDeadlineMs: 2_000_000, credentials: credentials() },
-    );
-    expect(
-      providerOverride.catalog.get('openrouter', 'chat')?.profile.result_kind,
-    ).toBe('grounded_answer');
-  });
+      };
+
+      const mapped = map(source, { requestDeadlineMs: 2_000_000 });
+      const customChat = mapped.catalog.get('acme-provider', 'chat');
+      expect(customChat?.availability.configuration_valid).toBe(true);
+      expect(customChat?.profile).toMatchObject({
+        result_kind: 'model_answer',
+        grounding_policy: 'none',
+        corpora: [],
+        retrieval_method: 'model_only',
+      });
+    },
+  );
 
   it('flattens and deduplicates valid fallback edges in declaration order', () => {
     const mapped = map(


### PR DESCRIPTION
## Summary

Keep Parallel Chat configuration valid by applying the global web-search default only to profiles that explicitly support configurable web search.

## Changes

- Gate legacy web-search option injection on descriptor capability evidence.
- Preserve default and explicit override behavior for Claude, OpenAI, Gemini, and OpenRouter chat.
- Keep unsupported Parallel Chat overrides fail-closed.
- Preserve custom-provider behavior.

## Testing

- [x] Added / updated unit tests (`npm test`)
- [ ] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Typecheck passes
- [x] No provider calls were made
