### PR TITLE
fix(parallel): diagnose malformed chat responses

### DIFF
--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { OpaqueIdSchema } from '../contracts/common.js';
 import { UnsafeToRetrySubmissionError } from '../core/errors.js';
+import {
+  HttpRequestAbortedError,
+  HttpRequestTimeoutError,
+} from '../core/http-client.js';
 import { normalizeUrl } from '../core/normalizer.js';
 import type {
   AsyncPollResult,
@@ -526,6 +530,7 @@ export class ParallelChatProvider extends BaseProvider {
         return this.resultError(
           durationMs,
           'Parallel returned an invalid Chat response',
+          { kind: 'provider', httpStatus: response.status },
         );
       const content = parsedResponse.data.choices
         .map((choice) => choice.message?.content)
@@ -534,6 +539,7 @@ export class ParallelChatProvider extends BaseProvider {
         return this.resultError(
           durationMs,
           'Parallel returned a Chat response without message content',
+          { kind: 'provider', httpStatus: response.status },
         );
       const basis = basisMeta(parsedResponse.data.basis);
       return {
@@ -557,14 +563,20 @@ export class ParallelChatProvider extends BaseProvider {
         },
       };
     } catch (error) {
-      return {
-        provider: this.id,
-        tier: this.tier,
-        content: '',
-        citations: [],
-        durationMs: Math.round(performance.now() - start),
-        error: this.formatCatchError(error),
-      };
+      return this.resultError(
+        Math.round(performance.now() - start),
+        this.formatCatchError(error),
+        {
+          kind:
+            error instanceof HttpRequestTimeoutError ||
+            error instanceof HttpRequestAbortedError ||
+            (error instanceof DOMException && error.name === 'AbortError')
+              ? 'timeout'
+              : error instanceof TypeError
+                ? 'network'
+                : 'provider',
+        },
+      );
     }
   }
   private resultError(

--- a/tests/adapters/parallel.test.ts
+++ b/tests/adapters/parallel.test.ts
@@ -332,9 +332,23 @@ describe('Parallel first-party providers', () => {
         content: '',
         citations: [],
         error: expect.stringContaining(message),
+        failureDiagnostic: { kind: 'provider', httpStatus: 200 },
       });
     },
   );
+
+  it('records a bounded network diagnostic for Chat transport failures', async () => {
+    const result = await new ParallelChatProvider({
+      apiKey: key,
+      httpClient: vi.fn(async () => {
+        throw new TypeError('private network detail');
+      }) as unknown as HttpClient,
+      model: 'base',
+    }).execute('question', { timeout: 9 });
+
+    expect(result.failureDiagnostic).toEqual({ kind: 'network' });
+    expect(result.failureDiagnostic).not.toHaveProperty('message');
+  });
 
   it('has durable Task create, poll, retrieve and terminal mapping', async () => {
     const http = vi


### PR DESCRIPTION
## Summary
- distinguish malformed HTTP-success Chat responses from transport failures
- persist only safe status/category diagnostics, never provider response bodies
- classify timeout and network exceptions without exposing raw details

## Verification
- `npx vitest run tests/adapters/parallel.test.ts` (53 passed)
- secret-free `npm test` (119 files, 2,253 passed, 7 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

PlanMode #2999

This PR performs no provider calls or publication.