### PR TITLE
fix(validation): expose bounded canonical failure receipts

### DIFF
--- a/src/commands/live-validation.ts
+++ b/src/commands/live-validation.ts
@@ -1188,6 +1188,30 @@ export function rebuildFrozenValidationEvidence(
   const canonicalMetering = canonicalMeteringMetadata(providerMeta);
   const actualSource = canonicalMetering?.actual_cost_source ?? 'unknown';
   const quality = frozenEvidenceQuality(target, result);
+  // Read only the target's terminal slot/latest attempt, not the lossy
+  // terminal_response.errors or a previous/transient attempt diagnostic.
+  // A sensibility-only lifecycle override must never attach a provider error.
+  const state = result.manifest.coordination_state;
+  const slot = state.slots.find(
+    (candidate) =>
+      canonicalJson(candidate.primary.identity) ===
+      canonicalJson(target.expected_effective_identity),
+  );
+  const attempt = state.attempts.find(
+    (candidate) =>
+      candidate.attempt_id === slot?.latest_attempt_id &&
+      candidate.slot_id === slot?.slot_id &&
+      canonicalJson(candidate.profile.identity) ===
+        canonicalJson(target.expected_effective_identity),
+  );
+  const failure =
+    state.status === 'unsuccessful' &&
+    (slot?.status === 'failed' || slot?.status === 'timed_out')
+      ? (slot.error ??
+        (attempt?.status === 'failed' || attempt?.status === 'timed_out'
+          ? attempt.error
+          : undefined))
+      : undefined;
   const receipt = sanitizeCanonicalReceipt({
     target,
     candidate_fingerprint: gate.approval.candidate.fingerprint,
@@ -1214,6 +1238,7 @@ export function rebuildFrozenValidationEvidence(
     account: protocol.account,
     region: protocol.region,
     lifecycle: lifecycleOverride ?? result.lifecycle,
+    failure,
     response: {
       content: resultBodies.join('\n'),
       citations,

--- a/src/node-live-validation.ts
+++ b/src/node-live-validation.ts
@@ -10,9 +10,11 @@ import { createHash } from 'node:crypto';
 import { lstatSync, readFileSync, realpathSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { z } from 'zod/v4';
-import type {
-  ExecutionProfile,
-  ProviderIdentity,
+import {
+  ErrorCategorySchema,
+  type ExecutionProfile,
+  type ProviderIdentity,
+  type StructuredError,
 } from './contracts/domain/index.js';
 import {
   canonicalJson,
@@ -740,6 +742,7 @@ export function writeSanitizedCanonicalReceipt(
     'request_fingerprint',
     'run_evidence_sha256',
     'lifecycle',
+    'failure',
     'response',
     'usage',
     'metering',
@@ -749,6 +752,11 @@ export function writeSanitizedCanonicalReceipt(
   if (Object.keys(receipt).some((key) => !allowed.has(key))) {
     throw new CanonicalLiveValidationError(
       'Public receipt contains a non-allowlisted field.',
+    );
+  }
+  if (receipt.failure !== undefined && receipt.lifecycle !== 'failed') {
+    throw new CanonicalLiveValidationError(
+      'Only failed receipts may contain a failure summary.',
     );
   }
   if (
@@ -1414,11 +1422,57 @@ const SAFE_PROVIDER_PRICING_UNIT =
 const PRICING_UNIT_RECEIPT_PATH =
   /^receipt\.pricing_quote\.missing_units\[\d+\]$/;
 
+// Closed public vocabulary of terminal coordinator/runtime/bridge failures.
+// StructuredError.code/provider_code are open strings in the domain contract;
+// accepting their general grammar here would allow private text to escape.
+const ReceiptFailureSchema = z.strictObject({
+  code: z.enum([
+    'provider_authentication_failed',
+    'provider_plan_required',
+    'provider_billing_failed',
+    'provider_rate_limited',
+    'provider_invalid_request',
+    'provider_network_failed',
+    'provider_timeout',
+    'provider_reported_error',
+    'provider_result_invalid',
+    'provider_task_failed',
+    'provider_task_cancelled',
+    'adapter_execute_failed',
+    'adapter_retrieve_failed',
+    'frozen_adapter_binding_unavailable',
+    'frozen_adapter_execution_mismatch',
+    'budget_reservation_exceeded',
+    'request_cancelled',
+    'attempt_deadline_exceeded',
+    'accepted_durable_attempt_deadline_exceeded',
+    'request_deadline_exceeded',
+    'attempt_execution_failed',
+    'non_durable_execution_interrupted',
+  ]),
+  category: ErrorCategorySchema,
+  retryable: z.boolean(),
+  fallback_allowed: z.boolean(),
+  provider_code: z
+    .string()
+    .length(8)
+    .regex(/^http_[1-5][0-9]{2}$/)
+    .optional(),
+});
+
 function assertSafeReceiptValue(
   value: unknown,
   path = 'receipt',
   frozenPricingUnits: ReadonlySet<string> = new Set(),
 ): void {
+  if (
+    path === 'receipt.failure' &&
+    !ReceiptFailureSchema.safeParse(value).success
+  ) {
+    throw new CanonicalLiveValidationError(
+      'Public receipt has an invalid failure summary.',
+    );
+  }
   if (
     value === null ||
     typeof value === 'boolean' ||
@@ -1500,6 +1554,8 @@ export function sanitizeCanonicalReceipt(input: {
   readonly account: string;
   readonly region: string;
   readonly lifecycle: 'succeeded' | 'failed' | 'cancelled';
+  /** Trusted terminal canonical error, never an adapter diagnostic or message. */
+  readonly failure?: StructuredError;
   readonly response?: {
     readonly content?: string;
     readonly citations?: readonly {
@@ -1533,6 +1589,21 @@ export function sanitizeCanonicalReceipt(input: {
     pricing_snapshot_fingerprint: input.target.pricing_snapshot_fingerprint,
     pricing_quote: input.pricing_quote,
     lifecycle: input.lifecycle,
+    failure:
+      input.lifecycle === 'failed' && input.failure
+        ? {
+            code: input.failure.code,
+            category: input.failure.category,
+            retryable: input.failure.retryable,
+            fallback_allowed: input.failure.fallback_allowed,
+            ...(input.failure.provider_code !== undefined &&
+              ReceiptFailureSchema.shape.provider_code.safeParse(
+                input.failure.provider_code,
+              ).success && {
+                provider_code: input.failure.provider_code,
+              }),
+          }
+        : undefined,
     response: input.response
       ? {
           content_sha256: input.response.content

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -12,7 +12,8 @@ import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ParallelChatProvider } from '../src/adapters/parallel.js';
 import { createCliProgram } from '../src/cli-program.js';
 import {
   type ApprovalGate,
@@ -34,6 +35,10 @@ import {
 } from '../src/commands/live-validation.js';
 import type { PreparedResearchExecution } from '../src/core/execution-plan.js';
 import { profileIdentityKey } from '../src/core/execution-plan.js';
+import {
+  type HttpClient,
+  HttpRequestTimeoutError,
+} from '../src/core/http-client.js';
 import { BUILTIN_PRICING_SNAPSHOT } from '../src/core/pricing-snapshot.js';
 import { buildProviderCatalog } from '../src/core/profile-catalog.js';
 import {
@@ -573,6 +578,107 @@ describe('canonical v3 live validation evidence boundary', () => {
         lifecycle: 'failed',
       }),
     ).toThrow('prohibited material');
+  });
+
+  it('bounds failure metadata at projection and rejects unsafe summaries at the write boundary', () => {
+    const target = buildCanonicalValidationMatrix().targets[0]!;
+    const base = {
+      target,
+      candidate_fingerprint: `sha256:${'a'.repeat(64)}`,
+      request_id: 'failure-receipt',
+      account: 'reviewed-account',
+      region: 'us',
+      lifecycle: 'failed' as const,
+    };
+    const summary = {
+      code: 'provider_reported_error',
+      category: 'provider' as const,
+      retryable: true,
+      fallback_allowed: true,
+    };
+    const failure = {
+      ...summary,
+      message: 'private message',
+      details: [{ detail_code: 'private_detail', message: 'private payload' }],
+      provider_code: 'http_200',
+    };
+    const receipt = sanitizeCanonicalReceipt({ ...base, failure });
+    expect(receipt.failure).toEqual({ ...summary, provider_code: 'http_200' });
+    for (const provider_code of [
+      undefined,
+      'private_value',
+      'secret',
+      'http_099',
+      'http_600',
+      'http_200\n',
+      'x'.repeat(1000),
+    ]) {
+      expect(
+        sanitizeCanonicalReceipt({
+          ...base,
+          failure: { ...failure, provider_code },
+        }).failure,
+      ).toEqual(summary);
+    }
+    for (const lifecycle of ['succeeded', 'cancelled'] as const) {
+      expect(
+        sanitizeCanonicalReceipt({ ...base, lifecycle, failure }),
+      ).not.toHaveProperty('failure');
+    }
+    expect(sanitizeCanonicalReceipt(base)).not.toHaveProperty('failure');
+    for (const invalid of [
+      { code: 'private_value' },
+      { category: 'private_value' },
+      { retryable: 'true' },
+      { fallback_allowed: null },
+    ]) {
+      expect(() =>
+        sanitizeCanonicalReceipt({
+          ...base,
+          failure: { ...failure, ...invalid } as typeof failure,
+        }),
+      ).toThrow('invalid failure summary');
+    }
+    const root = mkdtempSync(join(tmpdir(), 'librarium-failure-receipt-'));
+    roots.push(root);
+    expect(() =>
+      writeSanitizedCanonicalReceipt(
+        root,
+        'succeeded.json',
+        { ...receipt, lifecycle: 'succeeded' },
+        target,
+      ),
+    ).toThrow('Only failed receipts');
+    for (const unsafe of [
+      null,
+      [],
+      Array(257).fill(summary),
+      { ...summary, code: 'private_value' },
+      { ...summary, category: 'private_value' },
+      { ...summary, retryable: 'true' },
+      { ...summary, fallback_allowed: [] },
+      { ...summary, provider_code: 'http_600' },
+      { ...summary, provider_code: 'x'.repeat(1000) },
+      ...[
+        'message',
+        'details',
+        'raw',
+        'payload',
+        'headers',
+        'diagnostics',
+        'secret',
+        'credentials',
+      ].map((key) => ({ ...summary, [key]: 'private' })),
+    ]) {
+      expect(() =>
+        writeSanitizedCanonicalReceipt(
+          root,
+          'unsafe.json',
+          { ...receipt, failure: unsafe },
+          target,
+        ),
+      ).toThrow('invalid failure summary');
+    }
   });
 
   it('admits only frozen provider-namespaced pricing units', () => {
@@ -1355,6 +1461,7 @@ describe('frozen paid protocol (injected, zero-network)', () => {
         readonly billableUnits: number;
       };
     },
+    exactProvider?: Provider,
   ): Promise<string> {
     const entry = BUILTIN_PROVIDER_CATALOG.find(
       (candidate) =>
@@ -1456,13 +1563,14 @@ describe('frozen paid protocol (injected, zero-network)', () => {
           },
           profile,
           catalog_digest: target.catalog_digest,
-          provider,
+          provider: exactProvider ?? provider,
         }),
         now: () => Date.parse('2026-08-13T00:00:00.000Z'),
         wait: async () => {},
       },
     });
-    const raw = JSON.stringify(result.manifest);
+    const raw = readFileSync(join(runDirectory, 'run.json'), 'utf8');
+    expect(JSON.parse(raw)).toEqual(result.manifest);
     fixtureManifests.set(requestId, raw);
     return raw;
   }
@@ -1656,6 +1764,176 @@ describe('frozen paid protocol (injected, zero-network)', () => {
     });
     expect(JSON.stringify(evidence.receipt)).not.toContain('https://');
   });
+
+  it.each([
+    ['invalid-schema', 'provider_reported_error', 'provider', 'http_200'],
+    ['missing-content', 'provider_reported_error', 'provider', 'http_200'],
+    ['timeout', 'provider_timeout', 'timeout', undefined],
+    ['network', 'provider_network_failed', 'network', undefined],
+    ['quality-only', undefined, undefined, undefined],
+  ] as const)(
+    'projects %s through the real adapter, bridge and persisted canonical run offline',
+    async (scenario, code, category, providerCode) => {
+      const restoreNetwork = installOfflineNetworkGuard();
+      try {
+        const { gate: frozen, matrix } = gate();
+        const target = matrix.targets.find(
+          (item) => item.key === 'parallel/chat',
+        )!;
+        const protocol = frozen.approval.targets.find(
+          (item) => item.key === target.key,
+        )!;
+        const privateText = 'private-provider-payload-and-secret';
+        const httpClient = vi.fn(async () => {
+          if (scenario === 'timeout') throw new HttpRequestTimeoutError(1000);
+          if (scenario === 'network') throw new TypeError(privateText);
+          return {
+            status: 200,
+            statusText: 'OK',
+            headers: { authorization: privateText },
+            data: {
+              choices:
+                scenario === 'invalid-schema'
+                  ? []
+                  : scenario === 'missing-content'
+                    ? [{}]
+                    : [{ message: { content: '' } }],
+              error: privateText,
+              diagnostics: { secret: privateText },
+            },
+            durationMs: 1,
+          };
+        });
+        const provider = new ParallelChatProvider({
+          apiKey: 'offline-fixture-key',
+          httpClient: httpClient as HttpClient,
+        });
+        const execute = vi.spyOn(provider, 'execute');
+        const raw = await canonicalManifest(
+          target,
+          frozen.approval.raw_root,
+          `receipt-${scenario}`,
+          'succeeded',
+          undefined,
+          provider,
+        );
+        const manifest = CanonicalRunManifestV3Schema.parse(JSON.parse(raw));
+        const state = manifest.coordination_state;
+        const adapterResult = await execute.mock.results[0]!.value;
+        expect(httpClient).toHaveBeenCalledOnce();
+        expect(state.status).toBe(code ? 'unsuccessful' : 'succeeded');
+        const expected = code
+          ? {
+              code,
+              category,
+              retryable: true,
+              fallback_allowed: true,
+              ...(providerCode && { provider_code: providerCode }),
+            }
+          : undefined;
+        for (const record of [state.slots[0]!, state.attempts[0]!]) {
+          expect(record.status).toBe(code ? 'failed' : 'succeeded');
+          if (expected)
+            expect(record.error).toEqual({
+              ...expected,
+              message: 'The provider returned an error.',
+            });
+          else expect(record.error).toBeUndefined();
+        }
+        if (code)
+          expect(adapterResult.failureDiagnostic).toEqual({
+            kind: category,
+            ...(providerCode && { httpStatus: 200 }),
+          });
+        const terminal = {
+          status: 'terminal' as const,
+          lifecycle: code ? ('failed' as const) : ('succeeded' as const),
+          request_id: manifest.request.request_id,
+          raw_manifest: raw,
+          manifest,
+        };
+        const evidence = rebuildFrozenValidationEvidence(
+          frozen,
+          target,
+          protocol,
+          terminal,
+          'failed',
+        );
+        expect(evidence.receipt.lifecycle).toBe('failed');
+        expect(evidence.quality).toMatchObject({
+          passed: false,
+          content_present: false,
+        });
+        if (expected) expect(evidence.receipt.failure).toEqual(expected);
+        else expect(evidence.receipt).not.toHaveProperty('failure');
+        const serialized = JSON.stringify(evidence.receipt);
+        for (const forbidden of [
+          privateText,
+          'offline-fixture-key',
+          'message',
+          'payload',
+          'headers',
+          'diagnostics',
+          'secret',
+          'failureDiagnostic',
+          'The provider returned an error.',
+          adapterResult.error,
+        ].filter(Boolean)) {
+          expect(serialized).not.toContain(forbidden);
+        }
+        writeSanitizedCanonicalReceipt(
+          frozen.approval.receipt_root,
+          `${scenario}.json`,
+          evidence.receipt,
+          target,
+        );
+        expect(
+          JSON.parse(
+            readFileSync(
+              join(frozen.approval.receipt_root, `${scenario}.json`),
+              'utf8',
+            ),
+          ),
+        ).toEqual(evidence.receipt);
+
+        // Removing the slot copy still projects only its exact latest attempt.
+        if (expected) {
+          state.slots[0]!.error = undefined;
+          manifest.terminal_response!.errors = [];
+          expect(
+            rebuildFrozenValidationEvidence(frozen, target, protocol, terminal)
+              .receipt.failure,
+          ).toEqual(expected);
+          state.slots[0]!.latest_attempt_id = 'another-attempt';
+          expect(
+            rebuildFrozenValidationEvidence(frozen, target, protocol, terminal)
+              .receipt,
+          ).not.toHaveProperty('failure');
+        } else {
+          // Even a stale error must not turn quality rejection into a
+          // reported provider execution failure after canonical success.
+          state.slots[0]!.error = {
+            code: 'provider_timeout',
+            category: 'timeout',
+            retryable: true,
+            fallback_allowed: true,
+            message: 'stale',
+          };
+          expect(
+            rebuildFrozenValidationEvidence(
+              frozen,
+              target,
+              protocol,
+              terminal,
+              'failed',
+            ).receipt,
+          ).not.toHaveProperty('failure');
+        }
+      } finally {
+        restoreNetwork();
+      }
+    },
+  );
 
   it('reports terminal certification with success-only completed results', () => {
     expect(


### PR DESCRIPTION
## Summary
Failed live-validation receipts now retain one bounded failure summary from the exact target coordinator slot (or its latest failed attempt), instead of losing canonical diagnostics at the public projection.

- Allowlist canonical error codes and categories, boolean retry/fallback flags, and optional HTTP-only provider codes (`http_100`–`http_599`). Never publish messages, details, raw errors, payloads, headers, or credentials.
- Validate the strict summary again at the receipt write boundary. Unknown fields/shapes/codes fail closed; arbitrary provider codes are omitted.
- Leave success receipts unchanged and omit provider failure metadata when only deterministic quality checks reject a canonically successful result. No adapter behavior changes.
- Offline regressions exercise both invalid-schema and missing-content HTTP-200 responses, timeout, network, persisted slot/latest-attempt errors, quality-only rejection, and privacy bypass attempts.

## Verification
All checks ran with a secret-free environment; new end-to-end fixtures deny network access and inject HTTP responses.
- Targeted validation/Parallel/runtime suites: 200 passed.
- Final full unit suite: 119 files, 2,259 passed, 7 skipped.
- Typecheck, lint (414 files), build, contract snapshot drift, and git diff --check: passed.
- No receipt JSON Schema or fixture snapshot exists outside these owning projection/writer contracts; public interchange schemas are unchanged.

PlanMode #3420 (under certification task #2564). No provider calls, candidate certification dispatch, release, publication, deployment, settings, or lockfile changes. Merge is authorized only after the full existing CI matrix passes on the unchanged head.