### PR TITLE
test(installer): fix remote fixture platform

### DIFF
--- a/tests/install-script.test.ts
+++ b/tests/install-script.test.ts
@@ -79,6 +79,10 @@ function runRemoteInstaller(input: {
     join(bin, 'curl'),
     '#!/bin/sh\nout=""\nurl=""\nwhile [ "$#" -gt 0 ]; do\n  case "$1" in\n    -o) out="$2"; shift 2 ;;\n    *) url="$1"; shift ;;\n  esac\ndone\ncase "$url" in\n  */SHA256SUMS) cp "$FIXTURE_MANIFEST" "$out" ;;\n  *) cp "$FIXTURE_CANDIDATE" "$out" ;;\nesac\n',
   );
+  executable(
+    join(bin, 'uname'),
+    "#!/bin/sh\ncase \"$1\" in\n  -s) printf 'Linux\\n' ;;\n  -m) printf 'x86_64\\n' ;;\n  *) exit 1 ;;\nesac\n",
+  );
   return spawnSync('sh', [installer], {
     cwd: input.root,
     encoding: 'utf8',


### PR DESCRIPTION
## Summary

- make the remote installer fixture hermetic across Linux and macOS
- pin its mocked platform to the existing Linux x64 checksum fixture
- unblock stable v2 distribution certification

## Verification

- 48 targeted release/installer tests pass on Linux
- the same 48 tests pass independently on macOS jBeast, including the previously failing remote checksum case
- typecheck, lint, and diff check pass on both platforms

PlanMode #2564