### PR TITLE
Fix Valyu provenance validation for public responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.13",
+  "version": "2.0.0-rc.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.13",
+      "version": "2.0.0-rc.14",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.13",
+  "version": "2.0.0-rc.14",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -1160,9 +1160,12 @@ export function deterministicReceiptSensibility(input: {
     input.provenance?.result_kind === profile.result_kind &&
     input.provenance?.retrieval_methods?.includes(profile.retrieval_method) ===
       true &&
-    profile.corpora.every((corpus) =>
-      input.provenance?.corpora?.includes(corpus),
-    );
+    // Specialized Valyu categories survive on citation metadata; the public
+    // ResearchResponse provenance schema intentionally cannot claim them as a
+    // universal corpus.
+    profile.corpora
+      .filter((corpus) => corpus !== 'specialized')
+      .every((corpus) => input.provenance?.corpora?.includes(corpus));
   const collectionModeRequired =
     profile.result_kind === 'surface_observation' ||
     profile.retrieval_method === 'surface_collector';

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -674,6 +674,37 @@ describe('canonical v3 live validation evidence boundary', () => {
       }).passed,
     ).toBe(true);
   });
+
+  it('compares Valyu provenance against the publicly representable corpora', () => {
+    const target = buildCanonicalValidationMatrix().targets.find(
+      (candidate) => candidate.key === 'valyu/research',
+    );
+    if (!target) throw new Error('missing Valyu research target');
+    const provenance = {
+      access_mode: 'direct' as const,
+      operator_id: 'valyu',
+      result_kind: 'research_report' as const,
+      retrieval_methods: ['research_agent' as const],
+      corpora: ['web' as const],
+    };
+
+    expect(
+      deterministicReceiptSensibility({
+        target,
+        content: 'A cited research report',
+        citations: [{ url: 'https://example.com/source', provider: 'valyu' }],
+        provenance,
+      }),
+    ).toMatchObject({ provenance_profile_match: true, passed: true });
+    expect(
+      deterministicReceiptSensibility({
+        target,
+        content: 'A cited research report',
+        citations: [{ url: 'https://example.com/source', provider: 'valyu' }],
+        provenance: { ...provenance, corpora: [] },
+      }).provenance_profile_match,
+    ).toBe(false);
+  });
 });
 
 describe('canonical v3 live validation persisted fixture lane', () => {


### PR DESCRIPTION
## Summary

Accept Valyu provider provenance when every corpus representable by the public response schema is present, without requiring the internal `specialized` category that survives only on citation metadata. Advances the candidate to 2.0.0-rc.14.

## Changes

- exclude only `specialized` from public provenance corpus matching
- retain result-kind, retrieval-method, representable-corpus, citation, and content gates
- add regression coverage proving `web` remains mandatory for Valyu Research
- advance package metadata to RC14

## Testing

- `npm run build`
- `npx biome check src/node-live-validation.ts tests/node-live-validation.test.ts package.json package-lock.json`
- `env -u OPENAI_API_KEY -u GEMINI_API_KEY -u PERPLEXITY_API_KEY npm test` — 2,163 passed, 7 skipped
- rebuilt runtime probe against RC13-style Valyu Research provenance — all quality flags passed
- `git diff --check`

PlanMode task #2545.

Publication, deployment, and npm release remain out of scope.