### PR TITLE
fix(validation): admit stable candidate artifacts

### DIFF
--- a/src/node-live-validation-binding.ts
+++ b/src/node-live-validation-binding.ts
@@ -712,7 +712,7 @@ function verifyRcCandidateTree(
     typeof identity.name !== 'string' ||
     !identity.name ||
     typeof identity.version !== 'string' ||
-    !/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.[1-9]\d*$/.test(
+    !/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-rc\.[1-9]\d*)?$/.test(
       identity.version,
     ) ||
     typeof identity.git_sha !== 'string' ||

--- a/tests/rc-artifacts.test.ts
+++ b/tests/rc-artifacts.test.ts
@@ -168,7 +168,10 @@ function canonicalWrite(path: string, value: unknown): void {
   writeFileSync(path, releaseCandidateInternals.canonicalText(value));
 }
 
-function fixtureRepository(root: string): {
+function fixtureRepository(
+  root: string,
+  version = VERSION,
+): {
   readonly repository: string;
   readonly tarball: string;
 } {
@@ -177,7 +180,7 @@ function fixtureRepository(root: string): {
   writeFileSync(join(repository, '.gitignore'), 'dist/\n');
   const packageValue = {
     name: 'librarium',
-    version: VERSION,
+    version,
     type: 'module',
     main: './dist/index.js',
     types: './dist/index.d.ts',
@@ -196,11 +199,11 @@ function fixtureRepository(root: string): {
   };
   const lockValue = {
     name: 'librarium',
-    version: VERSION,
+    version,
     lockfileVersion: 3,
     requires: true,
     packages: {
-      '': { name: 'librarium', version: VERSION },
+      '': { name: 'librarium', version },
     },
   };
   const packageJson = `${JSON.stringify(packageValue, null, 2)}\n`;
@@ -235,7 +238,7 @@ function fixtureRepository(root: string): {
     '{}\n',
   );
   commitRepository(repository);
-  const tarball = join(root, `librarium-${VERSION}.tgz`);
+  const tarball = join(root, `librarium-${version}.tgz`);
   writeFileSync(
     tarball,
     makeTarball({
@@ -284,9 +287,9 @@ const fixtureDependencies = {
   load_installed_matrix: () => matrix(),
 };
 
-async function completeFixture() {
+async function completeFixture(version = VERSION) {
   const root = temporaryRoot();
-  const { repository, tarball } = fixtureRepository(root);
+  const { repository, tarball } = fixtureRepository(root, version);
   const packageRoot = join(root, 'frozen-package');
   const frozen = await freezeReleasePackage({
     repository_root: repository,
@@ -584,6 +587,27 @@ describe('release candidate artifact contract', () => {
         `${name}=records/${name}.json`,
       ]),
     );
+  });
+
+  it('accepts a stable candidate at the credential-free authority gate', async () => {
+    const fixture = await completeFixture('2.0.0');
+    const authority = createFilesystemCandidateAuthority({
+      repository_root: fixture.repository,
+      package_json: join(fixture.repository, 'package.json'),
+      artifact_root: fixture.candidateRoot,
+      artifacts: Object.fromEntries(
+        RELEASE_CANDIDATE_RECORD_NAMES.map((name) => [
+          name,
+          `records/${name}.json`,
+        ]),
+      ),
+    });
+
+    expect(authority.candidate_version()).toBe('2.0.0');
+    expect(authority.candidate_fingerprint()).toBe(
+      fixture.candidate.candidate.fingerprint,
+    );
+    expect(() => authority.verify()).not.toThrow();
   });
 
   it('reassembles byte-identical candidates without rebuilding package bytes', async () => {


### PR DESCRIPTION
## Summary

Allows an immutable stable release candidate such as `2.0.0` to pass the same credential-free artifact authority gate already used by RC identities. Without this, stable certification succeeds but paid validation is blocked before credential resolution.

## Changes

- Accept exact stable `X.Y.Z` and RC `X.Y.Z-rc.N` candidate identities at the transitive artifact authority boundary.
- Parameterize the complete release-candidate fixture by version.
- Prove a stable candidate is assembled, fingerprinted, and reverified through the full filesystem authority.

## Testing

- `npx vitest run tests/rc-artifacts.test.ts tests/node-live-validation.test.ts` — 128 passed.
- Secret-free `npm test` — 119 files; 2,243 passed, 7 skipped.
- `npm run typecheck` — passed.
- `npm run lint` — 414 files clean.
- `npm run build` — passed.
- `git diff --check` — passed.

PlanMode #2999
