### PR TITLE
Add .agents/setup and .agents/resume for orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# librarium orb resume — runs on every orb wake.
+# Fast, idempotent checks that the environment is still usable.
+
+# Verify librarium is still on PATH (global installs survive orb resume).
+if ! command -v librarium >/dev/null 2>&1; then
+  echo "[librarium] librarium not on PATH — run .agents/setup to reinstall"
+fi

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# librarium orb setup — runs once on a fresh orb.
+# Installs Node 22.12 (the project floor), dependencies, a global librarium
+# binary, and builds dist/ so the CLI and plugin are usable immediately.
+
+cd "$(dirname "$0")/.."
+
+NODE_TARGET=22.12.0
+
+echo "[$(date +%H:%M:%S)] Checking Node version"
+CURRENT=$(node -v 2>/dev/null || echo "none")
+if [ "$CURRENT" != "v$NODE_TARGET" ]; then
+  echo "  Current: $CURRENT, target: v$NODE_TARGET"
+  if command -v n >/dev/null 2>&1; then
+    n "$NODE_TARGET"
+  elif npx --yes n --version >/dev/null 2>&1; then
+    npx --yes n "$NODE_TARGET"
+  else
+    echo "  n not available — install Node $NODE_TARGET manually if builds fail"
+  fi
+else
+  echo "  Already on v$NODE_TARGET"
+fi
+
+echo "[$(date +%H:%M:%S)] Installing dependencies"
+npm install
+
+echo "[$(date +%H:%M:%S)] Building dist/"
+npm run build
+
+echo "[$(date +%H:%M:%S)] Installing librarium globally"
+npm install -g librarium
+
+echo "[$(date +%H:%M:%S)] Setup complete"

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ dist/
 agents/
 .agents/*
 !.agents/skills/
+!.agents/setup
+!.agents/resume
+.amp/portals/*
 benchmark/results/


### PR DESCRIPTION
## What this adds

Future orbs for librarium development now start with the correct toolchain and a working build instead of a bare Node 20 environment.

### `.\agents/setup` (runs once on a fresh orb)

1. **Node 22.12.0** — checks the current Node version and installs the project floor (22.12.0) via `n` or `npx n` if needed. Skips gracefully if already at the target or if `n` is unavailable.
2. **`npm install`** — dependencies from the lockfile
3. **`npm run build`** — builds `dist/` so the CLI and plugin are usable immediately
4. **`npm install -g librarium`** — global binary so the Amp plugin's `amp.$`librarium ...`` calls work out of the box

Idempotent: a second run detects Node 22.12 is already installed and skips the upgrade. Verified: cold run ~9s, warm run ~7s.

### `.\agents/resume` (runs on every orb wake)

Fast (3ms) check that `librarium` is still on PATH. Prints a warning if not — no heavy work, per the 10-second resume budget.

### `.\gitignore` updates

- Whitelists `.agents/setup` and `.agents/resume` (the existing `.agents/*` rule excluded them)
- Ignores `.amp/portals/\*` (ephemeral portal URLs)

## Verification

- Ran `.agents/setup` twice — both runs succeed, warm run converges without side effects
- Ran `.agents/resume` — completes in 3ms, silent when librarium is on PATH
- Executable bits set on both scripts
- `git check-ignore` confirms `.agents/setup` and `.agents/resume` are now trackable, `.amp/portals/\*` is ignored