### PR TITLE
fix(validation): preserve provider evidence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.14",
+  "version": "2.0.0-rc.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.14",
+      "version": "2.0.0-rc.15",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.14",
+  "version": "2.0.0-rc.15",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/adapters/perplexity-agent-base.ts
+++ b/src/adapters/perplexity-agent-base.ts
@@ -476,7 +476,7 @@ export function parseAgentResponse(
   const cited = citedResultIds(messages, searchResults);
 
   let error: ParsedAgentResponse['error'];
-  if (root.error !== undefined) {
+  if (root.error !== undefined && root.error !== null) {
     const errorRecord = record(root.error);
     if (!errorRecord)
       throw responseError('Perplexity Agent error was malformed.');

--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -1001,9 +1001,7 @@ function frozenEvidenceQuality(
         ? [
             {
               url: citation.source.url,
-              // This comes from the canonical terminal response, never the
-              // selected target or an adapter identifier.
-              provider: citation.source.provider_reference ?? citation.id,
+              provider: item.provider,
             },
           ]
         : [],
@@ -1166,7 +1164,7 @@ export function rebuildFrozenValidationEvidence(
         ? [
             {
               url: citation.source.url,
-              provider: citation.source.provider_reference ?? citation.id,
+              provider: item.provider,
             },
           ]
         : [],
@@ -2181,7 +2179,10 @@ export function registerLiveValidationCommand(
         const config = (
           dependencies.productionConfig ?? loadProductionValidationConfig
         )();
-        const matrix = productionValidationMatrix(config);
+        const matrix = productionValidationMatrix(
+          config,
+          gate.approval.targets,
+        );
         const candidateAuthority =
           dependencies.candidateAuthority ??
           (() => {

--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -121,11 +121,33 @@ function normalizedProductionProviders(config: Config): Config['providers'] {
 }
 
 /** Build the config-aware public matrix before any credential context exists. */
-export function productionValidationMatrix(config: Config) {
+export function productionValidationMatrix(
+  config: Config,
+  protocols: readonly Pick<
+    LiveValidationApproval['targets'][number],
+    'key' | 'options'
+  >[] = [],
+) {
   const expected = buildCanonicalValidationMatrix();
   // A paid matrix is a complete fixed audit. An explicit disabled public
   // family must fail admission; it must never silently remove that family.
   const providers = normalizedProductionProviders(config);
+  for (const protocol of protocols) {
+    const target = expected.targets.find(
+      (candidate) => candidate.key === protocol.key,
+    );
+    if (!target) {
+      throw new CanonicalLiveValidationError(
+        `Unknown canonical public profile: ${protocol.key}.`,
+      );
+    }
+    const id = publicConfigId(target);
+    providers[id] = {
+      ...providers[id],
+      enabled: true,
+      options: protocol.options,
+    };
+  }
   const normalizedConfig = { ...config, providers };
   const mapped = mapConfiguration(normalizedConfig, {
     authoredGroups: configGroupProvenance(normalizedConfig),

--- a/tests/adapters/perplexity-agent.test.ts
+++ b/tests/adapters/perplexity-agent.test.ts
@@ -207,6 +207,21 @@ describe('Perplexity Agent API adapters', () => {
     },
   );
 
+  it('treats a null error on a completed response as no provider error', () => {
+    expect(
+      parseAgentResponse({
+        ...completed('completed-with-null-error'),
+        error: null,
+      }),
+    ).not.toHaveProperty('error');
+    expect(() =>
+      parseAgentResponse({
+        ...completed('completed-with-malformed-error'),
+        error: 'malformed',
+      }),
+    ).toThrow('error was malformed');
+  });
+
   it('preserves numeric search-result ids while projecting string citation references', async () => {
     const parsed = parseAgentResponse(completed('numeric-id'));
     expect(parsed.searchResults[0]?.id).toBe(1);

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -501,6 +501,28 @@ describe('production paid matrix and candidate attribution', () => {
     );
   });
 
+  it('binds approved provider options into the paid catalog authority', () => {
+    const config = loadConfig(
+      join(tmpdir(), 'librarium-missing-option-matrix-config.json'),
+    );
+    const baseline = productionValidationMatrix(config);
+    const search = baseline.targets.find(
+      (target) => target.key === 'valyu/search',
+    );
+    if (!search) throw new Error('missing Valyu search target');
+
+    const optionBound = productionValidationMatrix(config, [
+      { key: search.key, options: { searchType: 'web' } },
+    ]);
+    const boundSearch = optionBound.targets.find(
+      (target) => target.key === search.key,
+    );
+
+    expect(optionBound.targets).toHaveLength(41);
+    expect(optionBound.catalog_digest).not.toBe(baseline.catalog_digest);
+    expect(boundSearch?.catalog_digest).toBe(optionBound.catalog_digest);
+  });
+
   it('rejects an explicitly disabled canonical family before provider construction', () => {
     const config = loadConfig(
       join(tmpdir(), 'librarium-missing-disabled-config.json'),

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -1589,6 +1589,37 @@ describe('frozen paid protocol (injected, zero-network)', () => {
         : ({} as ReturnType<typeof CanonicalRunManifestV3Schema.parse>),
   };
 
+  it('projects the canonical result provider instead of a citation URL into receipts', async () => {
+    const { gate: frozen, matrix } = gate();
+    const target = matrix.targets[0]!;
+    const protocol = frozen.approval.targets[0]!;
+    const raw = JSON.parse(
+      await canonicalManifest(
+        target,
+        frozen.approval.raw_root,
+        'valyu-provider-reference-url',
+      ),
+    );
+    raw.terminal_response.results[0].citations[0].source.provider_reference =
+      'https://example.com/provider-reference';
+
+    const evidence = rebuildFrozenValidationEvidence(frozen, target, protocol, {
+      status: 'terminal',
+      lifecycle: 'succeeded',
+      request_id: 'valyu-provider-reference-url',
+      raw_manifest: JSON.stringify(raw),
+      manifest: raw,
+    });
+
+    expect(evidence.receipt).toMatchObject({
+      response: {
+        citation_count: 1,
+        citations: [{ provider: target.adapter_id }],
+      },
+    });
+    expect(JSON.stringify(evidence.receipt)).not.toContain('https://');
+  });
+
   it('reports terminal certification with success-only completed results', () => {
     expect(
       terminalValidationCertification(


### PR DESCRIPTION
## Summary

RC15 accepts completed Perplexity Agent responses that carry `error: null`, keeps canonical provider identity in sanitized citation receipts, and binds approved per-target options into paid catalog authority before execution.

## Changes

- treat a null Perplexity Agent error field as absent while still rejecting malformed non-null errors
- project canonical result providers into quality checks and sanitized receipts instead of provider reference URLs
- incorporate frozen per-target options before production catalog construction so option-sensitive digests and execution bindings agree
- advance the candidate version to `2.0.0-rc.15`

## Testing

- `npx vitest run tests/adapters/perplexity-agent.test.ts tests/node-live-validation-production.test.ts tests/node-live-validation.test.ts` — 140 passed
- `env -i HOME=\"$HOME\" PATH=\"$PATH\" TMPDIR=\"${TMPDIR:-/tmp}\" CI=1 npm test` — 2,166 passed, 7 skipped
- `npm run build` — passed
- `npx biome check src/adapters/perplexity-agent-base.ts src/commands/live-validation.ts src/node-live-validation-production.ts tests/adapters/perplexity-agent.test.ts tests/node-live-validation-production.test.ts tests/node-live-validation.test.ts` — passed
- offline reconstruction against retained RC14 evidence — both completed Perplexity Deep responses accepted without resubmission; Valyu Search rebuilt a passing sanitized receipt with five canonical `valyu` citations

## Validation scope

The retained-response reconstruction is diagnostic source proof, not exact-candidate RC15 live certification. A protected-main candidate proof and the separately bounded Sonar Pro paid retest remain post-merge steps.

Refs #2545
Refs #2972
Refs #2973