### PR TITLE
fix(grok): persist bounded failure diagnostics

### DIFF
--- a/src/adapters/grok-responses.ts
+++ b/src/adapters/grok-responses.ts
@@ -1,6 +1,11 @@
+import {
+  HttpRequestAbortedError,
+  HttpRequestTimeoutError,
+} from '../core/http-client.js';
 import { classifySourceKindFromUrl } from '../core/source-kind.js';
 import type {
   Citation,
+  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -192,6 +197,10 @@ export class GrokResponsesProvider extends BaseProvider {
         return this.errorResult(
           durationMs,
           this.formatError(response.status, data),
+          {
+            kind: this.classifyFailure(response.status, data),
+            httpStatus: response.status,
+          },
         );
       }
 
@@ -234,7 +243,16 @@ export class GrokResponsesProvider extends BaseProvider {
       };
     } catch (err) {
       const durationMs = Math.round(performance.now() - start);
-      return this.errorResult(durationMs, this.formatCatchError(err));
+      return this.errorResult(durationMs, this.formatCatchError(err), {
+        kind:
+          err instanceof HttpRequestTimeoutError ||
+          err instanceof HttpRequestAbortedError ||
+          (err instanceof DOMException && err.name === 'AbortError')
+            ? 'timeout'
+            : err instanceof TypeError
+              ? 'network'
+              : 'provider',
+      });
     }
   }
 
@@ -272,7 +290,11 @@ export class GrokResponsesProvider extends BaseProvider {
     return base;
   }
 
-  private errorResult(durationMs: number, error: string): ProviderResult {
+  private errorResult(
+    durationMs: number,
+    error: string,
+    failureDiagnostic?: ProviderFailureDiagnostic,
+  ): ProviderResult {
     return {
       provider: this.id,
       tier: this.tier,
@@ -280,7 +302,23 @@ export class GrokResponsesProvider extends BaseProvider {
       citations: [],
       durationMs,
       error,
+      ...(failureDiagnostic && { failureDiagnostic }),
     };
+  }
+
+  private classifyFailure(
+    status: number,
+    data: unknown,
+  ): ProviderFailureDiagnostic['kind'] {
+    if (status === 400 && /api key/i.test(this.errorMessage(data))) {
+      return 'authentication';
+    }
+    if (status === 401 || status === 403) return 'authentication';
+    if (status === 402) return 'billing';
+    if (status === 408 || status === 504) return 'timeout';
+    if (status === 429) return 'rate_limit';
+    if (status >= 400 && status < 500) return 'invalid_request';
+    return 'provider';
   }
 
   private errorMessage(data: unknown): string {

--- a/tests/adapters/grok.test.ts
+++ b/tests/adapters/grok.test.ts
@@ -249,6 +249,17 @@ describe('GrokProvider', () => {
     expect(result.citations).toEqual([]);
     expect(result.error).toContain(`API returned ${status}`);
     expect(result.error).toContain(hint);
+    expect(result.failureDiagnostic).toEqual({
+      kind:
+        status === 401
+          ? 'authentication'
+          : status === 403
+            ? 'authentication'
+            : status === 429
+              ? 'rate_limit'
+              : 'invalid_request',
+      httpStatus: status,
+    });
   });
 
   it('normalizes network failures without throwing', async () => {
@@ -259,6 +270,7 @@ describe('GrokProvider', () => {
     const result = await provider().execute('ground this', { timeout: 10 });
 
     expect(result.error).toContain('Network error connecting to Grok (xAI)');
+    expect(result.failureDiagnostic).toEqual({ kind: 'network' });
   });
 
   it('wires the timeout and caller abort signal through the HTTP client', async () => {
@@ -339,6 +351,10 @@ describe('GrokProvider — live-verified edge cases', () => {
 
     expect(result.error).toContain('400');
     expect(result.error).toContain('XAI_API_KEY');
+    expect(result.failureDiagnostic).toEqual({
+      kind: 'authentication',
+      httpStatus: 400,
+    });
   });
 
   // NaN cannot appear on the JSON wire (it serializes to null), so null is


### PR DESCRIPTION
## Summary
- classify Grok HTTP failures into bounded canonical categories
- persist only the HTTP status and allowlisted category, never provider response bodies
- distinguish auth, billing, rate-limit, timeout, invalid-request, network, and provider failures

## Context
Exact-candidate validation currently records Grok failures as an undifferentiated provider error, preventing safe diagnosis while keeping raw provider bodies private. This closes that diagnostic gap before the next bounded validation round.

## Verification
- Grok adapter tests: 26 passed
- secret-free full suite: 2,244 passed, 7 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

PlanMode #2999 / #2564