### PR TITLE
chore: lock v2 rc8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.7",
+  "version": "2.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.7",
+      "version": "2.0.0-rc.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.7",
+  "version": "2.0.0-rc.8",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Lock Librarium 2.0.0-rc.8 from the fully merged provider-validation repair stack.

## Changes

- Bump the package version from `2.0.0-rc.7` to `2.0.0-rc.8` in the three canonical package fields.
- Preserve the exact 40-target matrix, catalog digest, pricing snapshot, and contract artifacts.

## Testing

- [x] Full unit suite: 2,144 passed, 7 skipped
- [x] Typecheck, lint, build, declarations, Worker, integration, packed consumer, and PTY passed
- [x] Live fixture, benchmark replay, and workflow policy passed
- [x] `rc:package` and `rc:verify-package` passed from the clean commit
- [x] High-risk review returned GO with no findings
- [ ] Protected multi-platform RC workflow

## Candidate Evidence

- Matrix: 40 targets
- Tarball SHA-256: `6ed94d7b0505cb98bacc6eaea7740c79d0dae5e1a26b5c0343271cadbd5748eb`
- Package files: 258
- Declarations: 242

No package was published, tagged, or released. No provider calls were made.
