### PR TITLE
fix(validation): preserve paid catalog authority

### DIFF
--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -103,7 +103,13 @@ function exactInput(
   };
 }
 
-function normalizedProductionProviders(config: Config): Config['providers'] {
+function normalizedProductionProviders(
+  config: Config,
+  protocols: readonly Pick<
+    LiveValidationApproval['targets'][number],
+    'key' | 'options'
+  >[] = [],
+): Config['providers'] {
   const expected = buildCanonicalValidationMatrix();
   for (const target of expected.targets) {
     if (config.providers[publicConfigId(target)]?.enabled === false) {
@@ -117,21 +123,6 @@ function normalizedProductionProviders(config: Config): Config['providers'] {
     const id = publicConfigId(target);
     providers[id] = { ...providers[id], enabled: true };
   }
-  return providers;
-}
-
-/** Build the config-aware public matrix before any credential context exists. */
-export function productionValidationMatrix(
-  config: Config,
-  protocols: readonly Pick<
-    LiveValidationApproval['targets'][number],
-    'key' | 'options'
-  >[] = [],
-) {
-  const expected = buildCanonicalValidationMatrix();
-  // A paid matrix is a complete fixed audit. An explicit disabled public
-  // family must fail admission; it must never silently remove that family.
-  const providers = normalizedProductionProviders(config);
   for (const protocol of protocols) {
     const target = expected.targets.find(
       (candidate) => candidate.key === protocol.key,
@@ -148,6 +139,21 @@ export function productionValidationMatrix(
       options: protocol.options,
     };
   }
+  return providers;
+}
+
+/** Build the config-aware public matrix before any credential context exists. */
+export function productionValidationMatrix(
+  config: Config,
+  protocols: readonly Pick<
+    LiveValidationApproval['targets'][number],
+    'key' | 'options'
+  >[] = [],
+) {
+  const expected = buildCanonicalValidationMatrix();
+  // A paid matrix is a complete fixed audit. An explicit disabled public
+  // family must fail admission; it must never silently remove that family.
+  const providers = normalizedProductionProviders(config, protocols);
   const normalizedConfig = { ...config, providers };
   const mapped = mapConfiguration(normalizedConfig, {
     authoredGroups: configGroupProvenance(normalizedConfig),
@@ -281,7 +287,10 @@ export function createProductionFrozenCanonicalExecutor(
   config: Config,
   dependencies: ProductionLiveValidationDependencies = {},
 ): FrozenCanonicalExecutor {
-  const productionProviders = normalizedProductionProviders(config);
+  const productionProviders = normalizedProductionProviders(
+    config,
+    approval.targets,
+  );
   const initialize = dependencies.initializeProviders ?? initializeProviders;
   const resolveProvider = dependencies.resolveExactProvider ?? getExactProvider;
   const createDirectory = dependencies.createRunDirectory ?? createRunDir;

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -260,7 +260,12 @@ describe('production live-validation binding (injected, offline)', () => {
     const config = loadConfig(
       join(tmpdir(), 'librarium-missing-live-validation-config.json'),
     );
-    const target = productionValidationMatrix(config).targets[0]!;
+    const canonicalTargets = buildCanonicalValidationMatrix().targets;
+    const protocols = [
+      protocol(canonicalTargets[0]!),
+      protocol(canonicalTargets[1]!),
+    ];
+    const target = productionValidationMatrix(config, protocols).targets[0]!;
     const observed = counters();
     const injected = executorDependencies(target, observed);
     const {
@@ -270,6 +275,7 @@ describe('production live-validation binding (injected, offline)', () => {
     const binding = createProductionFrozenCanonicalExecutor(
       {
         raw_root: mkdtempSync(join(tmpdir(), 'librarium-binding-')),
+        targets: protocols,
       } as LiveValidationApproval,
       config,
       dependencies,


### PR DESCRIPTION
## Summary

Keep the paid-validation production matrix and frozen executor bound to the same complete provider catalog, including every preregistered protocol option.

## Changes

- normalize all frozen target options once when constructing production providers
- use that identical provider set for both matrix generation and execution
- add a two-protocol structural-preflight regression proving catalog digest continuity

## Testing

- `npx vitest run tests/node-live-validation-production.test.ts tests/node-live-validation.test.ts` — 100 passed
- secret-free `npm test` — 2,243 passed, 7 skipped
- `npm run typecheck`
- `npm run lint` — 414 files clean
- `npm run build`
- `git diff --check`

No provider request occurred while diagnosing or verifying this fix.

PlanMode #2999