### PR TITLE
fix(validation): stabilize Gemini and Tavily custody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep Gemini Deep Research's reversible preview `failed` and `incomplete`
+  observations provisional until completion or the frozen request deadline,
+  while preserving terminal cancellation and budget-exhaustion states.
+- Correlate Tavily Research submissions with the frozen canonical attempt ID
+  and recover an uncertain create response only when Tavily's project-scoped
+  Logs API proves exactly one accepted task; ambiguous custody never resubmits.
+
 ### Added
 
 - **`parallel/turbo`**: first-class Parallel Search API turbo profile. It reuses

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.15",
+  "version": "2.0.0-rc.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.15",
+      "version": "2.0.0-rc.16",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.15",
+  "version": "2.0.0-rc.16",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/adapters/gemini-deep.ts
+++ b/src/adapters/gemini-deep.ts
@@ -86,9 +86,13 @@ const STATUS_MAP: Record<string, AsyncTaskStatus> = {
   in_progress: 'running',
   requires_action: 'running',
   completed: 'completed',
-  failed: 'failed',
+  // The preview Interactions API has returned completed output after earlier
+  // `failed` and `incomplete` observations for the same immutable interaction.
+  // Keep those provider states provisional and let the caller's absolute
+  // deadline bound polling rather than irreversibly discarding later output.
+  failed: 'running',
   cancelled: 'cancelled',
-  incomplete: 'failed',
+  incomplete: 'running',
   budget_exceeded: 'failed',
 };
 
@@ -294,7 +298,10 @@ export class GeminiDeepProvider extends BackgroundBaseProvider {
     return {
       status,
       rawStatus: data.status,
-      message: data.error?.message ?? undefined,
+      message:
+        data.status === 'failed' || data.status === 'incomplete'
+          ? `Gemini reported provisional status: ${data.status}`
+          : data.error?.message,
     };
   }
 

--- a/src/adapters/tavily-research.ts
+++ b/src/adapters/tavily-research.ts
@@ -70,11 +70,24 @@ const TavilyFailed = z.object({
   status: z.literal('failed'),
   error: z.union([z.string().min(1), z.object({ message: z.string().min(1) })]),
 });
+const TavilyResearchLog = z.object({
+  timestamp: z.string().datetime({ offset: true }),
+  endpoint: z.literal('research'),
+  request_id: TavilyId,
+});
+const TavilyLogs = z.object({
+  logs: z.array(TavilyResearchLog),
+  count: z.number().int().nonnegative(),
+});
 type TavilyTerminal =
   | z.infer<typeof TavilyCompleted>
   | z.infer<typeof TavilyFailed>;
 
 const URL = 'https://api.tavily.com/research';
+const LOGS_URL = 'https://api.tavily.com/logs';
+const SUBMISSION_RECONCILIATION_DELAYS_MS = [
+  0, 250, 750, 2_000, 5_000,
+] as const;
 const SUBMISSION_FAILED =
   'Tavily Research submission failed before a valid handle was returned.';
 const POLL_FAILED = 'Tavily Research status check failed.';
@@ -161,11 +174,13 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
     query: string,
     options: ProviderOptions,
   ): Promise<AsyncTaskHandle> {
+    const projectId = options.submissionId;
+    const startedAt = Date.now();
     let response;
     try {
       response = await this.request<unknown>(URL, {
         method: 'POST',
-        headers: this.headers(),
+        headers: this.headers(projectId),
         body: {
           input: query,
           model: this.configured.model ?? 'auto',
@@ -182,11 +197,27 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
         signal: options.signal,
       });
     } catch (error) {
+      const recovered = await this.reconcileSubmission(
+        query,
+        projectId,
+        startedAt,
+        options,
+      );
+      if (recovered) return recovered;
       throw new TavilyResearchSubmissionError(
         this.catchDiagnostic(error, options.signal),
       );
     }
     if (response.status !== 201) {
+      if (response.status >= 500) {
+        const recovered = await this.reconcileSubmission(
+          query,
+          projectId,
+          startedAt,
+          options,
+        );
+        if (recovered) return recovered;
+      }
       throw new TavilyResearchSubmissionError(
         this.httpDiagnostic(response.status, response.data),
       );
@@ -196,11 +227,19 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
       const id = TavilyId.safeParse(
         (response.data as { request_id?: unknown })?.request_id,
       );
-      if (!id.success)
+      if (!id.success) {
+        const recovered = await this.reconcileSubmission(
+          query,
+          projectId,
+          startedAt,
+          options,
+        );
+        if (recovered) return recovered;
         throw new TavilyResearchSubmissionError({
           kind: 'provider',
           httpStatus: 201,
         });
+      }
       return {
         provider: this.id,
         taskId: id.data,
@@ -308,8 +347,82 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
     }
   }
 
-  private headers(): Record<string, string> {
-    return { Authorization: `Bearer ${this.getApiKey()}` };
+  private headers(projectId?: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.getApiKey()}`,
+      ...(projectId && { 'X-Project-ID': projectId }),
+    };
+  }
+
+  /**
+   * Resolve an uncertain POST through Tavily's read-only Logs API. The frozen
+   * attempt id was attached before submission as an exact project filter, so
+   * only one matching Research log can establish custody. Zero, multiple, or
+   * malformed matches remain acceptance-unknown and never trigger another POST.
+   */
+  private async reconcileSubmission(
+    query: string,
+    projectId: string | undefined,
+    submittedAt: number,
+    options: ProviderOptions,
+  ): Promise<AsyncTaskHandle | undefined> {
+    if (!projectId || options.signal?.aborted) return undefined;
+    const remainingMs = submittedAt + options.timeout * 1_000 - Date.now();
+    const deadline = Date.now() + Math.min(Math.max(remainingMs, 0), 10_000);
+    for (const delay of SUBMISSION_RECONCILIATION_DELAYS_MS) {
+      if (delay > 0) {
+        try {
+          await wait(
+            Math.min(delay, Math.max(deadline - Date.now(), 0)),
+            options.signal,
+          );
+        } catch {
+          return undefined;
+        }
+      }
+      if (Date.now() >= deadline || options.signal?.aborted) return undefined;
+      try {
+        const date = new Date(submittedAt).toISOString().slice(0, 10);
+        const response = await this.request<unknown>(LOGS_URL, {
+          method: 'POST',
+          headers: this.headers(),
+          body: {
+            limit: 2,
+            start_date: date,
+            end_date: new Date().toISOString().slice(0, 10),
+            endpoints: ['research'],
+            project_id: projectId,
+            filter_by_api_key: true,
+          },
+          timeout: Math.min(3_000, Math.max(deadline - Date.now(), 1)),
+          signal: options.signal,
+        });
+        if (response.status !== 200) return undefined;
+        const parsed = TavilyLogs.safeParse(response.data);
+        if (
+          !parsed.success ||
+          parsed.data.count !== 1 ||
+          parsed.data.logs.length !== 1
+        ) {
+          return undefined;
+        }
+        const match = parsed.data.logs[0];
+        if (match) {
+          return {
+            provider: this.id,
+            taskId: match.request_id,
+            query,
+            submittedAt,
+            status: 'pending',
+            providerStatus: 'reconciled_from_logs',
+          };
+        }
+      } catch {
+        // The original POST remains uncertain. A Logs transport failure cannot
+        // safely prove rejection and must never cause a second submission.
+      }
+    }
+    return undefined;
   }
 
   private task(requestId: string, timeout: number) {

--- a/src/core/provider-attempt-bridge.ts
+++ b/src/core/provider-attempt-bridge.ts
@@ -676,6 +676,7 @@ export function createProviderAttemptBridge(
           provider.submit(launch.query, {
             timeout: providerTimeoutSeconds(remainingMs),
             signal,
+            submissionId: launch.attempt_id,
           }),
         launch,
         now,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ export interface ProviderOptions {
   /** Relative operation timeout in seconds. */
   timeout: number;
   signal?: AbortSignal;
+  /**
+   * Frozen canonical attempt id. Background adapters may use it only as an
+   * opaque provider-side correlation value; it never authorizes resubmission.
+   */
+  submissionId?: string;
 }
 
 // Normalized usage/cost as reported by a provider's API. Honest data only:

--- a/tests/adapters/gemini-deep-async.test.ts
+++ b/tests/adapters/gemini-deep-async.test.ts
@@ -137,7 +137,7 @@ describe('GeminiDeepProvider Interactions API', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('maps poll statuses (in_progress running, failed with message)', async () => {
+  it('keeps reversible failed observations provisional', async () => {
     globalThis.fetch = vi
       .fn()
       .mockResolvedValueOnce(
@@ -158,8 +158,8 @@ describe('GeminiDeepProvider Interactions API', () => {
       rawStatus: 'in_progress',
     });
     expect(await provider.poll(makeHandle())).toEqual({
-      status: 'failed',
-      message: 'agent overloaded',
+      status: 'running',
+      message: 'Gemini reported provisional status: failed',
       rawStatus: 'failed',
     });
 
@@ -167,6 +167,51 @@ describe('GeminiDeepProvider Interactions API', () => {
     expect(calls[0]?.[0]).toBe(
       'https://generativelanguage.googleapis.com/v1beta/interactions/int-123',
     );
+  });
+
+  it('accepts completion after a provisional failed observation', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: 'int-reversible',
+          status: 'failed',
+          error: { message: 'temporary agent failure' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { id: 'int-reversible', status: 'completed' }),
+      );
+
+    const provider = makeProvider();
+    const handle = makeHandle('int-reversible');
+    await expect(provider.poll(handle)).resolves.toMatchObject({
+      status: 'running',
+      rawStatus: 'failed',
+    });
+    await expect(provider.poll(handle)).resolves.toMatchObject({
+      status: 'completed',
+      rawStatus: 'completed',
+    });
+  });
+
+  it.each([
+    ['budget_exceeded', 'failed'],
+    ['cancelled', 'cancelled'],
+  ] as const)('keeps stable %s observations terminal', async (raw, status) => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, { id: 'int-terminal', status: raw }),
+      );
+
+    await expect(
+      makeProvider().poll(makeHandle('int-terminal')),
+    ).resolves.toEqual({
+      status,
+      rawStatus: raw,
+      message: undefined,
+    });
   });
 
   it('throws on a transport-level poll failure so polling retries', async () => {
@@ -290,7 +335,7 @@ describe('GeminiDeepProvider Interactions API', () => {
     expect(result.content).toBe('Part one.\nPart two.');
   });
 
-  it('returns an error result for failed or not-yet-completed interactions', async () => {
+  it('keeps provisional failures nonterminal during retrieval', async () => {
     globalThis.fetch = vi
       .fn()
       .mockResolvedValueOnce(
@@ -306,7 +351,8 @@ describe('GeminiDeepProvider Interactions API', () => {
 
     const provider = makeProvider();
     const failed = await provider.retrieve(makeHandle());
-    expect(failed.error).toBe('research failed');
+    expect(failed.error).toContain('not completed yet');
+    expect(failed.error).toContain('failed');
 
     const pending = await provider.retrieve(makeHandle());
     expect(pending.error).toContain('not completed yet');

--- a/tests/execution-runtime.test.ts
+++ b/tests/execution-runtime.test.ts
@@ -941,6 +941,12 @@ describe('private prepared execution runtime', () => {
       durable_handle: { provider_task_id: 'async-task', status: 'pending' },
     });
     expect(result.outputs_by_attempt).toEqual({});
+    expect(durable.submit).toHaveBeenCalledWith(
+      'runtime query',
+      expect.objectContaining({
+        submissionId: result.state.attempts[0]?.attempt_id,
+      }),
+    );
     expect(durable.poll).not.toHaveBeenCalled();
     expect(durable.retrieve).not.toHaveBeenCalled();
   });

--- a/tests/research-provider-adapters.test.ts
+++ b/tests/research-provider-adapters.test.ts
@@ -540,6 +540,99 @@ describe('durable research provider adapters', () => {
     });
   });
 
+  it('recovers exactly one uncertain Tavily submission from project-scoped logs without resubmitting', async () => {
+    const httpClient = vi.fn(async <_T>(url: string, _options = {}) => {
+      if (url === 'https://api.tavily.com/research') {
+        throw new TypeError('fetch failed after write');
+      }
+      expect(url).toBe('https://api.tavily.com/logs');
+      return response({
+        logs: [
+          {
+            timestamp: '2026-08-23T12:00:00.000Z',
+            endpoint: 'research',
+            request_id: 'recovered-task',
+          },
+        ],
+        count: 1,
+      }) as never;
+    }) as HttpClient;
+    const provider = new TavilyResearchProvider({
+      credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+      httpClient,
+    });
+
+    await expect(
+      provider.submit('query', {
+        timeout: 10,
+        submissionId: 'attempt-frozen-123',
+      }),
+    ).resolves.toMatchObject({
+      taskId: 'recovered-task',
+      status: 'pending',
+      providerStatus: 'reconciled_from_logs',
+    });
+
+    const submissionCalls = httpClient.mock.calls.filter(
+      ([url]) => url === 'https://api.tavily.com/research',
+    );
+    expect(submissionCalls).toHaveLength(1);
+    expect(submissionCalls[0]?.[1]).toMatchObject({
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-key',
+        'X-Project-ID': 'attempt-frozen-123',
+      },
+    });
+    const logsCall = httpClient.mock.calls.find(
+      ([url]) => url === 'https://api.tavily.com/logs',
+    );
+    expect(logsCall?.[1]).toMatchObject({
+      method: 'POST',
+      body: {
+        limit: 2,
+        endpoints: ['research'],
+        project_id: 'attempt-frozen-123',
+        filter_by_api_key: true,
+      },
+    });
+  });
+
+  it('refuses ambiguous Tavily log custody and never resubmits', async () => {
+    const httpClient = vi.fn(async <_T>(url: string) => {
+      if (url === 'https://api.tavily.com/research') {
+        throw new TypeError('fetch failed after write');
+      }
+      return response({
+        logs: ['one', 'two'].map((suffix) => ({
+          timestamp: '2026-08-23T12:00:00.000Z',
+          endpoint: 'research',
+          request_id: `task-${suffix}`,
+        })),
+        count: 2,
+      }) as never;
+    }) as HttpClient;
+    const provider = new TavilyResearchProvider({
+      credentials: { env: { TAVILY_API_KEY: 'test-key' } },
+      httpClient,
+    });
+
+    await expect(
+      provider.submit('query', {
+        timeout: 10,
+        submissionId: 'attempt-frozen-ambiguous',
+      }),
+    ).rejects.toMatchObject({
+      name: 'UnsafeToRetrySubmissionError',
+      failureDiagnostic: { kind: 'network' },
+    });
+    expect(
+      httpClient.mock.calls.filter(
+        ([url]) => url === 'https://api.tavily.com/research',
+      ),
+    ).toHaveLength(1);
+  });
+
   it.each([
     ['malformed progress', response({ status: 'in_progress' }, 202), 202],
     ['malformed success', response({ status: 'completed' }, 200), 200],


### PR DESCRIPTION
## Summary
- keep reversible Gemini Deep preview failures provisional until completion or the frozen request deadline
- correlate Tavily Research with the canonical attempt ID and recover uncertain submissions only from one exact project-scoped Logs API match
- bump the candidate version to 2.0.0-rc.16

## Safety
- Gemini cancellation and budget exhaustion remain terminal
- Tavily reconciliation is read-only and never issues a second Research POST
- zero, multiple, malformed, or unavailable log matches remain acceptance-unknown

## Verification
- `npm run build`
- `npm run typecheck`
- `npx biome check src/ tests/ benchmark/`
- focused lifecycle suite: 102 passed
- full key-free suite: 2,170 passed, 7 skipped; one unrelated existing failure in `tests/wizard-preflight.test.ts` reproduces independently and is not touched by this PR