### PR TITLE
Terminalize paid validation after request deadlines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.12",
+  "version": "2.0.0-rc.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.12",
+      "version": "2.0.0-rc.13",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.12",
+  "version": "2.0.0-rc.13",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -197,12 +197,29 @@ function classifyCustodyOutcome(
       readonly status: string;
       readonly attempts?: readonly {
         readonly status?: string;
+        readonly error?: { readonly code?: string };
         readonly durable_handle?: { readonly status?: string };
       }[];
     };
   },
 ): import('./commands/live-validation.js').FrozenExecutionOutcome {
   if (hasUnknownAcceptanceWithoutHandle(manifest)) {
+    return {
+      status: 'terminal',
+      lifecycle: 'failed',
+      request_id: reference.request_id,
+      raw_manifest: JSON.stringify(manifest),
+    };
+  }
+  const requestDeadlineExceeded =
+    manifest.coordination_state.status !== 'running' &&
+    (manifest.coordination_state.attempts?.some(
+      (attempt) =>
+        attempt.status === 'timed_out' &&
+        attempt.error?.code === 'request_deadline_exceeded',
+    ) ??
+      false);
+  if (requestDeadlineExceeded) {
     return {
       status: 'terminal',
       lifecycle: 'failed',

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -413,6 +413,44 @@ describe('production live-validation binding (injected, offline)', () => {
     },
   );
 
+  it('terminalizes a recorded request deadline despite pending durable custody', async () => {
+    const target = buildCanonicalValidationMatrix().targets.find(
+      (candidate) => candidate.key === 'perplexity-deep-research/research',
+    )!;
+    const observed = counters();
+    const dependencies = executorDependencies(target, observed);
+    dependencies.resume = async () => {
+      observed.resume += 1;
+      return {
+        manifest: {
+          coordination_state: {
+            status: 'unsuccessful',
+            attempts: [
+              {
+                status: 'timed_out',
+                error: { code: 'request_deadline_exceeded' },
+                durable_handle: { status: 'pending' },
+              },
+            ],
+          },
+        },
+      } as any;
+    };
+    const rawRoot = mkdtempSync(join(tmpdir(), 'librarium-binding-'));
+    const binding = createProductionFrozenCanonicalExecutor(
+      { raw_root: rawRoot } as LiveValidationApproval,
+      { providers: {} } as Config,
+      dependencies,
+    );
+    const reference = await binding.prepare(target, protocol(target));
+    await expect(
+      binding.execute(target, protocol(target), reference),
+    ).resolves.toMatchObject({ status: 'terminal', lifecycle: 'failed' });
+    await expect(
+      binding.reconcile(target, protocol(target), reference),
+    ).resolves.toMatchObject({ status: 'terminal', lifecycle: 'failed' });
+  });
+
   it('stops live validation when acceptance is unknown and no durable handle exists', async () => {
     const target = buildCanonicalValidationMatrix().targets.find(
       (candidate) => candidate.key === 'exa/research',


### PR DESCRIPTION
## Summary

Paid live validation now records an explicit request deadline as a terminal failure even when the provider's durable handle remains pending. This prevents expired validations from remaining in an endless reconciliation loop and locks the corrected candidate as v2.0.0-rc.13.

## Changes

- classify canonical `timed_out` / `request_deadline_exceeded` evidence before generic durable-custody reconciliation
- preserve reconciliation for non-deadline failed or cancelled states with unresolved remote custody
- add a Perplexity Deep regression covering the observed pending-handle timeout
- lock package metadata to `2.0.0-rc.13`

## Testing

- `npm test` with provider API variables removed — 2,162 passed, 7 skipped
- `npm run live-validation:fixture` — 96 passed
- `npm run typecheck`
- `npx biome check src/node-live-validation-production.ts tests/node-live-validation-production.test.ts package.json package-lock.json`
- local frozen package build and verification succeeded

PlanMode: #2966 (child of #2545)

Publication and deployment are out of scope.
