### PR TITLE
chore: lock v2 rc11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.10",
+  "version": "2.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.10",
+      "version": "2.0.0-rc.11",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.10",
+  "version": "2.0.0-rc.11",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- lock package metadata to v2.0.0-rc.11
- create an immutable candidate that can execute only the explicitly approved paid subset

PlanMode: #2776

## Local verification
- `npm test` (2,161 passed, 7 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`