### PR TITLE
Classify proven Exa submit rejections without unknown custody

### DIFF
--- a/src/adapters/exa-research.ts
+++ b/src/adapters/exa-research.ts
@@ -1,9 +1,14 @@
 import { z } from 'zod';
 import { UnsafeToRetrySubmissionError } from '../core/errors.js';
+import {
+  HttpRequestAbortedError,
+  HttpRequestTimeoutError,
+} from '../core/http-client.js';
 import type {
   AsyncPollResult,
   AsyncTaskHandle,
   Citation,
+  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -71,6 +76,8 @@ const ExaRun = z.object({
 type ExaRun = z.infer<typeof ExaRun>;
 
 const URL = 'https://api.exa.ai/agent/runs';
+const SUBMISSION_FAILED =
+  'Exa Agent submission failed before a valid handle was returned.';
 const statuses: Record<string, AsyncTaskHandle['status']> = {
   queued: 'pending',
   running: 'running',
@@ -78,6 +85,15 @@ const statuses: Record<string, AsyncTaskHandle['status']> = {
   failed: 'failed',
   cancelled: 'cancelled',
 };
+
+class ExaResearchSubmissionError extends UnsafeToRetrySubmissionError {
+  readonly failureDiagnostic: ProviderFailureDiagnostic;
+
+  constructor(failureDiagnostic: ProviderFailureDiagnostic) {
+    super(SUBMISSION_FAILED);
+    this.failureDiagnostic = failureDiagnostic;
+  }
+}
 
 /** Durable Exa Agent adapter bound only to `exa/research`. */
 export class ExaResearchProvider extends BackgroundBaseProvider {
@@ -120,7 +136,9 @@ export class ExaResearchProvider extends BackgroundBaseProvider {
       const result = await this.retrieve(handle);
       return { ...result, durationMs: Math.round(performance.now() - start) };
     } catch (error) {
-      return this.error(start, this.formatCatchError(error));
+      return error instanceof ExaResearchSubmissionError
+        ? this.error(start, error.message, error.failureDiagnostic)
+        : this.error(start, this.formatCatchError(error));
     }
   }
 
@@ -150,22 +168,23 @@ export class ExaResearchProvider extends BackgroundBaseProvider {
         signal: options.signal,
       });
     } catch (error) {
-      throw new UnsafeToRetrySubmissionError(
-        error instanceof Error ? error.message : String(error),
+      throw new ExaResearchSubmissionError(
+        this.catchDiagnostic(error, options.signal),
       );
     }
     if (response.status !== 200) {
-      throw new UnsafeToRetrySubmissionError(
-        this.formatError(response.status, response.data),
+      throw new ExaResearchSubmissionError(
+        this.httpDiagnostic(response.status),
       );
     }
     const parsed = ExaRun.safeParse(response.data);
     if (!parsed.success) {
       const id = ExaId.safeParse((response.data as { id?: unknown })?.id);
       if (!id.success)
-        throw new UnsafeToRetrySubmissionError(
-          'Exa Agent returned an invalid run handle',
-        );
+        throw new ExaResearchSubmissionError({
+          kind: 'provider',
+          httpStatus: 200,
+        });
       return {
         provider: this.id,
         taskId: id.data,
@@ -295,7 +314,11 @@ export class ExaResearchProvider extends BackgroundBaseProvider {
       timeout,
     });
   }
-  private error(start: number, error: string): ProviderResult {
+  private error(
+    start: number,
+    error: string,
+    failureDiagnostic?: ProviderFailureDiagnostic,
+  ): ProviderResult {
     return {
       provider: this.id,
       tier: this.tier,
@@ -303,7 +326,56 @@ export class ExaResearchProvider extends BackgroundBaseProvider {
       citations: [],
       durationMs: Math.round(performance.now() - start),
       error,
+      ...(failureDiagnostic && { failureDiagnostic }),
     };
+  }
+
+  private httpDiagnostic(status: number): ProviderFailureDiagnostic {
+    const httpStatus =
+      Number.isInteger(status) && status >= 100 && status <= 599
+        ? status
+        : undefined;
+    const kind: ProviderFailureDiagnostic['kind'] =
+      status === 401 || status === 403
+        ? 'authentication'
+        : status === 402
+          ? 'billing'
+          : status === 429
+            ? 'rate_limit'
+            : status === 408 || status === 504
+              ? 'timeout'
+              : status >= 400 && status < 500
+                ? 'invalid_request'
+                : status >= 500
+                  ? 'provider'
+                  : 'provider';
+    return { kind, ...(httpStatus !== undefined && { httpStatus }) };
+  }
+
+  private catchDiagnostic(
+    error: unknown,
+    signal?: AbortSignal,
+  ): ProviderFailureDiagnostic {
+    if (
+      signal?.aborted ||
+      error instanceof HttpRequestAbortedError ||
+      error instanceof HttpRequestTimeoutError ||
+      (error instanceof DOMException &&
+        (error.name === 'AbortError' || error.name === 'TimeoutError'))
+    ) {
+      return { kind: 'timeout' };
+    }
+    const detail = error instanceof Error ? error.message : '';
+    if (/API key not found/i.test(detail)) return { kind: 'authentication' };
+    if (
+      error instanceof TypeError ||
+      /fetch failed|failed to fetch|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT/i.test(
+        detail,
+      )
+    ) {
+      return { kind: 'network' };
+    }
+    return { kind: 'provider' };
   }
 }
 

--- a/src/core/provider-attempt-bridge.ts
+++ b/src/core/provider-attempt-bridge.ts
@@ -73,6 +73,33 @@ const PROVIDER_FAILURE_KINDS = new Set<ProviderFailureKind>([
   'provider',
 ]);
 
+function isProvenSubmissionRejection(
+  diagnostic: ProviderFailureDiagnostic,
+): boolean {
+  if (diagnostic.kind === 'timeout' || diagnostic.kind === 'network') {
+    return false;
+  }
+  if (diagnostic.kind === 'provider') {
+    return (
+      diagnostic.httpStatus !== undefined &&
+      diagnostic.httpStatus >= 400 &&
+      diagnostic.httpStatus < 500
+    );
+  }
+  return true;
+}
+
+function failureDiagnosticFromUnknown(
+  error: unknown,
+): ProviderFailureDiagnostic | undefined {
+  if (typeof error !== 'object' || error === null || Array.isArray(error)) {
+    return undefined;
+  }
+  return validatedFailureDiagnostic(
+    (error as { readonly failureDiagnostic?: unknown }).failureDiagnostic,
+  );
+}
+
 function validatedFailureDiagnostic(
   value: unknown,
 ): ProviderFailureDiagnostic | undefined {
@@ -653,14 +680,29 @@ export function createProviderAttemptBridge(
         launch,
         now,
       );
-      if (submitted.kind !== 'value') {
-        // A rejected promise cannot prove that the remote side did not accept
-        // the request. Halt instead of retrying or spending a fallback.
+      if (submitted.kind === 'deadline') {
+        // The local deadline fired while POST may already have been in flight.
         await context.submissionAcceptanceUnknown(
           undefined,
-          submitted.kind === 'deadline'
-            ? 'submission_deadline_exceeded'
-            : 'submission_response_uncertain',
+          'submission_deadline_exceeded',
+        );
+        return { kind: 'acceptance_unknown' };
+      }
+      if (submitted.kind === 'error') {
+        const diagnostic = failureDiagnosticFromUnknown(submitted.error);
+        if (diagnostic && isProvenSubmissionRejection(diagnostic)) {
+          return {
+            kind: 'finished',
+            finished: {
+              outcome: 'failed',
+              error: diagnosedProviderFailure(diagnostic, false),
+            },
+          };
+        }
+        // Timeout/5xx/connection-drop after POST cannot prove rejection.
+        await context.submissionAcceptanceUnknown(
+          undefined,
+          'submission_response_uncertain',
         );
         return { kind: 'acceptance_unknown' };
       }

--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -161,6 +161,7 @@ export function productionValidationMatrix(config: Config) {
 function hasDurableCustody(manifest: {
   readonly coordination_state: {
     readonly attempts?: readonly {
+      readonly status?: string;
       readonly durable_handle?: { readonly status?: string };
     }[];
   };
@@ -172,17 +173,43 @@ function hasDurableCustody(manifest: {
   );
 }
 
+function hasUnknownAcceptanceWithoutHandle(manifest: {
+  readonly coordination_state: {
+    readonly attempts?: readonly {
+      readonly status?: string;
+      readonly durable_handle?: { readonly status?: string };
+    }[];
+  };
+}): boolean {
+  return (
+    manifest.coordination_state.attempts?.some(
+      (attempt) =>
+        attempt.status === 'acceptance_unknown' &&
+        attempt.durable_handle === undefined,
+    ) ?? false
+  );
+}
+
 function classifyCustodyOutcome(
   reference: FrozenAttemptReference,
   manifest: {
     readonly coordination_state: {
       readonly status: string;
       readonly attempts?: readonly {
+        readonly status?: string;
         readonly durable_handle?: { readonly status?: string };
       }[];
     };
   },
 ): import('./commands/live-validation.js').FrozenExecutionOutcome {
+  if (hasUnknownAcceptanceWithoutHandle(manifest)) {
+    return {
+      status: 'terminal',
+      lifecycle: 'failed',
+      request_id: reference.request_id,
+      raw_manifest: JSON.stringify(manifest),
+    };
+  }
   if (
     manifest.coordination_state.status === 'running' ||
     hasDurableCustody(manifest)

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -443,6 +443,68 @@ describe('private prepared execution runtime', () => {
     });
   });
 
+  it('finishes durable submit on a proven 401 without fallback, retry, or unknown custody', async () => {
+    const submit = vi.fn(async () => {
+      throw Object.assign(
+        new Error(
+          'Exa Agent submission failed before a valid handle was returned.',
+        ),
+        {
+          name: 'UnsafeToRetrySubmissionError',
+          failureDiagnostic: { kind: 'authentication', httpStatus: 401 },
+        },
+      );
+    });
+    const fallback: Provider = {
+      id: 'adapter-reserve',
+      displayName: 'Reserve',
+      tier: 'raw-search',
+      envVar: '',
+      execution: 'inline',
+      execute: vi.fn(async () => successfulResult('adapter-reserve')),
+    };
+    const durable: Provider = {
+      id: 'adapter-durable',
+      displayName: 'Durable',
+      tier: 'deep-research',
+      envVar: '',
+      execution: 'background',
+      execute: vi.fn(),
+      submit,
+      poll: vi.fn(),
+      retrieve: vi.fn(),
+    };
+    const result = await runPreparedExecution(
+      prepared([profile('durable', 'background')], [profile('reserve')]),
+      {
+        store: new InMemoryCoordinationStateStore(),
+        coordinator: coordinatorDependencies(),
+        attempts: createProviderAttemptBridge({
+          resolveExactBinding: (binding) =>
+            binding.adapter_id === 'adapter-durable'
+              ? resolvedBinding('durable', durable)
+              : binding.adapter_id === 'adapter-reserve'
+                ? resolvedBinding('reserve', fallback)
+                : undefined,
+          now: () => start,
+        }),
+      },
+    );
+
+    expect(submit).toHaveBeenCalledOnce();
+    expect(fallback.execute).not.toHaveBeenCalled();
+    expect(durable.poll).not.toHaveBeenCalled();
+    expect(result.state.attempts).toHaveLength(1);
+    expect(result.state.attempts[0]?.status).toBe('failed');
+    expect(result.state.attempts[0]?.error).toMatchObject({
+      code: 'provider_authentication_failed',
+      provider_code: 'http_401',
+      retryable: false,
+      fallback_allowed: false,
+    });
+    expect(result.state.unresolved_acceptances).toEqual([]);
+  });
+
   it('rechecks concurrent orphan submissions after the request expires', async () => {
     const plan = prepared(
       [profile('durable-a', 'background'), profile('durable-b', 'background')],

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -412,6 +412,44 @@ describe('production live-validation binding (injected, offline)', () => {
       });
     },
   );
+
+  it('stops live validation when acceptance is unknown and no durable handle exists', async () => {
+    const target = buildCanonicalValidationMatrix().targets.find(
+      (candidate) => candidate.key === 'exa/research',
+    )!;
+    const observed = counters();
+    const dependencies = executorDependencies(target, observed);
+    dependencies.resume = async () => {
+      observed.resume += 1;
+      return {
+        manifest: {
+          coordination_state: {
+            status: 'running',
+            attempts: [{ status: 'acceptance_unknown' }],
+          },
+        },
+      } as any;
+    };
+    const rawRoot = mkdtempSync(join(tmpdir(), 'librarium-binding-'));
+    const binding = createProductionFrozenCanonicalExecutor(
+      { raw_root: rawRoot } as LiveValidationApproval,
+      { providers: {} } as Config,
+      dependencies,
+    );
+    const reference = await binding.prepare(target, protocol(target));
+    await expect(
+      binding.execute(target, protocol(target), reference),
+    ).resolves.toMatchObject({
+      status: 'terminal',
+      lifecycle: 'failed',
+    });
+    await expect(
+      binding.reconcile(target, protocol(target), reference),
+    ).resolves.toMatchObject({
+      status: 'terminal',
+      lifecycle: 'failed',
+    });
+  });
 });
 
 describe('production paid matrix and candidate attribution', () => {

--- a/tests/research-provider-adapters.test.ts
+++ b/tests/research-provider-adapters.test.ts
@@ -7,7 +7,10 @@ import {
 } from '../src/adapters/index.js';
 import { TavilyResearchProvider } from '../src/adapters/tavily-research.js';
 import { YouResearchBackgroundProvider } from '../src/adapters/you-research-background.js';
-import type { HttpClient } from '../src/core/http-client.js';
+import {
+  type HttpClient,
+  HttpRequestTimeoutError,
+} from '../src/core/http-client.js';
 import { adapterProfileBinding } from '../src/core/profile-bindings.js';
 import { buildProviderCatalog } from '../src/core/profile-catalog.js';
 
@@ -274,6 +277,64 @@ describe('durable research provider adapters', () => {
       taskId: 'agent_run_preserved',
       status: 'failed',
       providerStatus: 'invalid_response',
+    });
+  });
+
+  it.each([
+    ['authentication', 401, 'authentication'],
+    ['forbidden', 403, 'authentication'],
+    ['invalid request', 422, 'invalid_request'],
+    ['rate limit', 429, 'rate_limit'],
+    ['server error', 503, 'provider'],
+  ] as const)(
+    'classifies Exa create HTTP %s as a bounded unsafe-to-retry diagnostic',
+    async (_label, status, kind) => {
+      const provider = new ExaResearchProvider({
+        credentials: { env: { EXA_API_KEY: 'test-key' } },
+        httpClient: async () =>
+          response(
+            { error: { message: 'Bearer secret-token' } },
+            status,
+          ) as never,
+      });
+      const submission = provider.submit('query', { timeout: 10 });
+      await expect(submission).rejects.toMatchObject({
+        name: 'UnsafeToRetrySubmissionError',
+        message:
+          'Exa Agent submission failed before a valid handle was returned.',
+        failureDiagnostic: { kind, httpStatus: status },
+      });
+      await expect(submission).rejects.not.toThrow(/secret|token|Bearer/i);
+    },
+  );
+
+  it('classifies a missing Exa key as authentication before any POST', async () => {
+    const httpClient = vi.fn(async () => response(exaRun()));
+    const provider = new ExaResearchProvider({
+      credentials: { env: {} },
+      httpClient,
+    });
+    await expect(
+      provider.submit('query', { timeout: 10 }),
+    ).rejects.toMatchObject({
+      name: 'UnsafeToRetrySubmissionError',
+      failureDiagnostic: { kind: 'authentication' },
+    });
+    expect(httpClient).not.toHaveBeenCalled();
+  });
+
+  it('classifies an Exa create timeout as maybe-accepted, not a proven rejection', async () => {
+    const provider = new ExaResearchProvider({
+      credentials: { env: { EXA_API_KEY: 'test-key' } },
+      httpClient: async () => {
+        throw new HttpRequestTimeoutError(30_000);
+      },
+    });
+    await expect(
+      provider.submit('query', { timeout: 10 }),
+    ).rejects.toMatchObject({
+      name: 'UnsafeToRetrySubmissionError',
+      failureDiagnostic: { kind: 'timeout' },
     });
   });
 


### PR DESCRIPTION
## Summary

Exa Agent create failures that never returned a run id were stored as `acceptance_unknown` with no durable handle. Live validation then treated that as pollable custody and looped. This PR keeps proven rejections (4xx, missing key) as terminal no-retry failures, and stops the live harness when unknown acceptance has no handle.

PlanMode #2776 / #2545. Does not retry the RC8 Exa attempt.

## Changes

- Exa create now attaches a bounded `failureDiagnostic` (kind + HTTP status, no body/secrets).
- The attempt bridge finishes proven 4xx/auth rejections instead of recording unknown custody; timeout/5xx/post-POST network drops stay `acceptance_unknown`.
- Live validation classifies `acceptance_unknown` without a `durable_handle` as a terminal failure, not a reconcile loop.

## Testing

- [x] Added / updated unit tests (`npm test`)
- [ ] Tested manually against a real provider
- [ ] No behavior change (docs, types, refactor only)

Focused: `tests/research-provider-adapters.test.ts`, `tests/execution-runtime.test.ts`, `tests/node-live-validation-production.test.ts` — 106 passed. Biome check on the six touched files passed.

Live diagnosis (GET list only, no new Agent create): account had no run near the RC8 21:38Z submit. The orb `EXA_API_KEY` was the literal `keychain:EXA_API_KEY`, which would fail in ~130ms before a usable body.

## Checklist

- [x] Focused unit tests pass
- [x] `biome check` passes on touched files
- [ ] New providers include an adapter, a built-in descriptor, explicit group membership, and a core export
- [ ] Config changes are reflected in `src/core/config.ts` and `src/types.ts`