### PR TITLE
fix(parallel): persist bounded chat diagnostics

### DIFF
--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -7,6 +7,7 @@ import type {
   AsyncTaskHandle,
   AsyncTaskStatus,
   Citation,
+  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
@@ -38,6 +39,17 @@ const STATUS: Record<string, AsyncTaskStatus> = {
   cancelling: 'running',
   cancelled: 'cancelled',
 };
+
+function classifyParallelFailure(
+  status: number,
+): ProviderFailureDiagnostic['kind'] {
+  if (status === 401 || status === 403) return 'authentication';
+  if (status === 402) return 'billing';
+  if (status === 408 || status === 504) return 'timeout';
+  if (status === 429) return 'rate_limit';
+  if (status >= 400 && status < 500) return 'invalid_request';
+  return 'provider';
+}
 
 interface WebResult {
   url?: unknown;
@@ -501,14 +513,14 @@ export class ParallelChatProvider extends BaseProvider {
       );
       const durationMs = Math.round(performance.now() - start);
       if (response.status < 200 || response.status >= 300)
-        return {
-          provider: this.id,
-          tier: this.tier,
-          content: '',
-          citations: [],
+        return this.resultError(
           durationMs,
-          error: this.formatError(response.status, response.data),
-        };
+          this.formatError(response.status, response.data),
+          {
+            kind: classifyParallelFailure(response.status),
+            httpStatus: response.status,
+          },
+        );
       const parsedResponse = chatResponseSchema.safeParse(response.data);
       if (!parsedResponse.success)
         return this.resultError(
@@ -555,7 +567,11 @@ export class ParallelChatProvider extends BaseProvider {
       };
     }
   }
-  private resultError(durationMs: number, error: string): ProviderResult {
+  private resultError(
+    durationMs: number,
+    error: string,
+    failureDiagnostic?: ProviderFailureDiagnostic,
+  ): ProviderResult {
     return {
       provider: this.id,
       tier: this.tier,
@@ -563,6 +579,7 @@ export class ParallelChatProvider extends BaseProvider {
       citations: [],
       durationMs,
       error,
+      ...(failureDiagnostic && { failureDiagnostic }),
     };
   }
 }

--- a/tests/adapters/parallel.test.ts
+++ b/tests/adapters/parallel.test.ts
@@ -290,6 +290,33 @@ describe('Parallel first-party providers', () => {
   });
 
   it.each([
+    [400, 'invalid_request'],
+    [401, 'authentication'],
+    [403, 'authentication'],
+    [402, 'billing'],
+    [408, 'timeout'],
+    [429, 'rate_limit'],
+    [500, 'provider'],
+    [504, 'timeout'],
+  ] as const)(
+    'records bounded diagnostics for HTTP %i Chat failures',
+    async (status, kind) => {
+      const result = await new ParallelChatProvider({
+        apiKey: key,
+        httpClient: client({ error: { message: 'provider detail' } }, status),
+        model: 'base',
+      }).execute('question', { timeout: 9 });
+
+      expect(result).toMatchObject({
+        content: '',
+        citations: [],
+        failureDiagnostic: { kind, httpStatus: status },
+      });
+      expect(result.failureDiagnostic).not.toHaveProperty('message');
+    },
+  );
+
+  it.each([
     [{ choices: [] }, 'invalid Chat response'],
     [{ choices: [{ message: {} }] }, 'invalid Chat response'],
   ])(


### PR DESCRIPTION
## Summary
- classify Parallel Chat HTTP failures into the existing safe diagnostic categories
- persist only HTTP status and allowlisted category into canonical evidence
- never persist provider response bodies or raw error text

## Verification
- `npx vitest run tests/adapters/parallel.test.ts` (52 passed)
- secret-free `npm test` (119 files, 2,252 passed, 7 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

PlanMode #2999

This PR performs no provider calls or publication.