### PR TITLE
Preserve frozen pricing units in live receipts

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -1301,6 +1301,7 @@ function writeFrozenEvidence(
     gate.approval.receipt_root,
     `${target.key.replace('/', '-')}.json`,
     built.receipt,
+    target,
   );
   return built.quality.passed === true
     ? { passed: true }

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -718,6 +718,7 @@ export function writeSanitizedCanonicalReceipt(
   root: string,
   name: string,
   receipt: Record<string, unknown>,
+  target?: CanonicalValidationTarget,
 ): void {
   const path = validationPath(root, name);
   const allowed = new Set([
@@ -750,8 +751,22 @@ export function writeSanitizedCanonicalReceipt(
       'Public receipt contains a non-allowlisted field.',
     );
   }
+  if (
+    target &&
+    (receipt.profile !== target.key ||
+      receipt.catalog_digest !== target.catalog_digest ||
+      receipt.pricing_snapshot_fingerprint !==
+        target.pricing_snapshot_fingerprint)
+  ) {
+    throw new CanonicalLiveValidationError(
+      'Public receipt target authority does not match its frozen profile.',
+    );
+  }
   // Re-serialize through the allowlist boundary before making evidence public.
-  assertSafeReceiptValue(receipt);
+  const frozenPricingUnits = new Set(
+    target ? quoteCanonicalValidationTarget(target).quote.missing_units : [],
+  );
+  assertSafeReceiptValue(receipt, 'receipt', frozenPricingUnits);
   safeWriteFile(path, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
 }
 

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -572,14 +572,58 @@ describe('canonical v3 live validation evidence boundary', () => {
       lifecycle: 'succeeded' as const,
     };
 
-    expect(
-      sanitizeCanonicalReceipt({
-        ...base,
-        pricing_quote: { missing_units: ['exa:agent_compute_units'] },
-      }),
-    ).toMatchObject({
+    const receipt = sanitizeCanonicalReceipt({
+      ...base,
       pricing_quote: { missing_units: ['exa:agent_compute_units'] },
     });
+    expect(receipt).toMatchObject({
+      pricing_quote: { missing_units: ['exa:agent_compute_units'] },
+    });
+    const receiptRoot = mkdtempSync(
+      join(tmpdir(), 'librarium-live-validation-receipt-'),
+    );
+    roots.push(receiptRoot);
+    expect(() =>
+      writeSanitizedCanonicalReceipt(
+        receiptRoot,
+        'exa-research.json',
+        receipt,
+        target,
+      ),
+    ).not.toThrow();
+    expect(
+      JSON.parse(readFileSync(join(receiptRoot, 'exa-research.json'), 'utf8')),
+    ).toEqual(receipt);
+    expect(() =>
+      writeSanitizedCanonicalReceipt(
+        receiptRoot,
+        'missing-target.json',
+        receipt,
+      ),
+    ).toThrow('prohibited material');
+    const otherTarget = buildCanonicalValidationMatrix().targets.find(
+      (candidate) => candidate.key === 'exa/search',
+    );
+    if (!otherTarget) throw new Error('missing Exa search target');
+    expect(() =>
+      writeSanitizedCanonicalReceipt(
+        receiptRoot,
+        'wrong-target.json',
+        receipt,
+        otherTarget,
+      ),
+    ).toThrow('target authority');
+    expect(() =>
+      writeSanitizedCanonicalReceipt(
+        receiptRoot,
+        'unknown-unit.json',
+        {
+          ...receipt,
+          pricing_quote: { missing_units: ['exa:unknown_unit'] },
+        },
+        target,
+      ),
+    ).toThrow('prohibited material');
 
     for (const unsafeUnit of [
       'secret:value',


### PR DESCRIPTION
## Summary

Fix the production live-validation receipt writer rejecting provider-namespaced pricing units that the sanitizer had already admitted from the exact frozen target. This was reproduced during RC9: `exa/research` completed successfully, but final evidence writing rejected its reviewed `exa:agent_compute_units` quote field.

## Changes

- Bind final receipt validation to the canonical target and its reviewed pricing snapshot.
- Require the receipt profile, catalog digest, and pricing fingerprint to match that target before using its frozen missing-unit allowlist.
- Preserve the prior fail-closed behavior when no target authority is supplied.
- Add regression coverage for the RC9 Exa unit, missing authority, mismatched target authority, and unknown namespaced units.

## Testing

- [x] Focused live-validation suite: 73 passed
- [x] Full unit suite: 2,159 passed, 7 skipped
- [x] Typecheck and Biome passed
- [x] Build and declaration fixtures passed
- [x] Worker compatibility: 29 passed
- [x] RC9 live reproduction established the failure after successful Exa durable retrieval; the regression exercises the same frozen `exa:agent_compute_units` write boundary

## Safety

The writer allows a provider-namespaced pricing unit only when it is present in the reviewed quote for the matching canonical target. It still rejects missing authority, a receipt bound to another target, unknown provider units, secrets, URLs, and filesystem paths.

PlanMode #2930. RC9 remains NO-GO and will not be resumed. No provider calls are made by this fix.