### PR TITLE
fix(validation): admit stable receipt identity

### DIFF
--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -1408,7 +1408,7 @@ const FORBIDDEN_RECEIPT_TEXT =
   /(?:bearer\s+|(?:sk|rk|pk)[_-][A-Za-z0-9_-]{12,}|akia[A-Z0-9]{12,}|ghp_[A-Za-z0-9]{12,}|xox[baprs]-[A-Za-z0-9-]{12,}|aiza[A-Za-z0-9_-]{12,}|api[_-]?key|access[_-]?token|authorization|secret|signed(?:[_-]?url)?|x-amz-(?:credential|signature|security-token)|https?:\/\/|(?:^|["'])(?:\/?(?:Users|home|tmp|private|opt|var|etc|mnt|srv|proc|dev)|[A-Za-z]:[\\/]))/i;
 
 const SAFE_RECEIPT_STRING =
-  /^(?:USD|[a-z][a-z0-9._-]{0,127}(?:\/[a-z][a-z0-9._-]{0,127})?|(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:0|[1-9]\d*)|(?:0|[1-9]\d*)(?:\.\d{1,36})?|[a-f0-9]{40}|sha256:[a-f0-9]{64}|fnv1a64\.1:[a-f0-9]{16})$/;
+  /^(?:USD|[a-z][a-z0-9._-]{0,127}(?:\/[a-z][a-z0-9._-]{0,127})?|(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-rc\.(?:0|[1-9]\d*))?|(?:0|[1-9]\d*)(?:\.\d{1,36})?|[a-f0-9]{40}|sha256:[a-f0-9]{64}|fnv1a64\.1:[a-f0-9]{16})$/;
 const SAFE_PROVIDER_PRICING_UNIT =
   /^[a-z][a-z0-9-]{0,62}:[a-z][a-z0-9_]{0,62}$/;
 const PRICING_UNIT_RECEIPT_PATH =

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -493,6 +493,7 @@ describe('canonical v3 live validation evidence boundary', () => {
       candidate_fingerprint:
         'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       candidate_git_sha: '6c580293bfd1c03f2f29d5674e33cdf0ae809ec0',
+      candidate_version: '2.0.0',
       request_id: 'request-1',
       account: 'reviewed-account',
       region: 'us',
@@ -505,7 +506,23 @@ describe('canonical v3 live validation evidence boundary', () => {
     });
     expect(JSON.stringify(safe)).not.toContain('response body remains private');
     expect(JSON.stringify(safe)).not.toContain('https://example.com/source');
-    expect(safe).toMatchObject({ schema_version: 1, lifecycle: 'succeeded' });
+    expect(safe).toMatchObject({
+      schema_version: 1,
+      candidate_version: '2.0.0',
+      lifecycle: 'succeeded',
+    });
+    expect(() =>
+      sanitizeCanonicalReceipt({
+        target,
+        candidate_fingerprint:
+          'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        candidate_version: '2.0.0-beta.1',
+        request_id: 'request-1',
+        account: 'reviewed-account',
+        region: 'us',
+        lifecycle: 'failed',
+      }),
+    ).toThrow('prohibited material');
     expect(() =>
       sanitizeCanonicalReceipt({
         target,


### PR DESCRIPTION
## Summary
- allow stable `X.Y.Z` candidate versions in sanitized live-validation receipts
- preserve support for `X.Y.Z-rc.N`
- continue rejecting unsupported prerelease identities

## Context
The first stable-candidate paid validation reached xAI once, then receipt serialization rejected `candidate_version: 2.0.0`. This change fixes that evidence boundary. No provider calls are part of this PR.

## Verification
- focused live-validation tests: 101 passed
- secret-free full unit suite: 2,244 passed, 7 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

PlanMode #2999 / #2564