### PR TITLE
chore: lock v2 rc12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.11",
+  "version": "2.0.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.11",
+      "version": "2.0.0-rc.12",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.11",
+  "version": "2.0.0-rc.12",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- lock the post-Firecrawl-fix release candidate as 2.0.0-rc.12
- keep package and lockfile versions aligned

## Verification
- `npm test -- --run tests/release-candidate-workflow.test.ts tests/rc-artifacts.test.ts` (63 passed)
- `npm run build`
- full source suite on the preceding fix commit: 2,161 passed, 7 skipped