### PR TITLE
Add first-class Parallel Search turbo profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`parallel/turbo`**: first-class Parallel Search API turbo profile. It reuses
+  the Search endpoint with `mode` fixed to `turbo` and keeps `parallel/search`
+  unchanged (mode still optional; Parallel defaults omitted mode to
+  `advanced`). Additional result counts still make pre-dispatch USD unavailable.
+  `parallel/turbo` is a member of the curated v2 `quick` workflow; `parallel/search`
+  is not.
+
 ### Documentation
 
 - Refresh the public v2 catalog, workflow, execution, provenance, pricing,
   privacy, TypeScript/PHP boundary, MCP, and custom-provider guidance. The
-  documentation now states the 33-provider, 40-profile public roster and the
+  documentation now states the 33-provider, 41-profile public roster and the
   four built-in workflows (`quick`, `deep`, `visibility`, and `all`).
 - Replace the README demo with a deterministic, network-denied canonical
   fixture replay. The demo does not use credentials, paid calls, or mocked

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ and diagnostics go to standard error.
 
 ## V2 catalog
 
-The v2 catalog has **33 built-in providers** and **40 implemented public
+The v2 catalog has **33 built-in providers** and **41 implemented public
 profiles**. A profile is the unit of selection and provenance:
 `provider_id/profile_id`. A provider can expose more than one profile, such as
 `exa/search` and the durable `exa/research` profile. Adapter IDs are a Node
@@ -79,7 +79,7 @@ Only these four names are built in:
 
 | Workflow | Membership | Purpose |
 | --- | --- | --- |
-| `quick` | Curated: `gemini-grounded/grounded`, `openrouter/grounded`, `brave-answers/grounded`, `exa/search`, `kagi-fastgpt/grounded` | Low-latency discovery and cited answers |
+| `quick` | Curated: `gemini-grounded/grounded`, `openrouter/grounded`, `brave-answers/grounded`, `exa/search`, `kagi-fastgpt/grounded`, `parallel/turbo` | Low-latency discovery and cited answers |
 | `deep` | Derived from implemented research-report profiles | Longer research jobs, including durable and process-local profiles |
 | `visibility` | Curated: six SearchAPI-collected surfaces, then `perplexity-sonar-pro/grounded`, `gemini-grounded/grounded`, `grok/web` | Compare labelled consumer-surface observations with first-party API baselines |
 | `all` | Derived from implemented catalog capabilities | All selectable profiles that satisfy the workflow policy |
@@ -108,7 +108,7 @@ process state remains available. All other profiles are `inline/none`.
 | Kagi | `kagi-fastgpt/grounded` |
 | OpenAI | `openai-research/research` (background/durable), `openai-chat/chat` |
 | OpenRouter | `openrouter/grounded`, `openrouter/chat` |
-| Parallel | `parallel/search`, `parallel/chat`, `parallel/research` (background/durable) |
+| Parallel | `parallel/search`, `parallel/turbo`, `parallel/chat`, `parallel/research` (background/durable) |
 | Perplexity | `perplexity-search/search` (raw Search, unchanged), `perplexity-sonar-pro/grounded` (Agent low, inline), `perplexity-deep-research/research` (Agent medium, background/durable), `perplexity-sonar-deep/research` (Agent high, background/durable) |
 | SearchAPI | `searchapi/search`, `searchapi-chatgpt/surface`, `searchapi-gemini/surface`, `searchapi-perplexity/surface`, `searchapi-google-ai-mode/surface`, `searchapi-bing-copilot/surface`, `searchapi-google-ai-overview/surface` |
 | SerpAPI | `serpapi/search` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 # Librarium -- Multi-Provider Deep Research
 
 Run research queries through Librarium’s v2 public provider/profile catalog.
-There are 33 built-in providers and 40 implemented profiles. Preserve the
+There are 33 built-in providers and 41 implemented profiles. Preserve the
 profile and collection provenance when reporting results; do not turn source
 counts or agreement into a confidence claim.
 

--- a/benchmark/fixtures/v1/runs/live-group/parallel-turbo.meta.json
+++ b/benchmark/fixtures/v1/runs/live-group/parallel-turbo.meta.json
@@ -1,0 +1,19 @@
+{
+  "provider": "parallel-turbo",
+  "tier": "raw-search",
+  "durationMs": 220,
+  "citationCount": 1,
+  "metering": {
+    "kind": "request_priced",
+    "pricingVersion": "2026-06",
+    "estimate": { "estimatedCostUsd": 0.001, "costConfidence": "estimated" }
+  },
+  "citations": [
+    {
+      "url": "https://nodejs.org/en/download/archive/v26.5.0",
+      "title": "Node.js v26.5.0",
+      "snippet": "Node.js v26.5.0 is the current release.",
+      "provider": "parallel-turbo"
+    }
+  ]
+}

--- a/benchmark/fixtures/v1/runs/live-group/run.json
+++ b/benchmark/fixtures/v1/runs/live-group/run.json
@@ -76,9 +76,24 @@
         "pricingVersion": "2026-06",
         "estimate": { "estimatedCostUsd": 0.015, "costConfidence": "estimated" }
       }
+    },
+    {
+      "id": "parallel-turbo",
+      "tier": "raw-search",
+      "status": "success",
+      "durationMs": 220,
+      "wordCount": 16,
+      "citationCount": 1,
+      "outputFile": "shared.md",
+      "metaFile": "parallel-turbo.meta.json",
+      "metering": {
+        "kind": "request_priced",
+        "pricingVersion": "2026-06",
+        "estimate": { "estimatedCostUsd": 0.001, "costConfidence": "estimated" }
+      }
     }
   ],
-  "sources": { "total": 5, "unique": 1, "file": "sources.json" },
+  "sources": { "total": 6, "unique": 1, "file": "sources.json" },
   "asyncTasks": [],
   "exitCode": 0
 }

--- a/benchmark/fixtures/v1/runs/live-group/sources.json
+++ b/benchmark/fixtures/v1/runs/live-group/sources.json
@@ -8,8 +8,9 @@
       "openrouter-online",
       "brave-answers",
       "exa",
-      "kagi-fastgpt"
+      "kagi-fastgpt",
+      "parallel-turbo"
     ],
-    "citationCount": 5
+    "citationCount": 6
   }
 ]

--- a/benchmark/fixtures/v1/runs/stable-group/parallel-turbo.meta.json
+++ b/benchmark/fixtures/v1/runs/stable-group/parallel-turbo.meta.json
@@ -1,0 +1,19 @@
+{
+  "provider": "parallel-turbo",
+  "tier": "raw-search",
+  "durationMs": 210,
+  "citationCount": 1,
+  "metering": {
+    "kind": "request_priced",
+    "pricingVersion": "2026-06",
+    "estimate": { "estimatedCostUsd": 0.001, "costConfidence": "estimated" }
+  },
+  "citations": [
+    {
+      "url": "https://www.australia.gov.au/about-australia/facts-and-figures",
+      "title": "Facts and figures",
+      "snippet": "Canberra is the national capital.",
+      "provider": "parallel-turbo"
+    }
+  ]
+}

--- a/benchmark/fixtures/v1/runs/stable-group/run.json
+++ b/benchmark/fixtures/v1/runs/stable-group/run.json
@@ -88,9 +88,30 @@
           "costConfidence": "estimated"
         }
       }
+    },
+    {
+      "id": "parallel-turbo",
+      "tier": "raw-search",
+      "status": "success",
+      "durationMs": 210,
+      "wordCount": 18,
+      "citationCount": 1,
+      "outputFile": "shared.md",
+      "metaFile": "parallel-turbo.meta.json",
+      "metering": {
+        "kind": "request_priced",
+        "pricingVersion": "2026-06",
+        "estimate": {
+          "estimatedCostUsd": 0.001,
+          "billableUnits": 1,
+          "unit": "request",
+          "pricingVersion": "2026-06",
+          "costConfidence": "estimated"
+        }
+      }
     }
   ],
-  "sources": { "total": 5, "unique": 1, "file": "sources.json" },
+  "sources": { "total": 6, "unique": 1, "file": "sources.json" },
   "asyncTasks": [],
   "exitCode": 0
 }

--- a/benchmark/fixtures/v1/runs/stable-group/sources.json
+++ b/benchmark/fixtures/v1/runs/stable-group/sources.json
@@ -8,8 +8,9 @@
       "openrouter-online",
       "brave-answers",
       "exa",
-      "kagi-fastgpt"
+      "kagi-fastgpt",
+      "parallel-turbo"
     ],
-    "citationCount": 5
+    "citationCount": 6
   }
 ]

--- a/benchmark/targets.json
+++ b/benchmark/targets.json
@@ -23,6 +23,13 @@
       "costConfidence": "unknown"
     },
     {
+      "id": "parallel-turbo",
+      "tier": "raw-search",
+      "envVar": "PARALLEL_API_KEY",
+      "estimatedCostUsd": null,
+      "costConfidence": "unknown"
+    },
+    {
       "id": "perplexity-sonar-deep",
       "tier": "deep-research",
       "envVar": "PERPLEXITY_API_KEY",
@@ -290,10 +297,12 @@
       "openrouter-online",
       "brave-answers",
       "exa",
-      "kagi-fastgpt"
+      "kagi-fastgpt",
+      "parallel-turbo"
     ],
     "raw": [
       "parallel-search",
+      "parallel-turbo",
       "perplexity-search",
       "brave-search",
       "jina-search",
@@ -314,6 +323,7 @@
       "jina-search",
       "brave-search",
       "firecrawl-search",
+      "parallel-turbo",
       "tavily"
     ],
     "visibility": [
@@ -387,7 +397,8 @@
       "searchapi-bing-copilot",
       "searchapi-google-ai-overview",
       "parallel-chat",
-      "parallel-search"
+      "parallel-search",
+      "parallel-turbo"
     ]
   },
   "candidateGroups": {

--- a/src/adapters/parallel-options.ts
+++ b/src/adapters/parallel-options.ts
@@ -72,7 +72,7 @@ const fetchPolicy = z
   })
   .strict();
 
-export const ParallelSearchOptionsSchema = z
+const ParallelSearchControlsSchema = z
   .object({
     objective: z.string().trim().min(1).max(20_000).optional(),
     searchQueries: z
@@ -80,7 +80,6 @@ export const ParallelSearchOptionsSchema = z
       .min(1)
       .max(10)
       .optional(),
-    mode: z.enum(['turbo', 'fast', 'basic', 'advanced']).optional(),
     maxCharsTotal: z.number().int().positive().optional(),
     maxCharsPerResult: z.number().int().positive().optional(),
     maxResults: z.number().int().positive().optional(),
@@ -89,6 +88,13 @@ export const ParallelSearchOptionsSchema = z
     fetchPolicy: fetchPolicy.optional(),
   })
   .strict();
+
+export const ParallelSearchOptionsSchema = ParallelSearchControlsSchema.extend({
+  mode: z.enum(['turbo', 'fast', 'basic', 'advanced']).optional(),
+}).strict();
+
+/** Turbo locks Search API `mode` to `turbo`; callers cannot override it. */
+export const ParallelTurboOptionsSchema = ParallelSearchControlsSchema;
 
 export const ParallelChatOptionsSchema = z
   .object({
@@ -126,6 +132,7 @@ export const ParallelResearchOptionsSchema = z
   });
 
 export type ParallelSearchOptions = z.infer<typeof ParallelSearchOptionsSchema>;
+export type ParallelTurboOptions = z.infer<typeof ParallelTurboOptionsSchema>;
 export type ParallelChatOptions = z.infer<typeof ParallelChatOptionsSchema>;
 export type ParallelResearchOptions = z.infer<
   typeof ParallelResearchOptionsSchema

--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -22,6 +22,8 @@ import {
   ParallelResearchOptionsSchema,
   type ParallelSearchOptions,
   ParallelSearchOptionsSchema,
+  type ParallelTurboOptions,
+  ParallelTurboOptionsSchema,
 } from './parallel-options.js';
 
 const API = 'https://api.parallel.ai';
@@ -278,22 +280,29 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 export class ParallelSearchProvider extends BaseProvider {
-  readonly id = 'parallel-search';
+  readonly id: string;
   readonly tier: ProviderTier = 'raw-search';
   constructor(
     private readonly configuredOptions: unknown = {},
     base: BaseProviderOptions = {},
+    private readonly searchIdentity: {
+      readonly id?: string;
+      readonly forcedMode?: 'turbo';
+    } = {},
   ) {
     super(base);
+    this.id = searchIdentity.id ?? 'parallel-search';
   }
   async execute(
     query: string,
     options: ProviderOptions,
   ): Promise<ProviderResult> {
     const start = performance.now();
-    const parsed = ParallelSearchOptionsSchema.safeParse(
-      this.configuredOptions,
-    );
+    const schema =
+      this.searchIdentity.forcedMode === 'turbo'
+        ? ParallelTurboOptionsSchema
+        : ParallelSearchOptionsSchema;
+    const parsed = schema.safeParse(this.configuredOptions);
     if (!parsed.success) return this.errorResult(start, parsed.error.message);
     try {
       const response = await this.request<{
@@ -370,7 +379,10 @@ export class ParallelSearchProvider extends BaseProvider {
       );
     }
   }
-  private body(query: string, value: ParallelSearchOptions) {
+  private body(
+    query: string,
+    value: ParallelSearchOptions | ParallelTurboOptions,
+  ) {
     const policy = sourcePolicy(value.sourcePolicy ?? {});
     const advanced = {
       ...(policy && { source_policy: policy }),
@@ -393,10 +405,13 @@ export class ParallelSearchProvider extends BaseProvider {
       ...(value.location && { location: value.location }),
       ...(value.maxResults !== undefined && { max_results: value.maxResults }),
     };
+    const mode =
+      this.searchIdentity.forcedMode ??
+      ('mode' in value ? value.mode : undefined);
     return {
       objective: value.objective ?? query,
       search_queries: value.searchQueries ?? [query],
-      ...(value.mode && { mode: value.mode }),
+      ...(mode && { mode }),
       ...(value.maxCharsTotal !== undefined && {
         max_chars_total: value.maxCharsTotal,
       }),
@@ -416,8 +431,18 @@ export class ParallelSearchProvider extends BaseProvider {
   private errorResult(start: number, error: string) {
     return this.resultError(
       Math.round(performance.now() - start),
-      `parallel-search options: ${error}`,
+      `${this.id} options: ${error}`,
     );
+  }
+}
+
+/** Parallel Search API with `mode` fixed to `turbo`. */
+export class ParallelTurboProvider extends ParallelSearchProvider {
+  constructor(configuredOptions: unknown = {}, base: BaseProviderOptions = {}) {
+    super(configuredOptions, base, {
+      id: 'parallel-turbo',
+      forcedMode: 'turbo',
+    });
   }
 }
 

--- a/src/adapters/provider-descriptors.ts
+++ b/src/adapters/provider-descriptors.ts
@@ -14,6 +14,7 @@ import {
   parallelChatOptions,
   parallelResearchOptions,
   parallelSearchOptions,
+  parallelTurboOptions,
   tavilyResearchOptions,
   webSearchOptions,
   youResearchBackgroundOptions,
@@ -53,6 +54,7 @@ import {
   ParallelChatProvider,
   ParallelResearchProvider,
   ParallelSearchProvider,
+  ParallelTurboProvider,
 } from './parallel.js';
 import { PerplexityDeepResearchProvider } from './perplexity-deep-research.js';
 import { PerplexitySearchProvider } from './perplexity-search.js';
@@ -192,6 +194,7 @@ function searchApiZeroRetention(options: SearchApiOptions): boolean {
 function parallelOptions<
   T extends z.output<
     | typeof parallelSearchOptions
+    | typeof parallelTurboOptions
     | typeof parallelChatOptions
     | typeof parallelResearchOptions
   >,
@@ -229,6 +232,10 @@ const factories: Record<string, ProviderFactory> = {
   'parallel-search': typedFactory(
     parallelSearchOptions,
     (context) => new ParallelSearchProvider(parallelOptions(context.options)),
+  ),
+  'parallel-turbo': typedFactory(
+    parallelTurboOptions,
+    (context) => new ParallelTurboProvider(parallelOptions(context.options)),
   ),
   'perplexity-sonar-deep': () => new PerplexitySonarDeepProvider(),
   'perplexity-deep-research': (context) =>

--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -147,7 +147,7 @@ const ApprovalSchema = z
     aggregate_budget_microusd: z.string().regex(MICROUSD),
     raw_root: z.string().min(1).max(1_024),
     receipt_root: z.string().min(1).max(1_024),
-    targets: z.array(TargetProtocolSchema).min(1).max(40),
+    targets: z.array(TargetProtocolSchema).min(1).max(41),
   })
   .superRefine((approval, ctx) => {
     if (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -326,9 +326,11 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'brave-answers',
     'exa',
     'kagi-fastgpt',
+    'parallel-turbo',
   ],
   raw: [
     'parallel-search',
+    'parallel-turbo',
     'perplexity-search',
     'brave-search',
     'jina-search',
@@ -349,6 +351,7 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'jina-search',
     'brave-search',
     'firecrawl-search',
+    'parallel-turbo',
     'tavily',
   ],
   visibility: [
@@ -429,6 +432,7 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'searchapi-google-ai-overview',
     'parallel-chat',
     'parallel-search',
+    'parallel-turbo',
   ],
 };
 

--- a/src/core/builtin-workflows.ts
+++ b/src/core/builtin-workflows.ts
@@ -66,6 +66,7 @@ export const QUICK_WORKFLOW_ROSTER: readonly WorkflowRosterMember[] = [
   { provider_id: 'brave-answers', profile_id: 'grounded' },
   { provider_id: 'exa', profile_id: 'search' },
   { provider_id: 'kagi-fastgpt', profile_id: 'grounded' },
+  { provider_id: 'parallel', profile_id: 'turbo' },
 ];
 
 /**

--- a/src/core/pricing-snapshot.ts
+++ b/src/core/pricing-snapshot.ts
@@ -122,6 +122,14 @@ const DEFINITIONS: readonly PriceDefinitionInput[] = [
     'official:docs.parallel.ai/getting-started/pricing',
     { requests: '1' },
   ),
+  unavailable(
+    'parallel',
+    'turbo',
+    ['requests', 'results'],
+    'Additional-result count changes the turbo Search price.',
+    'official:docs.parallel.ai/getting-started/pricing',
+    { requests: '1' },
+  ),
 
   // Perplexity
   unavailable(
@@ -438,6 +446,6 @@ export const BUILTIN_PRICING_SNAPSHOT: PricingSnapshotInput =
     reviewed_at: REVIEWED_AT,
     currency: 'USD',
     fingerprint:
-      'sha256:62ede14e769f22b86c9f50c98ba7c343dd988042176be4e8347fd02d30df8810',
+      'sha256:e7654b40db5af22a56e71112ba97882eaf392b9f42e48e29a920a28706ad59b5',
     definitions: DEFINITIONS,
   });

--- a/src/core/profile-bindings.ts
+++ b/src/core/profile-bindings.ts
@@ -473,6 +473,11 @@ export const BUILTIN_PROFILE_BINDING_SPECS: readonly BindingSpec[] = [
     adapter_id: 'parallel-search',
   },
   {
+    provider_id: 'parallel',
+    profile_id: 'turbo',
+    adapter_id: 'parallel-turbo',
+  },
+  {
     provider_id: 'perplexity-sonar-deep',
     profile_id: 'research',
     adapter_id: 'perplexity-sonar-deep',

--- a/src/core/provider-descriptor.ts
+++ b/src/core/provider-descriptor.ts
@@ -8,6 +8,7 @@ import {
   ParallelChatOptionsSchema,
   ParallelResearchOptionsSchema,
   ParallelSearchOptionsSchema,
+  ParallelTurboOptionsSchema,
 } from '../adapters/parallel-options.js';
 import { PerplexitySearchOptionsSchema } from '../adapters/perplexity-search-options.js';
 import {
@@ -156,6 +157,9 @@ export const firecrawlSearchOptions = commonOptions
   );
 export const parallelSearchOptions = commonOptions.merge(
   ParallelSearchOptionsSchema,
+);
+export const parallelTurboOptions = commonOptions.merge(
+  ParallelTurboOptionsSchema,
 );
 export const parallelChatOptions = commonOptions.merge(
   ParallelChatOptionsSchema,
@@ -420,6 +424,25 @@ export const BUILTIN_PROVIDER_DEFINITIONS = [
       bestFor: 'First-party ranked web evidence without answer synthesis.',
       setupUrl: 'https://docs.parallel.ai/search/search-quickstart',
       order: 295,
+    },
+    metering: { kind: 'api_unit_priced', unit: 'request' },
+    capabilities: inline('always'),
+    autoEnable: false,
+  }),
+  define({
+    id: 'parallel-turbo',
+    registrationOrder: 24.6,
+    tier: 'raw-search',
+    envVar: 'PARALLEL_API_KEY',
+    optionsSchema: parallelTurboOptions,
+    display: {
+      family: 'Parallel',
+      name: 'Parallel Turbo',
+      description:
+        'Parallel Search API turbo mode for lowest-latency ranked excerpts.',
+      bestFor: 'High-volume grounding where latency and cost matter most.',
+      setupUrl: 'https://docs.parallel.ai/search/modes',
+      order: 296,
     },
     metering: { kind: 'api_unit_priced', unit: 'request' },
     capabilities: inline('always'),

--- a/src/core/provider-profiles.ts
+++ b/src/core/provider-profiles.ts
@@ -1164,7 +1164,8 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
     display: {
       family: 'Parallel',
       name: 'Parallel',
-      description: 'Parallel search, chat, and research APIs for agents.',
+      description:
+        'Parallel search, turbo, chat, and research APIs for agents.',
       best_for: 'First-party Parallel retrieval and task execution.',
       setup_url: 'https://docs.parallel.ai/',
     },
@@ -1183,6 +1184,17 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
         retrieval_method: 'search_endpoint',
         operator_id: 'parallel',
         status: 'implemented',
+      }),
+      declare({
+        profile_id: 'turbo',
+        selection_order: 375,
+        target: NOT_APPLICABLE_TARGET,
+        result_kind: 'search_results',
+        corpora: ['web'],
+        retrieval_method: 'search_endpoint',
+        operator_id: 'parallel',
+        status: 'implemented',
+        workflows: ['quick'],
       }),
       declare({
         profile_id: 'chat',

--- a/src/node-live-validation-binding.ts
+++ b/src/node-live-validation-binding.ts
@@ -412,7 +412,7 @@ function verifyRcInstalledMatrix(value: unknown): void {
     'RC installed-package matrix',
   );
   if (
-    matrix.target_count !== 40 ||
+    matrix.target_count !== 41 ||
     typeof matrix.catalog_digest !== 'string' ||
     !/^fnv1a64\.1:[0-9a-f]{16}$/.test(matrix.catalog_digest) ||
     typeof matrix.pricing_snapshot_fingerprint !== 'string' ||
@@ -420,7 +420,7 @@ function verifyRcInstalledMatrix(value: unknown): void {
     typeof matrix.matrix_fingerprint !== 'string' ||
     !/^sha256:[0-9a-f]{64}$/.test(matrix.matrix_fingerprint) ||
     !Array.isArray(matrix.targets) ||
-    matrix.targets.length !== 40
+    matrix.targets.length !== 41
   ) {
     throw new CanonicalLiveValidationError(
       'RC installed-package matrix identity is invalid.',
@@ -470,7 +470,7 @@ function verifyRcInstalledMatrix(value: unknown): void {
     return target.key;
   });
   if (
-    new Set(keys).size !== 40 ||
+    new Set(keys).size !== 41 ||
     JSON.stringify(keys) !== JSON.stringify([...keys].sort(rcCompareText)) ||
     sha256Bytes(
       rcCanonicalJson({

--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -147,12 +147,12 @@ export function productionValidationMatrix(config: Config) {
     (target) => `${target.key}:${target.binding_id}:${target.adapter_id}`,
   );
   if (
-    matrix.targets.length !== 40 ||
-    new Set(actualInventory).size !== 40 ||
+    matrix.targets.length !== 41 ||
+    new Set(actualInventory).size !== 41 ||
     JSON.stringify(actualInventory) !== JSON.stringify(expectedInventory)
   ) {
     throw new CanonicalLiveValidationError(
-      'Production paid validation requires the exact 40-target canonical binding inventory.',
+      'Production paid validation requires the exact 41-target canonical binding inventory.',
     );
   }
   return matrix;

--- a/src/node-release-candidate.ts
+++ b/src/node-release-candidate.ts
@@ -83,7 +83,7 @@ export interface ReleaseMatrixTarget {
 }
 
 export interface ReleaseMatrixIdentity {
-  readonly target_count: 40;
+  readonly target_count: 41;
   readonly catalog_digest: string;
   readonly pricing_snapshot_fingerprint: string;
   readonly matrix_fingerprint: string;
@@ -795,11 +795,11 @@ function matrixIdentity(value: unknown): ReleaseMatrixIdentity {
   });
   const keys = targets.map((target) => target.key);
   if (
-    targets.length !== 40 ||
-    new Set(keys).size !== 40 ||
+    targets.length !== 41 ||
+    new Set(keys).size !== 41 ||
     canonicalJson(keys) !== canonicalJson([...keys].sort(compareText))
   ) {
-    fail('Release candidate requires the exact sorted 40-profile matrix.');
+    fail('Release candidate requires the exact sorted 41-profile matrix.');
   }
   const catalog = catalogDigest(
     matrix.catalog_digest,
@@ -833,10 +833,10 @@ function matrixIdentity(value: unknown): ReleaseMatrixIdentity {
       }),
     )
   ) {
-    fail('Canonical matrix fingerprint does not match its exact 40 targets.');
+    fail('Canonical matrix fingerprint does not match its exact 41 targets.');
   }
   return {
-    target_count: 40,
+    target_count: 41,
     catalog_digest: catalog,
     pricing_snapshot_fingerprint: pricing,
     matrix_fingerprint: fingerprint,
@@ -857,8 +857,8 @@ function parseMatrixIdentity(value: unknown): ReleaseMatrixIdentity {
     ],
     'Frozen installed-package identity',
   );
-  if (identity.target_count !== 40 || !Array.isArray(identity.targets)) {
-    fail('Frozen installed-package identity must contain exactly 40 targets.');
+  if (identity.target_count !== 41 || !Array.isArray(identity.targets)) {
+    fail('Frozen installed-package identity must contain exactly 41 targets.');
   }
   const targets = identity.targets.map((targetValue, index) => {
     const target = jsonRecord(
@@ -920,8 +920,8 @@ function parseMatrixIdentity(value: unknown): ReleaseMatrixIdentity {
   });
   const keys = targets.map((target) => target.key);
   if (
-    targets.length !== 40 ||
-    new Set(keys).size !== 40 ||
+    targets.length !== 41 ||
+    new Set(keys).size !== 41 ||
     canonicalJson(keys) !== canonicalJson([...keys].sort(compareText))
   ) {
     fail('Frozen installed-package targets must be unique and sorted.');
@@ -958,10 +958,10 @@ function parseMatrixIdentity(value: unknown): ReleaseMatrixIdentity {
       }),
     )
   ) {
-    fail('Frozen matrix fingerprint does not match its exact 40 targets.');
+    fail('Frozen matrix fingerprint does not match its exact 41 targets.');
   }
   return {
-    target_count: 40,
+    target_count: 41,
     catalog_digest: catalog,
     pricing_snapshot_fingerprint: pricing,
     matrix_fingerprint: fingerprint,

--- a/tests/adapters/parallel.test.ts
+++ b/tests/adapters/parallel.test.ts
@@ -3,6 +3,7 @@ import {
   ParallelChatProvider,
   ParallelResearchProvider,
   ParallelSearchProvider,
+  ParallelTurboProvider,
 } from '../../src/adapters/parallel.js';
 import type {
   HttpClient,
@@ -84,6 +85,34 @@ describe('Parallel first-party providers', () => {
         max_results: 2,
       },
     });
+  });
+
+  it('locks turbo to Search API mode turbo and rejects a mode override', async () => {
+    const http = client({
+      results: [{ url: 'https://example.test/turbo', title: 'Turbo' }],
+    });
+    const result = await new ParallelTurboProvider(
+      { maxResults: 1 },
+      { apiKey: key, httpClient: http },
+    ).execute('turbo query', { timeout: 9 });
+
+    expect(result.provider).toBe('parallel-turbo');
+    expect(result.error).toBeUndefined();
+    const [, request] = (http as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, HttpRequestOptions];
+    expect(request.body).toMatchObject({
+      objective: 'turbo query',
+      search_queries: ['turbo query'],
+      mode: 'turbo',
+      advanced_settings: { max_results: 1 },
+    });
+
+    const rejected = await new ParallelTurboProvider(
+      { mode: 'advanced' },
+      { apiKey: key, httpClient: http },
+    ).execute('turbo query', { timeout: 9 });
+    expect(rejected.error).toContain('parallel-turbo options');
+    expect(http).toHaveBeenCalledOnce();
   });
 
   it('rejects invalid search controls before dispatch', async () => {

--- a/tests/benchmark.test.ts
+++ b/tests/benchmark.test.ts
@@ -91,7 +91,7 @@ describe('benchmark corpus and target catalog', () => {
     const targets = allTargets(catalog);
     expect(
       targets.filter((target) => target.type === 'individual-provider'),
-    ).toHaveLength(37);
+    ).toHaveLength(38);
     expect(
       targets.filter((target) => target.type === 'built-in-group'),
     ).toHaveLength(8);

--- a/tests/builtin-workflows.test.ts
+++ b/tests/builtin-workflows.test.ts
@@ -48,6 +48,7 @@ describe('built-in workflows -- reserved names', () => {
       'brave-answers/grounded',
       'exa/search',
       'kagi-fastgpt/grounded',
+      'parallel/turbo',
     ]);
     expect(
       VISIBILITY_WORKFLOW_ROSTER.map((m) => `${m.provider_id}/${m.profile_id}`),

--- a/tests/default-groups.test.ts
+++ b/tests/default-groups.test.ts
@@ -108,7 +108,7 @@ describe('default groups -- visibility expansion', () => {
 
   it('has eight default groups and all 33 grounded providers', () => {
     expect(Object.keys(DEFAULT_GROUPS)).toHaveLength(8);
-    expect(DEFAULT_GROUPS.all).toHaveLength(33);
+    expect(DEFAULT_GROUPS.all).toHaveLength(34);
   });
 });
 

--- a/tests/fixtures/provider-conformance.ts
+++ b/tests/fixtures/provider-conformance.ts
@@ -145,6 +145,10 @@ export const PROVIDER_CONFORMANCE_EVIDENCE: Readonly<
     evidence: ['tests/adapters/parallel.test.ts'],
     lanes: [...base, 'options'],
   },
+  'parallel/turbo': {
+    evidence: ['tests/adapters/parallel.test.ts'],
+    lanes: [...base, 'options'],
+  },
   'valyu/search': {
     evidence: ['tests/adapters/valyu.test.ts'],
     lanes: [...base, 'options'],

--- a/tests/init-provider-choices.test.ts
+++ b/tests/init-provider-choices.test.ts
@@ -26,6 +26,7 @@ const PARALLEL_OPT_IN_PROVIDERS = [
   'parallel-research',
   'parallel-chat',
   'parallel-search',
+  'parallel-turbo',
 ] as const;
 
 describe('isLlmTierProvider', () => {

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -453,11 +453,11 @@ describe('production live-validation binding (injected, offline)', () => {
 });
 
 describe('production paid matrix and candidate attribution', () => {
-  it('requires the exact canonical 40-target binding inventory', () => {
+  it('requires the exact canonical 41-target binding inventory', () => {
     const matrix = productionValidationMatrix(
       loadConfig(join(tmpdir(), 'librarium-missing-matrix-config.json')),
     );
-    expect(matrix.targets).toHaveLength(40);
+    expect(matrix.targets).toHaveLength(41);
     expect(matrix.targets.map((target) => target.key)).toStrictEqual(
       buildCanonicalValidationMatrix().targets.map((target) => target.key),
     );

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -81,10 +81,10 @@ afterEach(() => {
 });
 
 describe('canonical v3 live validation matrix', () => {
-  it('derives the exact implemented 40-profile matrix, including durable private adapters', () => {
+  it('derives the exact implemented 41-profile matrix, including durable private adapters', () => {
     const matrix = buildCanonicalValidationMatrix();
     expect(matrix.targets.length).toBeGreaterThan(0);
-    expect(matrix.targets.length).toBeLessThanOrEqual(40);
+    expect(matrix.targets.length).toBeLessThanOrEqual(41);
     expect(matrix.targets.map((target) => target.key)).toContain(
       'exa/research',
     );
@@ -100,10 +100,10 @@ describe('canonical v3 live validation matrix', () => {
       adapter_id: 'exa-research',
       credential_family: 'EXA_API_KEY',
     });
-    expect(new Set(matrix.targets.map((target) => target.key)).size).toBe(40);
+    expect(new Set(matrix.targets.map((target) => target.key)).size).toBe(41);
     expect(
       new Set(matrix.targets.map((target) => target.adapter_id)).size,
-    ).toBe(40);
+    ).toBe(41);
   });
 
   it('admits only one exact prepared canonical profile and never a legacy selector list', () => {
@@ -206,7 +206,7 @@ describe('canonical v3 live validation matrix', () => {
     });
     expect(matrix.catalog_digest).toBe(catalog.digest);
     expect(matrix.targets.length).toBeGreaterThan(0);
-    expect(matrix.targets.length).toBeLessThanOrEqual(40);
+    expect(matrix.targets.length).toBeLessThanOrEqual(41);
     expect(
       matrix.targets.every(
         (target) => target.catalog_digest === catalog.digest,

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -102,7 +102,7 @@ describe('pricing snapshot validation', () => {
       .sort();
 
     expect(priced).toEqual(bound);
-    expect(new Set(priced).size).toBe(40);
+    expect(new Set(priced).size).toBe(41);
     expect(
       BUILTIN_PRICING_SNAPSHOT.definitions.every((entry) =>
         ['complete', 'partial', 'unavailable'].includes(entry.completeness),
@@ -327,10 +327,10 @@ describe('pricing snapshot validation', () => {
 
   it('pins and verifies the reviewed built-in fingerprint', async () => {
     expect(BUILTIN_PRICING_SNAPSHOT.fingerprint).toBe(
-      'sha256:62ede14e769f22b86c9f50c98ba7c343dd988042176be4e8347fd02d30df8810',
+      'sha256:e7654b40db5af22a56e71112ba97882eaf392b9f42e48e29a920a28706ad59b5',
     );
     expect(pricingSnapshotFingerprint(BUILTIN_PRICING_SNAPSHOT)).toBe(
-      'sha256:62ede14e769f22b86c9f50c98ba7c343dd988042176be4e8347fd02d30df8810',
+      'sha256:e7654b40db5af22a56e71112ba97882eaf392b9f42e48e29a920a28706ad59b5',
     );
     expect(
       `sha256:${createHash('sha256')

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -125,6 +125,7 @@ const IMPLEMENTED_MATRIX = [
   ['searchapi', 'search'],
   ['serpapi', 'search'],
   ['tavily', 'search'],
+  ['parallel', 'turbo'],
   ['parallel', 'search'],
   ['valyu', 'search'],
   ['searchapi-chatgpt', 'surface'],
@@ -927,6 +928,7 @@ describe('provider catalog -- built-in workflows', () => {
       'brave-answers/grounded',
       'exa/search',
       'kagi-fastgpt/grounded',
+      'parallel/turbo',
     ]);
   });
 
@@ -1040,7 +1042,7 @@ describe('provider catalog -- built-in workflows', () => {
     ]);
     // The reserved name still resolves to the built-in workflow, and the user's
     // pre-existing custom group is untouched.
-    expect(keysOf(built.resolveGroup('quick') ?? [])).toHaveLength(5);
+    expect(keysOf(built.resolveGroup('quick') ?? [])).toHaveLength(6);
     expect(keysOf(built.resolveGroup('custom:quick') ?? [])).toEqual([
       'tavily/search',
     ]);
@@ -1495,6 +1497,7 @@ describe('provider catalog -- explicit and capability selection', () => {
       'searchapi/search',
       'serpapi/search',
       'tavily/search',
+      'parallel/turbo',
       'parallel/search',
       'valyu/search',
     ]);
@@ -1516,7 +1519,7 @@ describe('provider catalog -- explicit and capability selection', () => {
     );
     expect(selected).not.toContain('serpapi/search');
     expect(selected).not.toContain('tavily/search');
-    expect(selected).toHaveLength(8);
+    expect(selected).toHaveLength(9);
   });
 
   it('never selects an unauthenticated profile by capability', () => {

--- a/tests/provider-conformance.test.ts
+++ b/tests/provider-conformance.test.ts
@@ -34,7 +34,7 @@ describe('built-in provider conformance inventory', () => {
     expect(Object.keys(PROVIDER_CONFORMANCE_EVIDENCE).sort()).toEqual(
       implemented,
     );
-    expect(implemented).toHaveLength(40);
+    expect(implemented).toHaveLength(41);
   });
 
   it('keeps every implemented profile bound to one executable strategy', () => {

--- a/tests/provider-descriptors.test.ts
+++ b/tests/provider-descriptors.test.ts
@@ -25,7 +25,7 @@ describe('built-in provider descriptors', () => {
 
   it('drives registry, catalog, credentials, aliases, and metering', async () => {
     await initializeProviders();
-    expect(BUILTIN_PROVIDER_DESCRIPTORS).toHaveLength(37);
+    expect(BUILTIN_PROVIDER_DESCRIPTORS).toHaveLength(38);
     expect(getAllProviders()).toHaveLength(BUILTIN_PROVIDER_DESCRIPTORS.length);
 
     for (const descriptor of BUILTIN_PROVIDER_DESCRIPTORS) {
@@ -100,6 +100,7 @@ describe('built-in provider descriptors', () => {
       'gemini-chat',
       'openrouter-chat',
       'parallel-search',
+      'parallel-turbo',
       'searchapi-chatgpt',
       'searchapi-gemini',
       'searchapi-perplexity',
@@ -133,6 +134,7 @@ describe('built-in provider descriptors', () => {
         'parallel-research',
         'parallel-chat',
         'parallel-search',
+        'parallel-turbo',
         'you-answer',
       ]),
     );
@@ -197,6 +199,7 @@ describe('built-in provider descriptors', () => {
       { id: 'parallel-research', isOptIn: true, enableByDefault: false },
       { id: 'parallel-chat', isOptIn: true, enableByDefault: false },
       { id: 'parallel-search', isOptIn: true, enableByDefault: false },
+      { id: 'parallel-turbo', isOptIn: true, enableByDefault: false },
     ]);
   });
 

--- a/tests/public-documentation-drift.test.ts
+++ b/tests/public-documentation-drift.test.ts
@@ -34,9 +34,9 @@ const mcpTools = [
 describe('public v2 documentation drift', () => {
   it('keeps the generated catalog facts in README aligned with source', () => {
     expect(BUILTIN_PROVIDER_CATALOG).toHaveLength(33);
-    expect(profileKeys).toHaveLength(40);
+    expect(profileKeys).toHaveLength(41);
     expect(README).toMatch(
-      /\*\*33 built-in providers\*\* and \*\*40 implemented public\s+profiles\*\*/,
+      /\*\*33 built-in providers\*\* and \*\*41 implemented public\s+profiles\*\*/,
     );
 
     for (const provider of BUILTIN_PROVIDER_CATALOG) {

--- a/tests/rc-artifacts.test.ts
+++ b/tests/rc-artifacts.test.ts
@@ -113,7 +113,7 @@ function matrix(overrides: Record<string, unknown> = {}) {
     schema_version: 1,
     catalog_digest: catalogDigest,
     pricing_snapshot_fingerprint: pricingFingerprint,
-    targets: Array.from({ length: 40 }, (_, index) => {
+    targets: Array.from({ length: 41 }, (_, index) => {
       const id = String(index).padStart(2, '0');
       return {
         key: `provider-${id}/profile`,
@@ -374,7 +374,7 @@ describe('release candidate artifact contract', () => {
     }
   });
 
-  it('accepts the real 40-profile matrix and its versioned catalog digest', () => {
+  it('accepts the real 41-profile matrix and its versioned catalog digest', () => {
     const actual = buildCanonicalValidationMatrix();
     expect(actual.catalog_digest).toMatch(/^fnv1a64\.1:[0-9a-f]{16}$/);
     expect(() => assertReleaseMatrixParity(actual, actual)).not.toThrow();
@@ -446,7 +446,7 @@ describe('release candidate artifact contract', () => {
       },
     });
     expect(commands.map((args) => args[0])).toEqual(['run', 'pack']);
-    expect(frozen.installed_package.target_count).toBe(40);
+    expect(frozen.installed_package.target_count).toBe(41);
     expect(frozen.npm.inventory).toContainEqual(
       expect.objectContaining({ path: 'dist/release-matrix.json' }),
     );
@@ -463,7 +463,7 @@ describe('release candidate artifact contract', () => {
       dependencies: fixtureDependencies,
     });
     expect(verified.candidate).toEqual(fixture.candidate.candidate);
-    expect(verified.installed_package.target_count).toBe(40);
+    expect(verified.installed_package.target_count).toBe(41);
     expect(verified.sea.rows).toHaveLength(5);
     expect(verified.live_validation.record_names).toEqual(
       RELEASE_CANDIDATE_RECORD_NAMES,

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -172,7 +172,7 @@ describe('registry', () => {
   it('initializeProviders registers all active providers', async () => {
     await initializeProviders();
     const all = getAllProviders();
-    expect(all).toHaveLength(37);
+    expect(all).toHaveLength(38);
 
     const ids = all.map((p) => p.id);
     expect(ids).toContain('perplexity-sonar-deep');
@@ -234,7 +234,7 @@ describe('registry', () => {
     ]);
     expect(
       getAllProviders().filter((provider) => provider.execution === 'inline'),
-    ).toHaveLength(31);
+    ).toHaveLength(32);
   });
 
   it('injects credentials into every background built-in', async () => {

--- a/tests/request-deadline-migration.test.ts
+++ b/tests/request-deadline-migration.test.ts
@@ -602,6 +602,7 @@ describe('v1 total request-deadline migration', () => {
       'parallel-research',
       'parallel-chat',
       'parallel-search',
+      'parallel-turbo',
       'perplexity-sonar-deep',
       'perplexity-deep-research',
       'openai-research',
@@ -643,7 +644,7 @@ describe('v1 total request-deadline migration', () => {
     expect(
       BUILTIN_PROFILE_BINDING_SPECS.map((spec) => spec.adapter_id),
     ).toEqual(expectedAdapterIds);
-    expect(new Set(expectedAdapterIds).size).toBe(40);
+    expect(new Set(expectedAdapterIds).size).toBe(41);
     const declarations = new Map(
       catalogProfileRefs(BUILTIN_PROVIDER_CATALOG).map(
         ({ entry, declaration }) => [

--- a/tests/workers/provider-catalog.test.ts
+++ b/tests/workers/provider-catalog.test.ts
@@ -34,10 +34,10 @@ describe('provider catalog in workerd', () => {
   it('builds the full catalog without Node APIs', () => {
     const catalog = workerCatalog();
     expect(catalog.entries).toHaveLength(33);
-    expect(catalog.resolved).toHaveLength(40);
-    expect(catalog.profiles).toHaveLength(40);
-    expect(catalog.workflow('all').members).toHaveLength(40);
-    expect(catalog.workflow('quick').members).toHaveLength(5);
+    expect(catalog.resolved).toHaveLength(41);
+    expect(catalog.profiles).toHaveLength(41);
+    expect(catalog.workflow('all').members).toHaveLength(41);
+    expect(catalog.workflow('quick').members).toHaveLength(6);
     expect(catalog.workflow('visibility').members).toHaveLength(9);
     expect(catalog.workflow('deep').members).toHaveLength(9);
   });


### PR DESCRIPTION
## Summary

Adds `parallel/turbo` as a first-class v2 Search profile for Parallel Search API turbo mode, and puts it on the curated `quick` workflow.

`parallel/search` is unchanged: `mode` remains optional, and Parallel still defaults an omitted mode to `advanced`. Catalog bindings are one adapter per profile, so turbo uses a dedicated `parallel-turbo` adapter that reuses the Search endpoint and locks `mode` to `turbo`.

## Changes

- New public profile `parallel/turbo` bound to adapter `parallel-turbo` / `PARALLEL_API_KEY`
- Turbo rejects a configured `mode` override before dispatch
- Curated `quick` roster is now six members, ending with `parallel/turbo`
- Public roster and live-validation/RC matrix size move from 40 to 41
- Pricing for turbo stays unavailable pre-dispatch because extra results change the $1/1k request price

## Testing

- Focused unit/catalog/docs/live-validation/RC/benchmark suites: 409 + later 175 focused tests passed
- `npx biome check` on touched source files: clean
- `npm run typecheck`: passed
- Live Parallel Search POST with `mode: turbo`: HTTP 200, 3 results, `search_id` present
- Live Brave Search GET after orb restart: current `BRAVE_API_KEY` HTTP 200; leftover disk `BRAVE_SEARCH_API_KEY` still 422 `SUBSCRIPTION_TOKEN_INVALID`

## Notes

PlanMode #2915 #2916. Does not lock RC9 or run the paid certification matrix.