### PR TITLE
Support targeted paid validation approvals

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -550,14 +550,20 @@ export function assertLiveValidationGate(
       'Frozen paid preregistration drifted from canonical authority.',
     );
   }
-  if (
-    JSON.stringify(approval.targets.map((target) => target.key)) !==
-    JSON.stringify(matrix.targets.map((target) => target.key))
-  ) {
-    throw new CanonicalLiveValidationError(
-      'Frozen paid preregistration target order differs from canonical matrix.',
-    );
-  }
+  const canonicalTargetIndexes = new Map(
+    matrix.targets.map((target, index) => [target.key, index]),
+  );
+  let priorTargetIndex = -1;
+  const approvedTargets = approval.targets.map((protocol) => {
+    const index = canonicalTargetIndexes.get(protocol.key);
+    if (index === undefined || index <= priorTargetIndex) {
+      throw new CanonicalLiveValidationError(
+        'Frozen paid preregistration target order differs from canonical matrix.',
+      );
+    }
+    priorTargetIndex = index;
+    return matrix.targets[index]!;
+  });
   assertSeparateEvidenceRoots(approval);
   if (!candidateAuthority) {
     throw new CanonicalLiveValidationError(
@@ -612,7 +618,7 @@ export function assertLiveValidationGate(
       );
     }
   }
-  return matrix;
+  return { ...matrix, targets: approvedTargets };
 }
 
 export type FrozenExecutionOutcome =
@@ -2191,7 +2197,7 @@ export function registerLiveValidationCommand(
               artifacts: parseArtifacts(options.artifact),
             });
           })();
-        assertLiveValidationGate(
+        const approvedMatrix = assertLiveValidationGate(
           gate,
           options.confirm,
           process.env.LIBRARIUM_LIVE_VALIDATION_APPROVED,
@@ -2206,7 +2212,7 @@ export function registerLiveValidationCommand(
           continueFrozenValidationProtocol(
             new CanonicalValidationCheckpointRepository(gate.approval.raw_root),
             gate,
-            matrix,
+            approvedMatrix,
             options.confirm ?? '',
             candidateAuthority,
           );
@@ -2220,14 +2226,14 @@ export function registerLiveValidationCommand(
         try {
           const state = await executeFrozenValidationProtocol({
             gate,
-            matrix,
+            matrix: approvedMatrix,
             executor,
             candidate_authority: candidateAuthority,
             signal: controller.signal,
           });
           const certification = terminalValidationCertification(
             state,
-            matrix.targets.length,
+            approvedMatrix.targets.length,
           );
           if (certification) {
             process.stdout.write(`${JSON.stringify(certification, null, 2)}\n`);

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -1678,6 +1678,94 @@ describe('frozen paid protocol (injected, zero-network)', () => {
     ).toThrow('matching full preregistration');
   });
 
+  it('executes only the canonical targets included in a paid subset', async () => {
+    const { gate: frozen, matrix, candidateAuthority } = gate();
+    const index = matrix.targets.findIndex(
+      (target) => target.key === 'brave-search/search',
+    );
+    const protocol = frozen.approval.targets[index];
+    if (index < 0 || !protocol)
+      throw new Error('missing targeted fixture profile');
+    const approval = {
+      ...frozen.approval,
+      aggregate_budget_microusd:
+        protocol.pricing.reserved_microusd ??
+        protocol.pricing.approved_maximum_microusd ??
+        '0',
+      targets: [protocol],
+    };
+    const targeted = {
+      approval,
+      fingerprint: approvalFingerprint(approval),
+    };
+
+    const approvedMatrix = assertLiveValidationGate(
+      targeted,
+      targeted.fingerprint,
+      targeted.fingerprint,
+      candidateAuthority,
+    );
+    expect(approvedMatrix.targets.map((target) => target.key)).toStrictEqual([
+      'brave-search/search',
+    ]);
+    const rawManifest = await canonicalManifest(
+      approvedMatrix.targets[0]!,
+      targeted.approval.raw_root,
+      'request-targeted',
+    );
+    const prepared: string[] = [];
+    const state = await executeFrozenValidationProtocol({
+      gate: targeted,
+      matrix: approvedMatrix,
+      candidate_authority: candidateAuthority,
+      reference_manifest_authority: fixtureReferenceAuthority,
+      executor: {
+        prepare: async (target, frozenProtocol) => {
+          prepared.push(target.key);
+          return attemptReference(
+            target,
+            frozenProtocol,
+            targeted.approval.raw_root,
+            'request-targeted',
+          );
+        },
+        execute: async () => ({
+          status: 'terminal',
+          lifecycle: 'succeeded',
+          request_id: 'request-targeted',
+          raw_manifest: rawManifest,
+        }),
+        reconcile: async () => {
+          throw new Error('targeted fixture must not reconcile');
+        },
+      },
+      wait: async () => {},
+    });
+    expect(prepared).toStrictEqual(['brave-search/search']);
+    expect(state.completed).toStrictEqual(['brave-search/search']);
+  });
+
+  it('rejects a paid subset that reorders canonical targets', () => {
+    const { gate: frozen, candidateAuthority } = gate();
+    const approval = {
+      ...frozen.approval,
+      targets: [frozen.approval.targets[2]!, frozen.approval.targets[1]!],
+    };
+    const reordered = {
+      approval,
+      fingerprint: approvalFingerprint(approval),
+    };
+
+    expect(() =>
+      assertLiveValidationGate(
+        reordered,
+        reordered.fingerprint,
+        reordered.fingerprint,
+        candidateAuthority,
+      ),
+    ).toThrow('target order differs from canonical matrix');
+  });
+
   it.each([
     [
       'query',


### PR DESCRIPTION
## Summary
- allow paid approvals to authorize a non-empty canonical-order subset of the frozen matrix
- execute and certify only the approved targets while retaining full matrix/catalog/pricing pins
- reject reordered or non-canonical subsets before credential resolution

PlanMode: #2776

## Safety proof
- focused live-validation tests: 95 passed
- full unit suite: 2,161 passed, 7 skipped
- typecheck, lint, and build passed
- regression executes only the approved target and proves omitted targets never reach prepare