### PR TITLE
Add Amp plugin for research companion with per-agent provider defaults

### DIFF
--- a/.amp/plugins/librarium/index.ts
+++ b/.amp/plugins/librarium/index.ts
@@ -1,0 +1,382 @@
+import type { PluginAPI, Agent } from '@ampcode/plugin'
+
+export const description =
+	'Research companion: multi-provider evidence-aware research via librarium, with per-agent provider defaults.'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Plugin configuration stored in Amp's configuration (separate from librarium's own v2 config). */
+interface LibrariumPluginConfig {
+	defaultGroup?: string
+	agentDefaults?: Record<string, AgentDefault>
+}
+
+interface AgentDefault {
+	group?: string
+	providers?: string[]
+	mode?: 'sync' | 'async' | 'mixed'
+	maxCost?: number
+}
+
+interface ResolvedSelection {
+	group?: string
+	providers?: string[]
+	mode?: 'sync' | 'async' | 'mixed'
+	maxCost?: number
+	source: 'explicit-input' | 'agent-default' | 'fallback-quick'
+}
+
+// ---------------------------------------------------------------------------
+// Agent identity → config key
+// ---------------------------------------------------------------------------
+
+function agentKey(def: Agent['definition']): string {
+	return def.kind === 'builtin-agent'
+		? `builtin:${def.mode}`
+		: `custom:${def.name ?? def.model}`
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent provider resolution
+// ---------------------------------------------------------------------------
+
+async function resolveSelection(
+	input: Record<string, unknown>,
+	ctx: { thread: { agent(): Promise<Agent> } },
+	config: LibrariumPluginConfig,
+): Promise<ResolvedSelection> {
+	// 1. Explicit tool-call args always win.
+	if (input.group || input.providers) {
+		return {
+			group: input.group as string | undefined,
+			providers: input.providers as string[] | undefined,
+			mode: input.mode as 'sync' | 'async' | 'mixed' | undefined,
+			maxCost: input.max_cost as number | undefined,
+			source: 'explicit-input',
+		}
+	}
+	// 2. Per-agent default from plugin config.
+	try {
+		const agent = await ctx.thread.agent()
+		const key = agentKey(agent.definition)
+		const def = config.agentDefaults?.[key]
+		if (def) return { ...def, source: 'agent-default' }
+	} catch {
+		// Agent identity unavailable — fall through to global default.
+	}
+	// 3. Global default group, or `quick` as the final fallback.
+	return {
+		group: config.defaultGroup ?? 'quick',
+		source: 'fallback-quick',
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shell helper
+// ---------------------------------------------------------------------------
+
+async function runCli(
+	amp: PluginAPI,
+	args: string[],
+): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
+	const { stdout, stderr, exitCode } = await amp.$`librarium ${args}`
+	if (exitCode !== 0) {
+		return { ok: false, error: stderr.trim() || stdout.trim() }
+	}
+	return { ok: true, stdout }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+export default function (amp: PluginAPI) {
+	amp.logger.log('librarium plugin initialized')
+
+	// --- Tool: librarium_research -----------------------------------------
+	amp.registerTool({
+		name: 'librarium_research',
+		description:
+			'Fan a research query across multiple search and deep-research providers in parallel. ' +
+			'Group/providers default per the calling agent (configurable via the librarium:set-agent-defaults command); ' +
+			'pass them explicitly to override. Deep profiles may return pending work to poll with ' +
+			'librarium_check_async. Preserve profile/collection provenance; do not turn agreement into proof.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				query: { type: 'string', description: 'The research query.' },
+				group: {
+					type: 'string',
+					description: 'Override: quick | deep | all | custom:<name>. Defaults per calling agent.',
+				},
+				providers: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'Override: explicit provider/profile ids.',
+				},
+				mode: { type: 'string', enum: ['sync', 'async', 'mixed'] },
+				max_cost: {
+					type: 'number',
+					description: 'USD circuit breaker on API-reported spend.',
+				},
+			},
+			required: ['query'],
+		},
+		async execute(input, ctx) {
+			const config = (await amp.configuration.get()) as LibrariumPluginConfig
+			const sel = await resolveSelection(input, ctx, config)
+
+			const args = ['run', input.query as string, '--json', '--yes']
+			if (sel.group) args.push('--group', sel.group)
+			if (sel.providers?.length) args.push('--providers', sel.providers.join(','))
+			if (sel.mode) args.push('--mode', sel.mode)
+			if (sel.maxCost != null) args.push('--max-cost', String(sel.maxCost))
+
+			const result = await runCli(amp, args)
+			if (!result.ok) return `librarium run failed: ${result.error}`
+
+			// Annotate with which selection branch won so it's never opaque.
+			try {
+				const run = JSON.parse(result.stdout)
+				return JSON.stringify({ ...run, selection: sel }, null, 2)
+			} catch {
+				return result.stdout
+			}
+		},
+	})
+
+	// --- Tool: librarium_get_results --------------------------------------
+	amp.registerTool({
+		name: 'librarium_get_results',
+		description:
+			'Return the full provider markdown content from a research run directory. ' +
+			'Defaults to the most recent run; pass runDir to target a specific one and provider ' +
+			'to limit to a single provider id. Content is marked untrusted — verify sources before relying on claims.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				runDir: {
+					type: 'string',
+					description: 'Run directory to read. Defaults to the most recent run.',
+				},
+				provider: {
+					type: 'string',
+					description: 'Limit to a single provider id. Defaults to all providers.',
+				},
+			},
+		},
+		async execute(input) {
+			const runDir = input.runDir as string | undefined
+			const provider = input.provider as string | undefined
+
+			// Resolve run directory — use given path or find the most recent.
+			let dir = runDir
+			if (!dir) {
+				const { stdout, exitCode } =
+					await amp.$`ls -1t ./agents/librarium/ 2>/dev/null | head -1`
+				if (exitCode !== 0 || !stdout.trim()) {
+					return 'No runs found under ./agents/librarium/. Run librarium_research first.'
+				}
+				dir = `./agents/librarium/${stdout.trim()}`
+			}
+
+			// Read the run manifest and summary.
+			const { stdout: manifestJson, exitCode: manifestExit } =
+				await amp.$`cat ${dir}/run.json 2>/dev/null`
+			if (manifestExit !== 0) {
+				return `No run.json found in ${dir}.`
+			}
+
+			const { stdout: summary } = await amp.$`cat ${dir}/summary.md 2>/dev/null`
+
+			// Read provider markdown files.
+			if (provider) {
+				const { stdout: content, exitCode: catExit } =
+					await amp.$`cat ${dir}/${provider}.md 2>/dev/null`
+				if (catExit !== 0) {
+					return JSON.stringify({
+						runDir: dir,
+						manifest: safeParse(manifestJson),
+						summary: summary.trim(),
+						error: `No provider file found for ${provider}`,
+					})
+				}
+				return JSON.stringify({
+					runDir: dir,
+					manifest: safeParse(manifestJson),
+					summary: summary.trim(),
+					providers: { [provider]: content },
+					untrusted: true,
+				})
+			}
+
+			// Read all provider .md files (exclude summary.md, prompt.md, answer.md).
+			const { stdout: listing } =
+				await amp.$`ls ${dir}/*.md 2>/dev/null`
+			const files = listing
+				.trim()
+				.split('\n')
+				.filter(Boolean)
+				.filter(
+					(f) =>
+						!f.endsWith('summary.md') &&
+						!f.endsWith('prompt.md') &&
+						!f.endsWith('answer.md'),
+				)
+
+			const providers: Record<string, string> = {}
+			for (const file of files) {
+				const name = file.replace(/^.*\//, '').replace(/\.md$/, '')
+				const { stdout: content } = await amp.$`cat ${file}`
+				// Cap per-provider content at ~40k chars with a truncation marker.
+				const capped =
+					content.length > 40_000
+						? `${content.slice(0, 40_000)}\n\n[... truncated at 40k chars ...]`
+						: content
+				providers[name] = capped
+			}
+
+			return JSON.stringify({
+				runDir: dir,
+				manifest: safeParse(manifestJson),
+				summary: summary.trim(),
+				providers,
+				untrusted: true,
+			})
+		},
+	})
+
+	// --- Tool: librarium_check_async --------------------------------------
+	amp.registerTool({
+		name: 'librarium_check_async',
+		description:
+			'Run one bounded resume pass over pending async deep-research work. ' +
+			'schemaVersion 3 always retrieves observed remote completion. ' +
+			'Pass retrieve=true to also fetch completed historical schemaVersion 2 tasks.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				retrieve: {
+					type: 'boolean',
+					description: 'Retrieve completed historical schemaVersion 2 tasks.',
+				},
+			},
+		},
+		async execute(input) {
+			const args = ['status', '--json']
+			if (input.retrieve) args.push('--retrieve')
+			const result = await runCli(amp, args)
+			if (!result.ok) return `check_async failed: ${result.error}`
+			return result.stdout
+		},
+	})
+
+	// --- Tool: librarium_list_providers -----------------------------------
+	amp.registerTool({
+		name: 'librarium_list_providers',
+		description:
+			'Return a snapshot of the provider registry and config: id, name, tier, source, ' +
+			'whether enabled, and whether an API key is configured.',
+		inputSchema: {
+			type: 'object',
+			properties: {},
+		},
+		async execute() {
+			const result = await runCli(amp, ['ls', '--json'])
+			if (!result.ok) return `list_providers failed: ${result.error}`
+			return result.stdout
+		},
+	})
+
+	// --- Tool: librarium_list_groups --------------------------------------
+	amp.registerTool({
+		name: 'librarium_list_groups',
+		description: 'Return the configured provider groups and their member provider ids.',
+		inputSchema: {
+			type: 'object',
+			properties: {},
+		},
+		async execute() {
+			const result = await runCli(amp, ['groups', '--json'])
+			if (!result.ok) return `list_groups failed: ${result.error}`
+			return result.stdout
+		},
+	})
+
+	// --- Bundled skill gates all 5 tools out of unrelated threads ---------
+	void amp.registerSkill({ path: 'skills/research' })
+
+	// --- Command: dispatch research from the palette ----------------------
+	amp.registerCommand(
+		'librarium:research',
+		{
+			title: 'Research',
+			category: 'Librarium',
+			description: 'Run a multi-provider research query.',
+		},
+		async (ctx) => {
+			const query = await ctx.ui.input('Research query')
+			if (!query) return
+			const group = await ctx.ui.select('Workflow', ['quick', 'deep', 'all'])
+			if (!group) return
+			await ctx.ui.notify(`Dispatching "${query}" (${group})…`)
+			const result = await runCli(amp, [
+				'run',
+				query,
+				'--group',
+				group,
+				'--json',
+				'--yes',
+			])
+			if (result.ok) {
+				try {
+					const run = JSON.parse(result.stdout)
+					await ctx.ui.notify(
+						`Run complete: ${run.outputDir ?? run.runDir ?? 'done'}`,
+					)
+				} catch {
+					await ctx.ui.notify('Run complete.')
+				}
+			} else {
+				await ctx.ui.notify(`Run failed: ${result.error}`)
+			}
+		},
+	)
+
+	// --- Command: set the current agent's default group -------------------
+	amp.registerCommand(
+		'librarium:set-agent-defaults',
+		{
+			title: 'Set agent research defaults',
+			category: 'Librarium',
+			description: 'Set the default research group for the current agent mode.',
+		},
+		async (ctx) => {
+			const agent = await ctx.thread.agent()
+			const key = agentKey(agent.definition)
+			const group = await ctx.ui.select(
+				`Default group for ${key}`,
+				['quick', 'deep', 'all'],
+			)
+			if (!group) return
+			await amp.configuration.update({
+				agentDefaults: { [key]: { group } },
+			})
+			await ctx.ui.notify(`${key} → ${group}`)
+		},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function safeParse(text: string): unknown {
+	try {
+		return JSON.parse(text)
+	} catch {
+		return text.trim()
+	}
+}

--- a/.amp/plugins/librarium/skills/research/SKILL.md
+++ b/.amp/plugins/librarium/skills/research/SKILL.md
@@ -1,0 +1,89 @@
+---
+description: Multi-provider, evidence-aware deep research via the librarium Amp plugin (33 providers, 40 profiles).
+triggers:
+  - /librarium
+  - /research
+  - /deep-research
+  - deep research
+  - multi-provider search
+builtin-tools:
+  - librarium_research
+  - librarium_get_results
+  - librarium_check_async
+  - librarium_list_providers
+  - librarium_list_groups
+---
+
+# Librarium — Multi-Provider Deep Research
+
+Run research queries through Librarium's v2 public provider/profile catalog.
+There are 33 built-in providers and 40 implemented profiles. Preserve the
+profile and collection provenance when reporting results; do not turn source
+counts or agreement into a confidence claim.
+
+## When to use each tool
+
+| Tool | Use it when |
+|------|-------------|
+| `librarium_research` | You need to fan a query across multiple providers for cited, multi-perspective evidence. This is the primary research tool. |
+| `librarium_check_async` | A prior `librarium_research` call returned pending async work (deep-research profiles). Polls one bounded resume pass. |
+| `librarium_get_results` | You need the full provider markdown content from a completed run. Content is marked untrusted — verify sources before relying on claims. |
+| `librarium_list_providers` | You need to see which providers are configured, enabled, and have API keys set. |
+| `librarium_list_groups` | You need to see available provider groups and their members before selecting one. |
+
+## Research workflow
+
+### 1. Analyze the query
+Determine the query type and select a group:
+- **Quick facts / low-latency**: `quick` (curated AI-grounded providers)
+- **Deep research**: `deep` (research-report profiles, may run async)
+- **Full catalog coverage**: `all` (catalog-derived, confirm cost exposure first)
+- **Custom**: `custom:<name>` (user-authored group)
+
+### 2. Dispatch
+Call `librarium_research` with the query and group. Group/providers default
+per the calling agent — pass them explicitly to override. The result includes
+a `selection` field showing which branch won (explicit-input, agent-default,
+or fallback-quick).
+
+### 3. Poll async work
+If the result indicates pending async work (from `background/durable`
+profiles), call `librarium_check_async` to run a bounded resume pass.
+schemaVersion 3 retrieves observed completion immediately.
+
+### 4. Read full results
+Call `librarium_get_results` to get the full provider markdown content from
+the run directory. Content is capped per provider (~40k chars) and marked
+untrusted.
+
+### 5. Synthesize
+Combine findings from multiple providers into a coherent answer. Record
+source overlap and provenance, but do not convert a higher citation count
+into a confidence score: shared collectors and repeated sources can make
+that evidence correlated.
+
+## Provider tiers
+
+| Tier | Providers | Speed | Depth |
+|------|-----------|-------|-------|
+| background/durable | Exa, Tavily, OpenAI Research, Gemini Deep, Perplexity Deep Research, Perplexity Sonar Deep, Parallel, Valyu, You Research | Minutes to longer | Persisted handles that can be polled and retrieved |
+| inline | Search, grounded, collected surface, and chat profiles | Usually seconds | Immediate response; no durable handle |
+
+## Evidence boundaries
+
+- A direct API response is `api_output`. It reports the response returned by
+  the named API; it does not make a result universally correct.
+- A citation is a source reference, not a guarantee that the source is safe
+  to fetch, authoritative, reachable, or supportive of every nearby claim.
+- Provenance records what happened; it is not a confidence score or a claim
+  of consumer behaviour.
+- Do not turn agreement into proof. Shared collectors and repeated sources
+  can make evidence correlated.
+
+## Output structure
+
+```
+./agents/librarium/{timestamp}-{slug}/
+  prompt.md, run.json, summary.md, sources.json
+  {provider}.md, {provider}.meta.json
+```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ incomplete, budget-limited, or fails.
 
 Other public commands are `live-validation`, `status`, `usage`, `browse`,
 `html`, `jsonl`, `refine`, `completions`, `ls`, `groups`, `init`, `doctor`,
-`config`, `cleanup`, `clear`, `upgrade`, `install-skill`, and `mcp`.
+`config`, `cleanup`, `clear`, `upgrade`, `install-skill`, `install-plugin`,
+and `mcp`.
 
 ### Command option ledger
 
@@ -193,6 +194,7 @@ that are not in the `run` table above.
 | `clear` | `--interactive`, `--dry-run`, `--yes`, `--output`, `--json` |
 | `upgrade` | `--check`, `--dry-run`, `--force` |
 | `install-skill` | `--force`, `--dry-run` |
+| `install-plugin` | `--force`, `--dry-run` |
 | `mcp` | no explicit option |
 
 ### Durable work: wait, retrieve, and cancel
@@ -296,6 +298,20 @@ per-provider cap and marks it untrusted. `check_async` performs one bounded
 resume pass; for canonical schema version 3 it retrieves an observed completed
 result immediately, while its `retrieve` flag applies only to historical
 schema version 2 runs.
+
+### Amp plugin
+
+```bash
+librarium install-plugin
+```
+
+Installs the librarium Amp plugin to `~/.config/amp/plugins/librarium/`. The
+plugin exposes the same five tools as the MCP server as native Amp tools,
+gated behind a bundled skill so they stay out of unrelated threads. It adds
+per-agent provider defaults (configurable via the `librarium:set-agent-defaults`
+command) so different agent modes can default to different research groups
+without per-call overrides. The `librarium:research` command dispatches a
+run from the command palette.
 
 ## Shared TypeScript/PHP boundary
 

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -8,6 +8,7 @@ import { registerDoctorCommand } from './commands/doctor.js';
 import { registerGroupsCommand } from './commands/groups.js';
 import { registerHtmlCommand } from './commands/html.js';
 import { registerInitCommand } from './commands/init.js';
+import { registerInstallPluginCommand } from './commands/install-plugin.js';
 import { registerInstallSkillCommand } from './commands/install-skill.js';
 import { registerJsonlCommand } from './commands/jsonl.js';
 import { registerLiveValidationCommand } from './commands/live-validation.js';
@@ -52,6 +53,7 @@ export function createCliProgram(): Command {
   registerCleanupCommand(program);
   registerUpgradeCommand(program);
   registerInstallSkillCommand(program);
+  registerInstallPluginCommand(program);
   registerMcpCommand(program);
 
   return program;

--- a/src/commands/install-plugin.ts
+++ b/src/commands/install-plugin.ts
@@ -1,0 +1,105 @@
+import { existsSync, lstatSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { Command } from 'commander';
+import { VERSION } from '../constants.js';
+
+/**
+ * Files that make up the Amp plugin, relative to the repository root.
+ * Each entry is downloaded from the version-pinned GitHub raw URL and
+ * installed to the corresponding path under the plugin directory.
+ */
+const PLUGIN_FILES = [
+  '.amp/plugins/librarium/index.ts',
+  '.amp/plugins/librarium/skills/research/SKILL.md',
+];
+
+const PLUGIN_DIR = join(homedir(), '.config', 'amp', 'plugins', 'librarium');
+const REPO_OWNER = 'jkudish';
+const REPO_NAME = 'librarium';
+
+function rawUrl(branch: string, filePath: string): string {
+  return `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${branch}/${filePath}`;
+}
+
+export function registerInstallPluginCommand(program: Command): void {
+  program
+    .command('install-plugin')
+    .description('Install the Amp plugin for AI-assisted research')
+    .option('--force', 'Overwrite existing plugin files')
+    .option('--dry-run', 'Show what would happen without installing')
+    .action(async (opts) => {
+      try {
+        if (opts.dryRun) {
+          console.log('Would download plugin files from:');
+          for (const file of PLUGIN_FILES) {
+            console.log(`  ${rawUrl(`v${VERSION}`, file)}`);
+          }
+          console.log(`Would install to:\n  ${PLUGIN_DIR}`);
+          return;
+        }
+
+        console.log('Downloading librarium Amp plugin...');
+
+        const branches = [`v${VERSION}`, 'main'];
+        let installed = 0;
+
+        for (const file of PLUGIN_FILES) {
+          const destPath = join(
+            PLUGIN_DIR,
+            file.replace('.amp/plugins/librarium/', ''),
+          );
+
+          if (existsSync(destPath)) {
+            if (!opts.force) {
+              console.log(`Already installed: ${destPath}`);
+              continue;
+            }
+            // Refuse to overwrite symlinks.
+            const stat = lstatSync(destPath);
+            if (stat.isSymbolicLink()) {
+              console.error(`${destPath} is a symlink — refusing to overwrite`);
+              process.exitCode = 1;
+              return;
+            }
+          }
+
+          let content: string | null = null;
+          for (const branch of branches) {
+            try {
+              const response = await fetch(rawUrl(branch, file));
+              if (response.ok) {
+                content = await response.text();
+                break;
+              }
+            } catch {
+              // Try next branch.
+            }
+          }
+
+          if (!content || content.trim().length < 50) {
+            console.error(
+              `Failed to download ${file} or content appears invalid.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          mkdirSync(dirname(destPath), { recursive: true });
+          writeFileSync(destPath, content, 'utf-8');
+          console.log(`Installed: ${destPath}`);
+          installed++;
+        }
+
+        if (installed > 0 || opts.force) {
+          console.log(`\nAmp plugin installed to ${PLUGIN_DIR}`);
+          console.log(
+            'Restart Amp or run the "plugins: reload" command to activate it.',
+          );
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/tests/commands/install-plugin.test.ts
+++ b/tests/commands/install-plugin.test.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+import { registerInstallPluginCommand } from '../../src/commands/install-plugin.js';
+
+describe('install-plugin command', () => {
+  it('registers the install-plugin command', () => {
+    const program = new Command();
+    registerInstallPluginCommand(program);
+    const cmd = program.commands.find((c) => c.name() === 'install-plugin');
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toBe(
+      'Install the Amp plugin for AI-assisted research',
+    );
+  });
+
+  it('has --force option', () => {
+    const program = new Command();
+    registerInstallPluginCommand(program);
+    const cmd = program.commands.find((c) => c.name() === 'install-plugin');
+    const forceOption = cmd?.options.find((o) => o.long === '--force');
+    expect(forceOption).toBeDefined();
+  });
+
+  it('has --dry-run option', () => {
+    const program = new Command();
+    registerInstallPluginCommand(program);
+    const cmd = program.commands.find((c) => c.name() === 'install-plugin');
+    const dryRunOption = cmd?.options.find((o) => o.long === '--dry-run');
+    expect(dryRunOption).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What this adds

Ships a directory plugin at `.amp/plugins/librarium/` that exposes librarium's research capabilities as native Amp tools, plus a CLI command to install it.

### Plugin (`.amp/plugins/librarium/`)

- **5 native Amp tools** gated behind a bundled skill (so they stay out of unrelated threads):
  - `librarium_research` — fan a query across multiple providers, with per-agent provider defaults
  - `librarium_get_results` — read full provider markdown from a run directory (marked untrusted)
  - `librarium_check_async` — poll pending async deep-research work
  - `librarium_list_providers` — list configured providers
  - `librarium_list_groups` — list provider groups
- **Bundled skill** (`skills/research/SKILL.md`) with `builtin-tools` frontmatter gating the 5 tools and documenting when to use each
- **Per-agent provider defaults**: `librarium_research` resolves group/providers in priority order — explicit tool args → per-agent config default (via `ctx.thread.agent()`) → `quick` fallback. The result includes a `selection` field showing which branch won.
- **2 commands**: `librarium:research` (palette dispatch) and `librarium:set-agent-defaults` (configure current agent's default group)
- No event hooks, no `web_search` interception — steering is via skill instructions only

### CLI command (`librarium install-plugin`)

Mirrors `librarium install-skill`: downloads the plugin files from version-pinned GitHub raw URLs (with `main` fallback) into `~/.config/amp/plugins/librarium/`. Supports `--force` and `--dry-run`.

### Documentation

- README updated with `install-plugin` in the command list, option ledger, and a new "Amp plugin" section under "For agents"

## What's intentionally deferred

`answer --verify`, `html`, `jsonl`, `visibility`, `doctor`, `usage`, `browse`, custom agent mode, status item, scheduled webhook — future iterations or a dedicated AEO plugin.

## Verification

- 19/19 tests pass across `install-plugin.test.ts`, `install-skill.test.ts`, `cli-program.test.ts`, and `public-documentation-drift.test.ts`
- Biome lint/format clean
- Full suite: 2146 pass, 1 pre-existing failure in `wizard-preflight.test.ts` (unrelated, fails on base `main` too)