### PR TITLE
chore: lock v2 rc9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.8",
+  "version": "2.0.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0-rc.9",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.8",
+  "version": "2.0.0-rc.9",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Lock Librarium 2.0.0-rc.9 from protected `main` after merging the Exa submit-classification fix and first-class `parallel/turbo` profile.

## Changes

- Bump the package version from `2.0.0-rc.8` to `2.0.0-rc.9` in the three canonical package fields.
- Preserve the exact 41-profile catalog, pricing snapshot, contract artifacts, and release matrix.

## Testing

- [x] Full unit suite: 2,159 passed, 7 skipped
- [x] Typecheck, lint, build, declarations, Worker, integration, packed consumer, PTY, and Linux SEA passed
- [x] Live-validation fixture (93 tests), offline benchmark replay (4 cases), and workflow policy passed
- [x] `rc:package` and `rc:verify-package` passed from the clean commit

## Candidate Evidence

- Source commit: `290f6ccfa853a1fca7b56456f12e4026f8319a44`
- Matrix: 41 profiles
- Matrix fingerprint: `sha256:f5c4671bf681089dd853457e96fb81abe487acf0a44950512a2b1d361ead18ec`
- Tarball SHA-256: `sha256:4fd560da94ffa0868e352d70ab97aaa23306cf71b11823fcc270cac80b7e5a43`
- Package files: 258
- Declarations: 242

PlanMode #2921.

No package was published, tagged, or released. No provider calls were made by this version-lock change.