### PR TITLE
fix(tavily): use valid Logs recovery window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correlate Tavily Research submissions with the frozen canonical attempt ID
   and recover an uncertain create response only when Tavily's project-scoped
   Logs API proves exactly one accepted task; ambiguous custody never resubmits.
+- Query Tavily's Logs API with a valid two-day UTC window during uncertain
+  Research submission recovery; Tavily rejects equal start and end dates.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.16",
+  "version": "2.0.0-rc.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librarium",
-      "version": "2.0.0-rc.16",
+      "version": "2.0.0-rc.17",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librarium",
-  "version": "2.0.0-rc.16",
+  "version": "2.0.0-rc.17",
   "description": "Evidence-aware multi-provider research with explicit profile provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/adapters/tavily-research.ts
+++ b/src/adapters/tavily-research.ts
@@ -382,13 +382,18 @@ export class TavilyResearchProvider extends BackgroundBaseProvider {
       }
       if (Date.now() >= deadline || options.signal?.aborted) return undefined;
       try {
-        const date = new Date(submittedAt).toISOString().slice(0, 10);
+        // Tavily documents inclusive date bounds but rejects equal values.
+        // Start one UTC day before submission so same-day recovery remains a
+        // valid query while the unique project id keeps the match exact.
+        const startDate = new Date(submittedAt - 86_400_000)
+          .toISOString()
+          .slice(0, 10);
         const response = await this.request<unknown>(LOGS_URL, {
           method: 'POST',
           headers: this.headers(),
           body: {
             limit: 2,
-            start_date: date,
+            start_date: startDate,
             end_date: new Date().toISOString().slice(0, 10),
             endpoints: ['research'],
             project_id: projectId,

--- a/tests/research-provider-adapters.test.ts
+++ b/tests/research-provider-adapters.test.ts
@@ -596,6 +596,14 @@ describe('durable research provider adapters', () => {
         filter_by_api_key: true,
       },
     });
+    const logBody = logsCall?.[1]?.body as {
+      start_date: string;
+      end_date: string;
+    };
+    expect(logBody.start_date).not.toBe(logBody.end_date);
+    expect(Date.parse(logBody.end_date) - Date.parse(logBody.start_date)).toBe(
+      86_400_000,
+    );
   });
 
   it('refuses ambiguous Tavily log custody and never resubmits', async () => {


### PR DESCRIPTION
## Summary
- use a two-day UTC window for Tavily Logs reconciliation because Tavily rejects equal start/end dates
- retain exact project-scoped matching and fail closed on zero, multiple, malformed, or unavailable matches
- bump candidate version to 2.0.0-rc.17

## Verification
- npm run build
- npm run typecheck
- focused lifecycle suite: 88 passed
- npx biome check src/ tests/ benchmark/
- git diff --check