### PR TITLE
fix: harden async reconciliation

### DIFF
--- a/src/adapters/tavily-research.ts
+++ b/src/adapters/tavily-research.ts
@@ -4,6 +4,7 @@ import type {
   AsyncPollResult,
   AsyncTaskHandle,
   Citation,
+  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -17,9 +18,24 @@ export interface TavilyResearchProviderOptions extends BaseProviderOptions {
 }
 
 const TavilyId = z.string().trim().min(1).max(255);
+const CredentialFreeHttpUrl = z
+  .string()
+  .url()
+  .refine((value) => {
+    try {
+      const parsed = new globalThis.URL(value);
+      return (
+        (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+        parsed.username === '' &&
+        parsed.password === ''
+      );
+    } catch {
+      return false;
+    }
+  });
 const TavilySource = z.object({
   title: z.string().min(1).optional(),
-  url: z.string().url(),
+  url: CredentialFreeHttpUrl,
   favicon: z.string().url().optional(),
 });
 type TavilySource = z.infer<typeof TavilySource>;
@@ -59,6 +75,30 @@ type TavilyTerminal =
   | z.infer<typeof TavilyFailed>;
 
 const URL = 'https://api.tavily.com/research';
+const SUBMISSION_FAILED =
+  'Tavily Research submission failed before a valid handle was returned.';
+const POLL_FAILED = 'Tavily Research status check failed.';
+const RETRIEVAL_FAILED = 'Tavily Research retrieval failed.';
+const EXECUTION_FAILED = 'Tavily Research execution failed.';
+
+class TavilyResearchSubmissionError extends UnsafeToRetrySubmissionError {
+  readonly failureDiagnostic: ProviderFailureDiagnostic;
+
+  constructor(failureDiagnostic: ProviderFailureDiagnostic) {
+    super(SUBMISSION_FAILED);
+    this.failureDiagnostic = failureDiagnostic;
+  }
+}
+
+class TavilyResearchLifecycleError extends Error {
+  readonly failureDiagnostic: ProviderFailureDiagnostic;
+
+  constructor(message: string, failureDiagnostic: ProviderFailureDiagnostic) {
+    super(message);
+    this.name = 'TavilyResearchLifecycleError';
+    this.failureDiagnostic = failureDiagnostic;
+  }
+}
 
 /** Durable Tavily Research adapter bound only to `tavily/research`. */
 export class TavilyResearchProvider extends BackgroundBaseProvider {
@@ -90,6 +130,7 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
           return this.error(
             start,
             'Tavily research task timed out locally; the remote task may still be running.',
+            { kind: 'timeout' },
           );
         await wait(Math.min(1_000, deadline - Date.now()), options.signal);
         const next = await this.poll(handle);
@@ -97,13 +138,22 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
         if (next.status === 'failed' || next.status === 'cancelled')
           return this.error(
             start,
-            next.message ?? `Tavily research task ${next.status}`,
+            next.message ?? 'Tavily Research task ended without a result.',
+            { kind: 'provider' },
           );
       }
       const result = await this.retrieve(handle);
       return { ...result, durationMs: Math.round(performance.now() - start) };
     } catch (error) {
-      return this.error(start, this.formatCatchError(error));
+      return error instanceof TavilyResearchSubmissionError
+        ? this.error(start, error.message, error.failureDiagnostic)
+        : error instanceof TavilyResearchLifecycleError
+          ? this.error(start, error.message, error.failureDiagnostic)
+          : this.error(
+              start,
+              EXECUTION_FAILED,
+              this.catchDiagnostic(error, options.signal),
+            );
     }
   }
 
@@ -132,13 +182,13 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
         signal: options.signal,
       });
     } catch (error) {
-      throw new UnsafeToRetrySubmissionError(
-        error instanceof Error ? error.message : String(error),
+      throw new TavilyResearchSubmissionError(
+        this.catchDiagnostic(error, options.signal),
       );
     }
     if (response.status !== 201) {
-      throw new UnsafeToRetrySubmissionError(
-        this.formatError(response.status, response.data),
+      throw new TavilyResearchSubmissionError(
+        this.httpDiagnostic(response.status, response.data),
       );
     }
     const parsed = TavilyPending.safeParse(response.data);
@@ -147,15 +197,16 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
         (response.data as { request_id?: unknown })?.request_id,
       );
       if (!id.success)
-        throw new UnsafeToRetrySubmissionError(
-          'Tavily returned an invalid research handle',
-        );
+        throw new TavilyResearchSubmissionError({
+          kind: 'provider',
+          httpStatus: 201,
+        });
       return {
         provider: this.id,
         taskId: id.data,
         query,
         submittedAt: Date.now(),
-        status: 'failed',
+        status: 'pending',
         providerStatus: 'invalid_response',
         lastPollError: 'Tavily returned a malformed create response',
       };
@@ -171,45 +222,47 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
   }
 
   async poll(handle: AsyncTaskHandle): Promise<AsyncPollResult> {
-    const response = await this.task(handle.taskId, 15_000);
+    let response;
+    try {
+      response = await this.task(handle.taskId, 15_000);
+    } catch (error) {
+      throw new TavilyResearchLifecycleError(
+        POLL_FAILED,
+        this.catchDiagnostic(error),
+      );
+    }
     if (response.status === 202) {
       const parsed = TavilyInProgress.safeParse(response.data);
-      return parsed.success
-        ? { status: 'running', rawStatus: 'in_progress' }
-        : {
-            status: 'failed',
-            rawStatus: 'invalid_response',
-            message: 'Tavily returned a malformed in-progress response',
-          };
+      if (!parsed.success) {
+        throw new TavilyResearchLifecycleError(POLL_FAILED, {
+          kind: 'provider',
+          httpStatus: 202,
+        });
+      }
+      return { status: 'running', rawStatus: 'in_progress' };
     }
     if (response.status !== 200) {
-      if (
-        response.status === 408 ||
-        response.status === 429 ||
-        response.status >= 500
-      )
-        throw new Error(`Poll returned HTTP ${response.status}`);
-      return {
-        status: 'failed',
-        rawStatus: `http_${response.status}`,
-        message: `Poll returned HTTP ${response.status}`,
-      };
+      throw new TavilyResearchLifecycleError(
+        POLL_FAILED,
+        this.httpDiagnostic(response.status, response.data),
+      );
     }
     const parsed = z
       .union([TavilyCompleted, TavilyFailed])
       .safeParse(response.data);
-    if (!parsed.success)
-      return {
-        status: 'failed',
-        rawStatus: 'invalid_response',
-        message: 'Tavily returned a malformed terminal response',
-      };
+    if (!parsed.success) {
+      throw new TavilyResearchLifecycleError(POLL_FAILED, {
+        kind: 'provider',
+        httpStatus: 200,
+      });
+    }
     return parsed.data.status === 'completed'
       ? { status: 'completed', rawStatus: 'completed' }
       : {
           status: 'failed',
           rawStatus: 'failed',
-          message: message(parsed.data.error),
+          message: 'Tavily Research task failed.',
+          failureDiagnostic: { kind: 'provider' },
         };
   }
 
@@ -220,19 +273,23 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
       if (response.status !== 200)
         return this.error(
           start,
-          `Retrieve failed with HTTP ${response.status}`,
+          RETRIEVAL_FAILED,
+          this.httpDiagnostic(response.status, response.data),
         );
       const parsed = z
         .union([TavilyCompleted, TavilyFailed])
         .safeParse(response.data);
       if (!parsed.success)
-        return this.error(
-          start,
-          'Tavily returned a malformed terminal response',
-        );
+        return this.error(start, RETRIEVAL_FAILED, {
+          kind: 'provider',
+          httpStatus: 200,
+        });
       const task: TavilyTerminal = parsed.data;
       if (task.status !== 'completed')
-        return this.error(start, message(task.error));
+        return this.error(start, RETRIEVAL_FAILED, {
+          kind: 'provider',
+          httpStatus: 200,
+        });
       const content = task.content;
       return {
         provider: this.id,
@@ -247,7 +304,7 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
         durationMs: Math.round(performance.now() - start),
       };
     } catch (error) {
-      return this.error(start, this.formatCatchError(error));
+      return this.error(start, RETRIEVAL_FAILED, this.catchDiagnostic(error));
     }
   }
 
@@ -263,7 +320,11 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
     });
   }
 
-  private error(start: number, error: string): ProviderResult {
+  private error(
+    start: number,
+    error: string,
+    failureDiagnostic?: ProviderFailureDiagnostic,
+  ): ProviderResult {
     return {
       provider: this.id,
       tier: this.tier,
@@ -271,8 +332,106 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
       citations: [],
       durationMs: Math.round(performance.now() - start),
       error,
+      ...(failureDiagnostic && { failureDiagnostic }),
     };
   }
+
+  private httpDiagnostic(
+    status: number,
+    body: unknown,
+  ): ProviderFailureDiagnostic {
+    const httpStatus =
+      Number.isInteger(status) && status >= 100 && status <= 599
+        ? status
+        : undefined;
+    const detail = submissionFailureText(body);
+    const kind: ProviderFailureDiagnostic['kind'] =
+      status === 429
+        ? 'rate_limit'
+        : status === 432
+          ? 'plan_required'
+          : status === 433
+            ? 'billing'
+            : status === 401
+              ? 'authentication'
+              : status === 403
+                ? looksPlanRestricted(detail)
+                  ? 'plan_required'
+                  : 'authentication'
+                : status === 402
+                  ? 'billing'
+                  : status === 408 || status === 504
+                    ? 'timeout'
+                    : status >= 400 && status < 500
+                      ? 'invalid_request'
+                      : 'provider';
+    return { kind, ...(httpStatus !== undefined && { httpStatus }) };
+  }
+
+  private catchDiagnostic(
+    error: unknown,
+    signal?: AbortSignal,
+  ): ProviderFailureDiagnostic {
+    if (
+      signal?.aborted ||
+      (error instanceof DOMException &&
+        (error.name === 'AbortError' || error.name === 'TimeoutError'))
+    ) {
+      return { kind: 'timeout' };
+    }
+    const detail = error instanceof Error ? error.message : '';
+    if (/API key not found/i.test(detail)) return { kind: 'authentication' };
+    if (
+      error instanceof TypeError ||
+      /fetch failed|failed to fetch|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT/i.test(
+        detail,
+      )
+    ) {
+      return { kind: 'network' };
+    }
+    return { kind: 'provider' };
+  }
+}
+
+function submissionFailureText(value: unknown): string {
+  if (typeof value === 'string') return value.slice(0, 512).toLowerCase();
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return '';
+  }
+  const record = value as Record<string, unknown>;
+  const nested =
+    typeof record.error === 'object' &&
+    record.error !== null &&
+    !Array.isArray(record.error)
+      ? (record.error as Record<string, unknown>)
+      : undefined;
+  const nestedDetail =
+    typeof record.detail === 'object' &&
+    record.detail !== null &&
+    !Array.isArray(record.detail)
+      ? (record.detail as Record<string, unknown>)
+      : undefined;
+  return [
+    record.message,
+    record.detail,
+    typeof record.error === 'string' ? record.error : undefined,
+    nested?.message,
+    nested?.detail,
+    nested?.code,
+    nestedDetail?.message,
+    nestedDetail?.detail,
+    nestedDetail?.code,
+    typeof nestedDetail?.error === 'string' ? nestedDetail.error : undefined,
+  ]
+    .filter((item): item is string => typeof item === 'string')
+    .join(' ')
+    .slice(0, 512)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ');
+}
+
+function looksPlanRestricted(detail: string): boolean {
+  return /\b(plan|subscription|upgrade|quota|credit limit)\b/i.test(detail);
 }
 
 function citations(
@@ -286,10 +445,6 @@ function citations(
       title: source.title,
       provider,
     }));
-}
-
-function message(error: z.infer<typeof TavilyFailed>['error']): string {
-  return typeof error === 'string' ? error : error?.message;
 }
 
 function wait(milliseconds: number, signal?: AbortSignal): Promise<void> {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -264,63 +264,81 @@ async function reconcileCanonicalRuns(
 ): Promise<{
   readonly runs: readonly {
     readonly runDir: string;
-    readonly state: 'pending' | 'terminal';
+    readonly state: 'pending' | 'terminal' | 'error';
     readonly response?: unknown;
+    readonly error?: typeof RECONCILIATION_FAILED;
   }[];
   readonly pending: number;
+  readonly errors: readonly (typeof RECONCILIATION_FAILED)[];
 }> {
-  const runs = [];
+  const runs: Array<{
+    runDir: string;
+    state: 'pending' | 'terminal' | 'error';
+    response?: unknown;
+    error?: typeof RECONCILIATION_FAILED;
+  }> = [];
+  const errors: (typeof RECONCILIATION_FAILED)[] = [];
   for (const runDir of discoverCanonicalRunDirectories(
     baseDir,
     Number.MAX_SAFE_INTEGER,
   )) {
-    const runsRoot = canonicalRunsRoot(runDir);
-    const before = readCanonicalRunManifest(runsRoot, runDir);
-    const remoteCustody = before.coordination_state.attempts.some(
-      (attempt) =>
-        attempt.durable_handle &&
-        ['pending', 'running'].includes(attempt.durable_handle.status),
-    );
-    const needsResume =
-      before.coordination_state.status === 'running' ||
-      !before.terminal_response ||
-      remoteCustody;
-    const canonical = needsResume
-      ? await resumeCanonicalPreparedExecution({
-          runs_root: runsRoot,
-          run_directory: runDir,
-          coordinator: createNodeCoordinatorDependencies(),
-          attempt_bridge: createRegisteredProviderAttemptBridge(
-            {
-              request: before.request,
-              catalog: { digest: before.coordination_state.catalog_digest },
-              profile_plans_by_identity:
-                before.coordination_state.profile_plans_by_identity,
-            },
-            getExactProvider,
-          ),
-        })
-      : {
-          manifest: before,
-          response: before.terminal_response,
-        };
-    writeCanonicalPresentationArtifacts(
-      canonical.manifest,
-      runDir,
-      generateSlug(canonical.manifest.request.query),
-    );
-    runs.push({
-      runDir,
-      state:
-        canonical.manifest.coordination_state.status === 'running'
-          ? ('pending' as const)
-          : ('terminal' as const),
-      ...(canonical.response && { response: canonical.response }),
-    });
+    try {
+      const runsRoot = canonicalRunsRoot(runDir);
+      const before = readCanonicalRunManifest(runsRoot, runDir);
+      const remoteCustody = before.coordination_state.attempts.some(
+        (attempt) =>
+          attempt.durable_handle &&
+          ['pending', 'running'].includes(attempt.durable_handle.status),
+      );
+      const needsResume =
+        before.coordination_state.status === 'running' ||
+        !before.terminal_response ||
+        remoteCustody;
+      const canonical = needsResume
+        ? await resumeCanonicalPreparedExecution({
+            runs_root: runsRoot,
+            run_directory: runDir,
+            coordinator: createNodeCoordinatorDependencies(),
+            attempt_bridge: createRegisteredProviderAttemptBridge(
+              {
+                request: before.request,
+                catalog: { digest: before.coordination_state.catalog_digest },
+                profile_plans_by_identity:
+                  before.coordination_state.profile_plans_by_identity,
+              },
+              getExactProvider,
+            ),
+          })
+        : {
+            manifest: before,
+            response: before.terminal_response,
+          };
+      writeCanonicalPresentationArtifacts(
+        canonical.manifest,
+        runDir,
+        generateSlug(canonical.manifest.request.query),
+      );
+      runs.push({
+        runDir,
+        state:
+          canonical.manifest.coordination_state.status === 'running'
+            ? ('pending' as const)
+            : ('terminal' as const),
+        ...(canonical.response && { response: canonical.response }),
+      });
+    } catch {
+      errors.push(RECONCILIATION_FAILED);
+      runs.push({
+        runDir,
+        state: 'error',
+        error: RECONCILIATION_FAILED,
+      });
+    }
   }
   return {
     runs,
     pending: runs.filter((run) => run.state === 'pending').length,
+    errors,
   };
 }
 
@@ -334,7 +352,7 @@ function printCanonicalRuns(
     const response = run.response as
       | { readonly status?: string; readonly request_id?: string }
       | undefined;
-    const detail = response?.status ?? run.state;
+    const detail = run.error ?? response?.status ?? run.state;
     print(`  ${run.runDir} | Status: ${detail}`);
   }
 }
@@ -415,7 +433,7 @@ export function registerStatusCommand(program: Command): void {
         };
         const color = isColorEnabled(prettyStream);
         const rendered = new Set<string>();
-        const errors: (typeof RECONCILIATION_FAILED)[] = [];
+        const errors: (typeof RECONCILIATION_FAILED)[] = [...canonical.errors];
         const regenerationErrors: (typeof REGENERATION_FAILED)[] = [];
         const record = (pass: ReconcileRunsResult): void => {
           errors.push(...pass.errors);
@@ -433,6 +451,7 @@ export function registerStatusCommand(program: Command): void {
           try {
             while (remaining) {
               canonical = await reconcileCanonicalRuns(baseDir, config);
+              errors.push(...canonical.errors);
               const pass = await reconcileRuns(runtime, runDirs, true);
               totalRetrieved += pass.retrieved;
               withSpinnerStopped(spinner, () => record(pass), true);

--- a/src/core/coordinator.ts
+++ b/src/core/coordinator.ts
@@ -1369,6 +1369,10 @@ export function cancelCoordination(
     attempt.status = 'cancelled';
     attempt.finished_at = cancelledAt;
     attempt.error = error;
+    if (wasDispatchPending) {
+      attempt.delivery_lease_id = undefined;
+      attempt.delivery_lease_expires_at = undefined;
+    }
     if (!wasDispatchPending) {
       appendAttemptFinished(next, attempt, dependencies);
     }
@@ -1417,6 +1421,10 @@ export function failCoordination(
     attempt.status = 'failed';
     attempt.finished_at = failedAt;
     attempt.error = error;
+    if (wasDispatchPending) {
+      attempt.delivery_lease_id = undefined;
+      attempt.delivery_lease_expires_at = undefined;
+    }
     if (!wasDispatchPending) appendAttemptFinished(next, attempt, dependencies);
   }
   for (const slot of next.slots) {
@@ -1487,6 +1495,10 @@ export function advanceDeadlines(
       attempt.finished_at = now;
       attempt.error = error;
       attempt.transient_poll_error = undefined;
+      if (wasDispatchPending) {
+        attempt.delivery_lease_id = undefined;
+        attempt.delivery_lease_expires_at = undefined;
+      }
       const slot = slotFor(next, attempt.slot_id);
       slot.status = 'timed_out';
       slot.error = error;

--- a/src/core/execution-runtime.ts
+++ b/src/core/execution-runtime.ts
@@ -27,6 +27,8 @@ import {
 import type { PreparedResearchExecution } from './execution-plan.js';
 import { profileIdentityKey } from './execution-plan.js';
 
+const TERMINAL_CUSTODY_OBSERVATION_MS = 30_000;
+
 /**
  * The Worker-safe execution port. It receives a launch that was already
  * selected and bound by preparation/coordinator code; implementors must never
@@ -47,6 +49,8 @@ export interface AttemptExecutionPort {
 
 export interface AttemptExecutionContext {
   readonly mode: 'sync' | 'async';
+  /** Observe an already terminal durable handle without submit or retrieval. */
+  readonly custody_only?: boolean;
   readonly poll_interval_ms: number;
   submissionAccepted(
     handle: DurableHandle,
@@ -244,6 +248,7 @@ export async function runPreparedExecution(
       observedBeforeExecution?.state.status !== 'running';
     const context: AttemptExecutionContext = {
       mode: custodyOnly ? 'async' : prepared.request.mode,
+      ...(custodyOnly && { custody_only: true }),
       poll_interval_ms: prepared.policy.limits.poll_interval_ms,
       submissionAccepted: async (handle, adapterStateRef) => {
         const persisted = await transition(
@@ -566,7 +571,18 @@ export async function runPreparedExecution(
               binding: plan.binding,
               catalog_digest: state.catalog_digest,
               query: attempt.query,
-              deadline_at: attempt.deadline_at,
+              // Terminal custody gets one bounded GET-only observation window.
+              // This ephemeral launch value never changes the persisted attempt
+              // deadline or terminal lifecycle.
+              deadline_at:
+                effectiveDependencies.reconcile_terminal_custody &&
+                (attempt.status === 'cancelled' ||
+                  attempt.status === 'timed_out')
+                  ? new Date(
+                      effectiveDependencies.coordinator.clock.now() +
+                        TERMINAL_CUSTODY_OBSERVATION_MS,
+                    ).toISOString()
+                  : attempt.deadline_at,
               // Resume never re-enters delivery claiming. This stable private
               // value satisfies AttemptLaunch's execution-port shape only.
               delivery_lease_id: 'durable-resume',

--- a/src/core/provider-attempt-bridge.ts
+++ b/src/core/provider-attempt-bridge.ts
@@ -170,6 +170,27 @@ function durableProviderFailure(
       );
 }
 
+function transientProviderFailure(error: unknown): StructuredError {
+  const diagnostic =
+    typeof error === 'object' && error !== null && 'failureDiagnostic' in error
+      ? validatedFailureDiagnostic(
+          (error as { readonly failureDiagnostic?: unknown }).failureDiagnostic,
+        )
+      : undefined;
+  return diagnostic
+    ? {
+        ...diagnosedProviderFailure(diagnostic, false),
+        // The remote task remains accepted. Retrying the GET observation is
+        // safe even when the observed cause would forbid a new submission.
+        retryable: true,
+      }
+    : providerFailure(
+        'adapter_poll_failed',
+        'The durable provider status check failed.',
+        false,
+      );
+}
+
 type DeadlineResult<T> =
   | { readonly kind: 'value'; readonly value: T }
   | { readonly kind: 'error'; readonly error: unknown }
@@ -428,6 +449,9 @@ export function createProviderAttemptBridge(
       }
       const task = taskFromDurableHandle(launch, handle, provider.id);
       if (handle.status === 'succeeded') {
+        if (context.custody_only) {
+          return { kind: 'accepted', durable_handle: handle };
+        }
         return retrieveCompletedTask(provider, task, launch, handle, now);
       }
       let latestHandle = handle;
@@ -455,11 +479,7 @@ export function createProviderAttemptBridge(
         }
         if (polled.kind === 'error') {
           await context.transientPollFailure(
-            providerFailure(
-              'adapter_poll_failed',
-              'The durable provider status check failed.',
-              false,
-            ),
+            transientProviderFailure(polled.error),
           );
           if (context.mode === 'async') {
             return { kind: 'accepted', durable_handle: latestHandle };
@@ -471,6 +491,12 @@ export function createProviderAttemptBridge(
         }
         const poll = polled.value;
         if (poll.status === 'completed') {
+          if (context.custody_only) {
+            return {
+              kind: 'accepted',
+              durable_handle: observedHandle(latestHandle, 'succeeded', now),
+            };
+          }
           return retrieveCompletedTask(
             provider,
             task,
@@ -727,11 +753,7 @@ export function createProviderAttemptBridge(
         }
         if (polled.kind === 'error') {
           await context.transientPollFailure(
-            providerFailure(
-              'adapter_poll_failed',
-              'The durable provider status check failed.',
-              false,
-            ),
+            transientProviderFailure(polled.error),
           );
           await wait(
             Math.min(context.poll_interval_ms, timeoutFor(launch, now)),

--- a/src/node-canonical-run.ts
+++ b/src/node-canonical-run.ts
@@ -151,6 +151,16 @@ export const CanonicalRunManifestV3Schema = z
     const createdAt = Date.parse(state.created_at);
     const requestedAt = Date.parse(manifest.request.requested_at);
     const requestDeadline = Date.parse(state.request_deadline_at);
+    const firstLifecycle = state.lifecycle[0];
+    const terminalLifecycle = state.lifecycle.at(-1);
+    const expectedTerminalKind =
+      state.status === 'cancelled'
+        ? 'request_cancelled'
+        : state.status === 'failed'
+          ? 'request_failed'
+          : state.status === 'running'
+            ? undefined
+            : 'request_completed';
     if (createdAt < requestedAt || requestDeadline <= createdAt) {
       ctx.addIssue({
         code: 'custom',
@@ -181,6 +191,17 @@ export const CanonicalRunManifestV3Schema = z
       const handleSubmitted = attempt.durable_handle
         ? Date.parse(attempt.durable_handle.submitted_at)
         : undefined;
+      const terminalAttempt = [
+        'succeeded',
+        'failed',
+        'timed_out',
+        'cancelled',
+      ].includes(attempt.status);
+      const finishedEvents = state.lifecycle.filter(
+        (event) =>
+          event.event_kind === 'attempt_finished' &&
+          event.attempt_id === attempt.attempt_id,
+      );
       if (
         queued < createdAt ||
         attemptDeadline < queued ||
@@ -194,7 +215,18 @@ export const CanonicalRunManifestV3Schema = z
         (started !== undefined &&
           (started < queued || started > attemptDeadline)) ||
         (finished !== undefined &&
-          (finished < (started ?? queued) || finished > attemptDeadline)) ||
+          (finished < (started ?? queued) ||
+            (attempt.status !== 'timed_out' && finished > attemptDeadline))) ||
+        (started !== undefined &&
+          terminalAttempt &&
+          (finished === undefined ||
+            finishedEvents.length !== 1 ||
+            finishedEvents[0]?.occurred_at !== attempt.finished_at)) ||
+        (started === undefined &&
+          terminalAttempt &&
+          (finished === undefined ||
+            finishedEvents.length !== 0 ||
+            terminalLifecycle?.occurred_at !== attempt.finished_at)) ||
         (handleSubmitted !== undefined &&
           (handleSubmitted < createdAt || handleSubmitted < queued)) ||
         (attempt.durable_handle?.last_observed_at !== undefined &&
@@ -208,16 +240,6 @@ export const CanonicalRunManifestV3Schema = z
         });
       }
     });
-    const firstLifecycle = state.lifecycle[0];
-    const terminalLifecycle = state.lifecycle.at(-1);
-    const expectedTerminalKind =
-      state.status === 'cancelled'
-        ? 'request_cancelled'
-        : state.status === 'failed'
-          ? 'request_failed'
-          : state.status === 'running'
-            ? undefined
-            : 'request_completed';
     if (
       firstLifecycle?.occurred_at !== state.created_at ||
       (expectedTerminalKind !== undefined &&

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -883,6 +883,92 @@ describe('private prepared execution runtime', () => {
     expect(durable.retrieve).not.toHaveBeenCalled();
   });
 
+  it('retains accepted custody after a diagnosed transient poll failure', async () => {
+    const submit = vi.fn(async () => ({
+      provider: 'adapter-durable',
+      taskId: 'accepted-task',
+      query: 'runtime query',
+      submittedAt: start,
+      status: 'pending' as const,
+    }));
+    const poll = vi.fn(async () => {
+      throw Object.assign(new Error('raw provider detail'), {
+        failureDiagnostic: { kind: 'authentication', httpStatus: 401 },
+      });
+    });
+    const retrieve = vi.fn();
+    const reserveExecute = vi.fn(async () =>
+      successfulResult('adapter-reserve'),
+    );
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit,
+      poll,
+      retrieve,
+    };
+    const reserve: Provider = {
+      id: 'adapter-reserve',
+      displayName: 'Reserve',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: reserveExecute,
+    };
+    const plan = prepared(
+      [profile('durable', 'background')],
+      [profile('reserve')],
+      'async',
+    );
+    const store = new InMemoryCoordinationStateStore();
+    const bridge = createProviderAttemptBridge({
+      resolveExactBinding: (binding) =>
+        binding.adapter_id === 'adapter-durable'
+          ? resolvedBinding('durable', durable)
+          : binding.adapter_id === 'adapter-reserve'
+            ? resolvedBinding('reserve', reserve)
+            : undefined,
+      now: () => start,
+    });
+
+    await runPreparedExecution(plan, {
+      store,
+      coordinator: coordinatorDependencies(),
+      attempts: bridge,
+    });
+    const resumed = await runPreparedExecution(plan, {
+      store,
+      coordinator: coordinatorDependencies(),
+      attempts: bridge,
+      resume_existing: true,
+    });
+
+    expect(submit).toHaveBeenCalledOnce();
+    expect(poll).toHaveBeenCalledOnce();
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(reserveExecute).not.toHaveBeenCalled();
+    expect(resumed.state.status).toBe('running');
+    expect(resumed.state.attempts).toHaveLength(1);
+    expect(resumed.state.attempts[0]).toMatchObject({
+      status: 'submitted',
+      durable_handle: {
+        provider_task_id: 'accepted-task',
+        status: 'pending',
+      },
+      transient_poll_error: {
+        code: 'provider_authentication_failed',
+        category: 'authentication',
+        provider_code: 'http_401',
+        fallback_allowed: false,
+      },
+    });
+    expect(JSON.stringify(resumed.state)).not.toContain('raw provider detail');
+  });
+
   it('retrieves an already-completed durable submission in async mode', async () => {
     const durable: Provider = {
       id: 'adapter-durable',

--- a/tests/node-canonical-run.test.ts
+++ b/tests/node-canonical-run.test.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ExecutionProfile } from '../src/contracts/domain/index.js';
 import {
+  advanceCoordination,
   cancelCoordination,
   createCoordinatorState,
 } from '../src/core/coordinator.js';
@@ -1293,6 +1294,11 @@ describe('canonical v3 run.json', () => {
         ).toISOString();
       },
       (value) => {
+        value.coordination_state.attempts[0].finished_at = new Date(
+          START + 1,
+        ).toISOString();
+      },
+      (value) => {
         value.provider_outputs_by_attempt.unknown_attempt = structuredClone(
           Object.values(value.provider_outputs_by_attempt)[0],
         );
@@ -1308,6 +1314,52 @@ describe('canonical v3 run.json', () => {
         false,
       );
     }
+  });
+
+  it('binds an unstarted timeout finish to the terminal request observation', async () => {
+    const { root, runDirectory } = directories();
+    const plan = prepared([profile('unstarted-timeout')]);
+    const pending = advanceCoordination(
+      createCoordinatorState(plan, coordinator('initial-')),
+      coordinator('launch-'),
+    ).state;
+    expect(pending.attempts[0]?.status).toBe('dispatch_pending');
+    expect(pending.attempts[0]).not.toHaveProperty('started_at');
+    const expired = advanceCoordination(pending, {
+      ...coordinator('expired-'),
+      clock: { now: () => START + 60_001 },
+    }).state;
+    const attempt = expired.attempts[0];
+    const terminal = expired.lifecycle.at(-1);
+    expect(attempt).toMatchObject({
+      status: 'timed_out',
+      finished_at: terminal?.occurred_at,
+    });
+    expect(attempt).not.toHaveProperty('started_at');
+    expect(
+      expired.lifecycle.some(
+        (event) =>
+          event.event_kind === 'attempt_finished' &&
+          event.attempt_id === attempt?.attempt_id,
+      ),
+    ).toBe(false);
+
+    const store = new RunJsonCoordinationStateStore({
+      runs_root: root,
+      run_directory: runDirectory,
+      request: plan.request,
+    });
+    await store.create(expired);
+    const manifest = store.readManifest();
+    expect(CanonicalRunManifestV3Schema.safeParse(manifest).success).toBe(true);
+
+    const impossible = structuredClone(manifest);
+    impossible.coordination_state.attempts[0]!.finished_at = new Date(
+      Date.parse(terminal?.occurred_at ?? '') + 1,
+    ).toISOString();
+    expect(CanonicalRunManifestV3Schema.safeParse(impossible).success).toBe(
+      false,
+    );
   });
 
   it('rejects symlinked roots, run directories, and run.json files', async () => {

--- a/tests/research-provider-adapters.test.ts
+++ b/tests/research-provider-adapters.test.ts
@@ -429,7 +429,7 @@ describe('durable research provider adapters', () => {
     );
   });
 
-  it('fails closed on malformed status and empty Tavily completion', async () => {
+  it('keeps malformed Tavily status nonterminal and rejects empty retrieval', async () => {
     const provider = new TavilyResearchProvider({
       credentials: { env: { TAVILY_API_KEY: 'test-key' } },
       httpClient: vi.fn(async () =>
@@ -450,8 +450,9 @@ describe('durable research provider adapters', () => {
       submittedAt: 0,
       status: 'running' as const,
     };
-    await expect(provider.poll(handle)).resolves.toMatchObject({
-      status: 'failed',
+    await expect(provider.poll(handle)).rejects.toMatchObject({
+      message: 'Tavily Research status check failed.',
+      failureDiagnostic: { kind: 'provider', httpStatus: 200 },
     });
     await expect(provider.retrieve(handle)).resolves.toMatchObject({
       content: '',
@@ -472,9 +473,230 @@ describe('durable research provider adapters', () => {
       provider.submit('query', { timeout: 10 }),
     ).resolves.toMatchObject({
       taskId: 'tavily-preserved',
-      status: 'failed',
+      status: 'pending',
       providerStatus: 'invalid_response',
+      lastPollError: 'Tavily returned a malformed create response',
     });
+  });
+
+  it.each([
+    ['malformed progress', response({ status: 'in_progress' }, 202), 202],
+    ['malformed success', response({ status: 'completed' }, 200), 200],
+    ['authentication', response({}, 401), 401],
+    ['authorization', response({}, 403), 403],
+    ['billing', response({}, 433), 433],
+    ['invalid request', response({}, 422), 422],
+  ] as const)(
+    'keeps accepted Tavily custody on $label poll evidence',
+    async (_label, pollResponse, httpStatus) => {
+      const provider = new TavilyResearchProvider({
+        credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+        httpClient: vi.fn(async () => pollResponse) as HttpClient,
+      });
+      const handle = {
+        provider: provider.id,
+        taskId: 'tavily-run',
+        query: 'q',
+        submittedAt: 0,
+        status: 'running' as const,
+      };
+
+      await expect(provider.poll(handle)).rejects.toMatchObject({
+        message: 'Tavily Research status check failed.',
+        failureDiagnostic: { httpStatus },
+      });
+      expect(handle).toEqual(
+        expect.objectContaining({ taskId: 'tavily-run', status: 'running' }),
+      );
+    },
+  );
+
+  it.each([
+    'file:///private/report',
+    'javascript:alert(1)',
+    'data:text/plain,report',
+    'https://user:password@example.com/report',
+    'not a URL',
+  ])('rejects unsafe Tavily citation URL %s', async (url) => {
+    const provider = new TavilyResearchProvider({
+      credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+      httpClient: async () =>
+        response({
+          request_id: 'tavily-run',
+          created_at: '2026-08-12T12:00:00.000Z',
+          status: 'completed',
+          content: 'report',
+          sources: [{ title: 'unsafe', url }],
+          response_time: 1,
+        }) as never,
+    });
+
+    await expect(
+      provider.retrieve({
+        provider: provider.id,
+        taskId: 'tavily-run',
+        query: 'q',
+        submittedAt: 0,
+        status: 'completed',
+      }),
+    ).resolves.toMatchObject({
+      content: '',
+      citations: [],
+      error: 'Tavily Research retrieval failed.',
+    });
+  });
+
+  it.each([
+    {
+      label: 'authentication',
+      implementation: async () =>
+        response({ error: { message: 'secret invalid token' } }, 401) as never,
+      diagnostic: { kind: 'authentication', httpStatus: 401 },
+    },
+    {
+      label: 'plan restriction',
+      implementation: async () =>
+        response({ detail: { error: 'PLAN_REQUIRED' } }, 403) as never,
+      diagnostic: { kind: 'plan_required', httpStatus: 403 },
+    },
+    {
+      label: 'rate limit',
+      implementation: async () =>
+        response({ detail: { error: 'plan upgrade required' } }, 429) as never,
+      diagnostic: { kind: 'rate_limit', httpStatus: 429 },
+    },
+    {
+      label: 'plan usage limit',
+      implementation: async () =>
+        response({ detail: { error: 'usage limit reached' } }, 432) as never,
+      diagnostic: { kind: 'plan_required', httpStatus: 432 },
+    },
+    {
+      label: 'pay-as-you-go limit',
+      implementation: async () =>
+        response({ detail: { error: 'paygo limit reached' } }, 433) as never,
+      diagnostic: { kind: 'billing', httpStatus: 433 },
+    },
+    {
+      label: 'invalid request',
+      implementation: async () => response({}, 422) as never,
+      diagnostic: { kind: 'invalid_request', httpStatus: 422 },
+    },
+    {
+      label: 'provider response',
+      implementation: async () => response({}, 503) as never,
+      diagnostic: { kind: 'provider', httpStatus: 503 },
+    },
+    {
+      label: 'request timeout with quota text',
+      implementation: async () =>
+        response({ detail: { error: 'quota exceeded' } }, 408) as never,
+      diagnostic: { kind: 'timeout', httpStatus: 408 },
+    },
+    {
+      label: 'gateway timeout with quota text',
+      implementation: async () =>
+        response({ detail: { error: 'quota exceeded' } }, 504) as never,
+      diagnostic: { kind: 'timeout', httpStatus: 504 },
+    },
+    {
+      label: 'provider failure with quota text',
+      implementation: async () =>
+        response({ detail: { error: 'quota exceeded' } }, 500) as never,
+      diagnostic: { kind: 'provider', httpStatus: 500 },
+    },
+    {
+      label: 'network failure',
+      implementation: async () => {
+        throw new TypeError('fetch failed https://secret.example/token');
+      },
+      diagnostic: { kind: 'network' },
+    },
+    {
+      label: 'timeout',
+      implementation: async () => {
+        throw new DOMException('secret timeout detail', 'TimeoutError');
+      },
+      diagnostic: { kind: 'timeout' },
+    },
+    {
+      label: 'invalid 201 handle',
+      implementation: async () => response({ status: 'pending' }, 201) as never,
+      diagnostic: { kind: 'provider', httpStatus: 201 },
+    },
+  ])(
+    'keeps Tavily $label submission failures bounded and unsafe to retry',
+    async ({ implementation, diagnostic }) => {
+      const httpClient = vi.fn(implementation);
+      const provider = new TavilyResearchProvider({
+        credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+        httpClient,
+      });
+
+      const submission = provider.submit('query', { timeout: 10 });
+      await expect(submission).rejects.toMatchObject({
+        name: 'UnsafeToRetrySubmissionError',
+        message:
+          'Tavily Research submission failed before a valid handle was returned.',
+        failureDiagnostic: diagnostic,
+      });
+      await expect(submission).rejects.not.toThrow(
+        /secret|token|https?:|PLAN_REQUIRED/i,
+      );
+      expect(httpClient).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('redacts Tavily terminal and transport failures at poll and retrieval boundaries', async () => {
+    const terminalFailure = {
+      request_id: 'tavily-run',
+      status: 'failed',
+      error: { message: 'Bearer secret-token https://secret.example/raw' },
+    };
+    const terminal = new TavilyResearchProvider({
+      credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+      httpClient: vi.fn(async () => response(terminalFailure)) as HttpClient,
+    });
+    const handle = {
+      provider: terminal.id,
+      taskId: 'tavily-run',
+      query: 'q',
+      submittedAt: 0,
+      status: 'running' as const,
+    };
+
+    await expect(terminal.poll(handle)).resolves.toEqual({
+      status: 'failed',
+      rawStatus: 'failed',
+      message: 'Tavily Research task failed.',
+      failureDiagnostic: { kind: 'provider' },
+    });
+    await expect(terminal.retrieve(handle)).resolves.toMatchObject({
+      content: '',
+      error: 'Tavily Research retrieval failed.',
+      failureDiagnostic: { kind: 'provider', httpStatus: 200 },
+    });
+
+    const transport = new TavilyResearchProvider({
+      credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+      httpClient: vi.fn(async () => {
+        throw new TypeError('fetch failed https://secret.example/Bearer-token');
+      }) as HttpClient,
+    });
+    await expect(transport.poll(handle)).rejects.toMatchObject({
+      message: 'Tavily Research status check failed.',
+      failureDiagnostic: { kind: 'network' },
+    });
+    await expect(transport.retrieve(handle)).resolves.toMatchObject({
+      error: 'Tavily Research retrieval failed.',
+      failureDiagnostic: { kind: 'network' },
+    });
+
+    const serialized = JSON.stringify([
+      await terminal.retrieve(handle),
+      await transport.retrieve(handle),
+    ]);
+    expect(serialized).not.toMatch(/secret|bearer|https?:|raw/i);
   });
 
   it('rejects invalid structured and source options before any transport call', async () => {

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -5,6 +5,8 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -171,8 +173,8 @@ function canonicalBridge(
 async function seedCanonicalRun(
   run: string,
   mode: 'sync' | 'async',
+  now = Date.now(),
 ): Promise<{ runDir: string; plan: PreparedResearchExecution; now: number }> {
-  const now = Date.now();
   const runDir = join(state.outputDir, run);
   mkdirSync(runDir, { recursive: true });
   const plan = canonicalPlan(mode, run, now);
@@ -379,6 +381,124 @@ describe('status command', () => {
     expect(state.retrieve).toHaveBeenCalledOnce();
     expect(readCanonicalRunManifest(state.outputDir, runDir).revision).toBe(
       revision,
+    );
+  });
+
+  it('terminalizes an expired run after its deadline and still reconciles a later run', async () => {
+    const expired = await seedCanonicalRun(
+      'expired-v3',
+      'async',
+      Date.now() - 120_000,
+    );
+    const active = await seedCanonicalRun('active-v3', 'async');
+    state.poll.mockClear();
+    state.retrieve.mockClear();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await program().parseAsync(['node', 'test', 'status', '--json']);
+
+    const expiredManifest = readCanonicalRunManifest(
+      state.outputDir,
+      expired.runDir,
+    );
+    const expiredAttempt = expiredManifest.coordination_state.attempts[0];
+    expect(expiredAttempt).toMatchObject({ status: 'timed_out' });
+    expect(Date.parse(expiredAttempt?.finished_at ?? '')).toBeGreaterThan(
+      Date.parse(expiredAttempt?.deadline_at ?? ''),
+    );
+    expect(
+      expiredManifest.coordination_state.lifecycle.find(
+        (event) =>
+          event.event_kind === 'attempt_finished' &&
+          event.attempt_id === expiredAttempt?.attempt_id,
+      )?.occurred_at,
+    ).toBe(expiredAttempt?.finished_at);
+    expect(
+      readCanonicalRunManifest(state.outputDir, active.runDir)
+        .coordination_state.status,
+    ).toBe('succeeded');
+    expect(state.poll).toHaveBeenCalledTimes(1);
+    expect(state.retrieve).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(payload.errors).toBeUndefined();
+
+    const receipt = structuredClone(expiredManifest.terminal_response);
+    const lifecycle = structuredClone(
+      expiredManifest.coordination_state.lifecycle,
+    );
+    const budget = structuredClone(expiredManifest.coordination_state.budget);
+    const outputs = structuredClone(
+      expiredManifest.provider_outputs_by_attempt,
+    );
+    state.submit.mockImplementation(async (query: string) => ({
+      provider: 'status-command-mock',
+      taskId: 'later-task',
+      query,
+      submittedAt: Date.now(),
+      status: 'pending',
+    }));
+    const later = await seedCanonicalRun('later-v3', 'async');
+    state.submit.mockClear();
+    state.poll.mockClear();
+    state.retrieve.mockClear();
+
+    await program().parseAsync(['node', 'test', 'status', '--json']);
+
+    const observed = readCanonicalRunManifest(state.outputDir, expired.runDir);
+    expect(state.submit).not.toHaveBeenCalled();
+    expect(state.poll).toHaveBeenCalledTimes(2);
+    expect(state.retrieve).toHaveBeenCalledOnce();
+    expect(state.retrieve.mock.calls[0]?.[0]).toMatchObject({
+      taskId: 'later-task',
+    });
+    expect(observed.terminal_response).toEqual(receipt);
+    expect(observed.coordination_state.lifecycle).toEqual(lifecycle);
+    expect(observed.coordination_state.budget).toEqual(budget);
+    expect(observed.provider_outputs_by_attempt).toEqual(outputs);
+    expect(observed.coordination_state.attempts[0]).toMatchObject({
+      status: 'timed_out',
+      durable_handle: { status: 'succeeded' },
+    });
+    expect(
+      readCanonicalRunManifest(state.outputDir, later.runDir).coordination_state
+        .status,
+    ).toBe('succeeded');
+  });
+
+  it('isolates one canonical reconciliation failure without transport or aborting later runs', async () => {
+    const active = await seedCanonicalRun('active-before-failure', 'async');
+    const failed = await seedCanonicalRun('failed-presentation', 'sync');
+    const outside = join(state.outputDir, 'outside-summary');
+    writeFileSync(outside, 'outside');
+    const summary = join(failed.runDir, 'summary.md');
+    rmSync(summary, { force: true });
+    symlinkSync(outside, summary);
+    state.poll.mockClear();
+    state.retrieve.mockClear();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await program().parseAsync(['node', 'test', 'status', '--json']);
+
+    expect(state.poll).toHaveBeenCalledTimes(1);
+    expect(state.retrieve).toHaveBeenCalledTimes(1);
+    expect(
+      readCanonicalRunManifest(state.outputDir, active.runDir)
+        .coordination_state.status,
+    ).toBe('succeeded');
+    const payload = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(payload.errors).toContain('artifact.reconciliation_failed');
+    expect(payload.canonicalRuns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          runDir: realpathSync(failed.runDir),
+          state: 'error',
+          error: 'artifact.reconciliation_failed',
+        }),
+        expect.objectContaining({
+          runDir: realpathSync(active.runDir),
+          state: 'terminal',
+        }),
+      ]),
     );
   });
 


### PR DESCRIPTION
## Summary

Harden durable reconciliation, timeout chronology, Tavily custody, and failure diagnostics without permitting resubmission or terminal result mutation.

## Changes

- Isolate reconciliation failures per run so later runs continue.
- Bind terminal attempt timestamps to canonical lifecycle evidence.
- Preserve GET-only custody observations after local timeout.
- Keep accepted Tavily handles nonterminal through malformed or transient observations.
- Add bounded Tavily diagnostics and credential-free HTTP(S) citation validation.

## Testing

- [x] Added / updated unit tests (`npm test`)
- [ ] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Build, declarations, Worker, integration, packed consumer, PTY, live fixture, contracts, and offline benchmark gates pass
- [x] High-risk deep review is GO with no unresolved Critical, High, or Medium findings
- [x] No provider calls were made
