### PR TITLE
chore: lock v2 rc10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.9",
+  "version": "2.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.9",
+      "version": "2.0.0-rc.10",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.9",
+  "version": "2.0.0-rc.10",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- lock package metadata to v2.0.0-rc.10
- create a fresh immutable candidate after the live receipt pricing-unit fix

PlanMode: #2930

## Local verification
- `npm test` (2,159 passed, 7 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`