### PR TITLE
fix(validation): preserve catalog through credential checks

### DIFF
--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -22,6 +22,7 @@ import {
   mergeConfigs,
 } from './core/config.js';
 import { mapConfiguration } from './core/configuration-mapping.js';
+import { type CredentialContext, hasCredential } from './core/credentials.js';
 import { getBuiltinProviderDefinition } from './core/provider-descriptor.js';
 import { INTERNAL_ADAPTER_PUBLIC_PROVIDER_IDS } from './internal-adapter-ids.js';
 import {
@@ -31,6 +32,7 @@ import {
   materializeCanonicalPreparedExecution,
   resumeCanonicalPreparedExecution,
 } from './node-canonical-run.js';
+import { createNodeCredentialContext } from './node-credentials.js';
 import {
   assertCanonicalValidationPreparedExecution,
   buildCanonicalValidationMatrix,
@@ -42,7 +44,6 @@ import {
 import { readTrustedFrozenReferenceManifest } from './node-live-validation-binding.js';
 import {
   assertAdmittedAdaptersRegistered,
-  preflightProductionRequest,
   preflightProductionRequestStructure,
 } from './node-request-preflight.js';
 import { createRunDir } from './node-run-directory.js';
@@ -58,8 +59,13 @@ export interface ProductionLiveValidationDependencies {
    * keychain-aware phase so tests can prove every rejection ordering.
    */
   readonly preflightStructure?: typeof preflightProductionRequestStructure;
-  /** Keychain-aware request admission after structural admission succeeds. */
-  readonly preflightCredentials?: typeof preflightProductionRequest;
+  /** Test seam for credential-aware prepared-execution drift checks. */
+  readonly preflightCredentials?: (
+    input: Parameters<typeof preflightProductionRequestStructure>[0],
+  ) => ReturnType<typeof preflightProductionRequestStructure> & {
+    readonly credentials: CredentialContext;
+  };
+  readonly createCredentials?: () => CredentialContext;
   /** Canonical run services are injectable for offline production-binding tests. */
   readonly createCoordinator?: typeof createNodeCoordinatorDependencies;
   readonly createAttemptBridge?: typeof createRegisteredProviderAttemptBridge;
@@ -279,8 +285,9 @@ function classifyCustodyOutcome(
 }
 
 /**
- * Creates an exact one-target executor. `prepare` performs both request
- * preflight phases only after all upstream gates have admitted the target.
+ * Creates an exact one-target executor. `prepare` performs structural request
+ * admission and exact credential resolution only after all upstream gates
+ * have admitted the target.
  */
 export function createProductionFrozenCanonicalExecutor(
   approval: LiveValidationApproval,
@@ -296,8 +303,9 @@ export function createProductionFrozenCanonicalExecutor(
   const createDirectory = dependencies.createRunDirectory ?? createRunDir;
   const structuralPreflight =
     dependencies.preflightStructure ?? preflightProductionRequestStructure;
-  const credentialPreflight =
-    dependencies.preflightCredentials ?? preflightProductionRequest;
+  const credentialPreflight = dependencies.preflightCredentials;
+  const createCredentials =
+    dependencies.createCredentials ?? createNodeCredentialContext;
   const createCoordinator =
     dependencies.createCoordinator ?? createNodeCoordinatorDependencies;
   const createAttemptBridge =
@@ -313,7 +321,7 @@ export function createProductionFrozenCanonicalExecutor(
     {
       readonly target: CanonicalValidationTarget;
       readonly prepared: ReturnType<
-        typeof preflightProductionRequest
+        typeof preflightProductionRequestStructure
       >['prepared'];
     }
   >();
@@ -359,10 +367,26 @@ export function createProductionFrozenCanonicalExecutor(
     // Credential phase: resolve only the admitted public family and construct
     // only the exact adapter, including private durable adapters which consume
     // their mapped public configuration.
-    const admitted = credentialPreflight({
-      config: configured,
-      transport: exactInput(target, protocol),
-    });
+    const admitted = credentialPreflight
+      ? credentialPreflight({
+          config: configured,
+          transport: exactInput(target, protocol),
+        })
+      : (() => {
+          const credentials = createCredentials();
+          const credentialReference =
+            configured.providers[publicConfigId(target)]?.apiKey ??
+            `$${protocol.credential_reference}`;
+          if (!hasCredential(credentialReference, credentials)) {
+            throw new CanonicalLiveValidationError(
+              `Frozen credential is unavailable for ${target.key}.`,
+            );
+          }
+          // The structural prepared execution is the approved all-provider
+          // catalog authority. Recompiling it with ambient credential
+          // availability would change unrelated catalog rows and its digest.
+          return { ...structural, credentials };
+        })();
     assertCanonicalValidationPreparedExecution(admitted.prepared, target);
     if (
       admitted.admittedAdapterIds.length !== 1 ||

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -261,15 +261,28 @@ describe('production live-validation binding (injected, offline)', () => {
       join(tmpdir(), 'librarium-missing-live-validation-config.json'),
     );
     const canonicalTargets = buildCanonicalValidationMatrix().targets;
-    const protocols = [
-      protocol(canonicalTargets[0]!),
-      protocol(canonicalTargets[1]!),
+    const protocolKeys = [
+      'grok-combined/combined',
+      'grok-x-only/x',
+      'grok/web',
+      'parallel/chat',
+      'parallel/research',
+      'perplexity-deep-research/research',
+      'perplexity-sonar-deep/research',
+      'valyu/search',
     ];
-    const target = productionValidationMatrix(config, protocols).targets[0]!;
+    const protocols = protocolKeys.map((key) =>
+      protocol(canonicalTargets.find((candidate) => candidate.key === key)!),
+    );
+    const matrix = productionValidationMatrix(config, protocols);
+    const target = matrix.targets.find(
+      (candidate) => candidate.key === protocols[0]!.key,
+    )!;
     const observed = counters();
     const injected = executorDependencies(target, observed);
     const {
       preflightStructure: _useProductionStructuralPreflight,
+      preflightCredentials: _useProductionCredentialPreflight,
       ...dependencies
     } = injected;
     const binding = createProductionFrozenCanonicalExecutor(
@@ -278,7 +291,12 @@ describe('production live-validation binding (injected, offline)', () => {
         targets: protocols,
       } as LiveValidationApproval,
       config,
-      dependencies,
+      {
+        ...dependencies,
+        createCredentials: () => ({
+          env: { [protocols[0]!.credential_reference]: '[REDACTED:api-key]' },
+        }),
+      },
     );
 
     await expect(
@@ -287,10 +305,43 @@ describe('production live-validation binding (injected, offline)', () => {
       catalog_digest: target.catalog_digest,
     });
     expect(observed).toMatchObject({
-      credential: 1,
+      credential: 0,
       initialize: 1,
       materialize: 1,
     });
+  });
+
+  it('rejects a missing frozen credential before provider initialization or materialization', async () => {
+    const config = loadConfig(
+      join(tmpdir(), 'librarium-missing-live-validation-config.json'),
+    );
+    const canonicalTarget = buildCanonicalValidationMatrix().targets.find(
+      (candidate) => candidate.key === 'grok-combined/combined',
+    )!;
+    const frozenProtocol = protocol(canonicalTarget);
+    const target = productionValidationMatrix(config, [
+      frozenProtocol,
+    ]).targets.find((candidate) => candidate.key === frozenProtocol.key)!;
+    const observed = counters();
+    const injected = executorDependencies(target, observed);
+    const {
+      preflightStructure: _useProductionStructuralPreflight,
+      preflightCredentials: _useProductionCredentialPreflight,
+      ...dependencies
+    } = injected;
+    const binding = createProductionFrozenCanonicalExecutor(
+      {
+        raw_root: mkdtempSync(join(tmpdir(), 'librarium-binding-')),
+        targets: [frozenProtocol],
+      } as LiveValidationApproval,
+      config,
+      { ...dependencies, createCredentials: () => ({ env: {} }) },
+    );
+
+    await expect(binding.prepare(target, frozenProtocol)).rejects.toThrow(
+      'Frozen credential is unavailable for grok-combined/combined',
+    );
+    expect(observed).toMatchObject({ initialize: 0, materialize: 0 });
   });
 
   it('initializes only a private durable adapter while retaining its public configuration authority', async () => {


### PR DESCRIPTION
## Summary

Keep paid validation bound to its approved all-provider catalog while still failing closed unless the exact selected credential is available.

## Changes

- retain the structurally admitted prepared execution as catalog authority rather than recompiling it from ambient credential availability
- resolve and validate only the selected frozen provider credential before initialization
- initialize only the structurally admitted adapter
- cover the exact eight-profile protocol set and missing-credential fail-closed behavior

## Testing

- `npx vitest run tests/node-live-validation-production.test.ts tests/node-live-validation.test.ts` — 101 passed
- secret-free `npm test` — 2,244 passed, 7 skipped
- `npm run typecheck`
- `npm run lint` — 414 files clean
- `npm run build`
- `git diff --check`

The release candidate gate exposed this before materialization or network access. No provider request occurred; checkpoint attempts and receipts remained empty.

PlanMode #2999