### PR TITLE
fix(validation): accept stable release candidates

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -40,8 +40,8 @@ import {
 } from '../node-live-validation-production.js';
 
 const SAFE_ID = /^[a-z][a-z0-9._-]{0,127}$/;
-const RC_VERSION =
-  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:0|[1-9]\d*)$/;
+const CANDIDATE_VERSION =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-rc\.(?:0|[1-9]\d*))?$/;
 const SHA256 = /^sha256:[a-f0-9]{64}$/;
 const MICROUSD = /^(?:0|[1-9]\d*)$/;
 const DECIMAL = /^(?:0|[1-9]\d*)(?:\.\d{1,36})?$/;
@@ -135,7 +135,7 @@ const ApprovalSchema = z
     candidate: z.strictObject({
       git_sha: z.string().regex(/^[a-f0-9]{40}$/),
       fingerprint: z.string().regex(SHA256),
-      version: z.string().regex(RC_VERSION),
+      version: z.string().regex(CANDIDATE_VERSION),
       artifact_hashes: z.record(
         z.string().regex(SAFE_ID),
         z.string().regex(SHA256),

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -27,6 +27,7 @@ import {
   frozenRequestFingerprint,
   installOfflineNetworkGuard,
   installOfflineValidationSigint,
+  readLiveValidationApproval,
   rebuildFrozenValidationEvidence,
   registerLiveValidationCommand,
   terminalValidationCertification,
@@ -1572,6 +1573,25 @@ describe('frozen paid protocol (injected, zero-network)', () => {
       request_contract: requestContract,
     };
   }
+
+  it('accepts a separately certified stable candidate approval', () => {
+    const frozen = gate().gate;
+    const approval = {
+      ...frozen.approval,
+      candidate: { ...frozen.approval.candidate, version: '2.0.0' },
+    };
+    const path = join(frozen.approval.raw_root, 'stable-approval.json');
+    writeFileSync(path, JSON.stringify(approval), {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+
+    expect(readLiveValidationApproval(path)).toEqual({
+      approval,
+      fingerprint: approvalFingerprint(approval),
+    });
+  });
+
   const fixtureReferenceAuthority = {
     read: (
       reference: { readonly request_id: string },


### PR DESCRIPTION
## Summary

Allows the paid-validation approval boundary to accept a separately certified stable `X.Y.Z` candidate as well as an `X.Y.Z-rc.N` candidate.

The stable certification and promotion flow landed in #154, but the paid-validation preregistration schema retained its RC-only version regex. That made the required post-certification stable validation impossible before any credential access.

## Verification

- focused live-validation protocol tests: 100 passed
- secret-free full unit suite: 119 files, 2,242 passed, 7 skipped
- `npm run build`, `npm run typecheck`, and `npm run lint`: passed
- `git diff --check`: passed

Related PlanMode work: #2999, #2564.

No paid/provider calls, publication, release, tag, or deployment was performed.
