### PR TITLE
fix(firecrawl): exclude insecure search results

### DIFF
--- a/src/adapters/firecrawl-search.ts
+++ b/src/adapters/firecrawl-search.ts
@@ -305,7 +305,7 @@ export class FirecrawlSearchProvider extends BaseProvider {
   ): NormalizedResult | undefined {
     if (!entry || typeof entry !== 'object') return undefined;
     const item = entry as FirecrawlWebResult | FirecrawlNewsResult;
-    const url = absoluteHttpUrl(item.url);
+    const url = absoluteHttpsUrl(item.url);
     if (!url) return undefined;
     const title = textValue(item.title);
     if (kind === 'web') {
@@ -444,14 +444,12 @@ function textValue(value: unknown): string | undefined {
   return normalized || undefined;
 }
 
-function absoluteHttpUrl(value: unknown): string | undefined {
+function absoluteHttpsUrl(value: unknown): string | undefined {
   const url = textValue(value);
   if (!url) return undefined;
   try {
     const parsed = new URL(url);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return undefined;
-    }
+    if (parsed.protocol !== 'https:') return undefined;
     return parsed.href;
   } catch {
     return undefined;

--- a/tests/adapters/firecrawl-search.test.ts
+++ b/tests/adapters/firecrawl-search.test.ts
@@ -198,7 +198,7 @@ describe('Firecrawl Search provider', () => {
     });
   });
 
-  it('ignores malformed results without a safe absolute HTTP(S) URL', async () => {
+  it('ignores results without a safe absolute HTTPS URL', async () => {
     globalThis.fetch = vi.fn().mockResolvedValueOnce(
       jsonResponse(200, {
         success: true,
@@ -211,6 +211,7 @@ describe('Firecrawl Search provider', () => {
             { url: 'not a URL' },
             { url: 'javascript:alert(1)' },
             { url: 'ftp://example.com' },
+            { url: 'http://insecure.example' },
             { url: 'https://ok.example' },
           ],
           news: 'not an array',
@@ -224,6 +225,7 @@ describe('Firecrawl Search provider', () => {
     );
 
     expect(result.content).toContain('https://ok.example');
+    expect(result.content).not.toContain('insecure.example');
     expect(result.citations).toEqual([
       {
         url: 'https://ok.example/',


### PR DESCRIPTION
## Summary
- filter Firecrawl search results to absolute HTTPS URLs
- omit insecure HTTP sources from rendered content and citations
- preserve original HTTPS URLs rather than rewriting provider data

## Verification
- `npm test -- --run tests/adapters/firecrawl-search.test.ts` (28 passed)
- `env -u OPENAI_API_KEY -u GEMINI_API_KEY -u PERPLEXITY_API_KEY npm test` (2,161 passed, 7 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

The first unmodified full-suite run inherited live synthesis credentials and failed the credential-isolation wizard test; the clean environment run above passed.