### PR TITLE
fix(parallel): accept compatible chat delta content

### DIFF
--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -87,7 +87,10 @@ interface ChatResponse {
   id?: string;
   interaction_id?: string;
   model?: string;
-  choices?: Array<{ message?: { content?: string } }>;
+  choices?: Array<{
+    message?: { content?: string };
+    delta?: { content?: string | null };
+  }>;
   basis?: FieldBasis[];
   usage?: {
     prompt_tokens?: number;
@@ -145,6 +148,10 @@ const chatResponseSchema = z
         z
           .object({
             message: z.object({ content: z.string() }).passthrough().optional(),
+            delta: z
+              .object({ content: z.string().nullish() })
+              .passthrough()
+              .optional(),
           })
           .passthrough(),
       )
@@ -533,8 +540,11 @@ export class ParallelChatProvider extends BaseProvider {
           { kind: 'provider', httpStatus: response.status },
         );
       const content = parsedResponse.data.choices
-        .map((choice) => choice.message?.content)
-        .find((value): value is string => typeof value === 'string');
+        .flatMap((choice) => [choice.message?.content, choice.delta?.content])
+        .find(
+          (value): value is string =>
+            typeof value === 'string' && value.trim().length > 0,
+        );
       if (content === undefined)
         return this.resultError(
           durationMs,

--- a/tests/adapters/parallel.test.ts
+++ b/tests/adapters/parallel.test.ts
@@ -160,58 +160,78 @@ describe('Parallel first-party providers', () => {
     });
   });
 
-  it('maps chat basis only when the response reports it and supports JSON schema output', async () => {
-    const http = client({
-      id: 'chat_record_1',
-      interaction_id: 'interaction_1',
-      model: 'base',
-      choices: [{ message: { content: '{"answer":"yes"}' } }],
-      basis: [
-        {
-          field: 'output',
-          reasoning: 'Confirmed by the source.',
-          confidence: 'high',
-          citations: [
-            { url: 'https://example.test/source', excerpts: ['Evidence.'] },
-          ],
+  it.each(['message', 'delta'] as const)(
+    'maps chat %s content, basis, usage and JSON schema output',
+    async (field) => {
+      const http = client({
+        id: 'chat_record_1',
+        interaction_id: 'interaction_1',
+        model: 'base',
+        choices: [{ [field]: { content: '{"answer":"yes"}' } }],
+        basis: [
+          {
+            field: 'output',
+            reasoning: 'Confirmed by the source.',
+            confidence: 'high',
+            citations: [
+              { url: 'https://example.test/source', excerpts: ['Evidence.'] },
+            ],
+          },
+        ],
+        usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      });
+      const provider = new ParallelChatProvider({
+        apiKey: key,
+        httpClient: http,
+        model: 'base',
+        configuredOptions: {
+          responseFormat: {
+            name: 'answer',
+            schema: { type: 'object' },
+            strict: true,
+          },
         },
-      ],
-      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
-    });
-    const provider = new ParallelChatProvider({
-      apiKey: key,
-      httpClient: http,
-      model: 'base',
-      configuredOptions: {
-        responseFormat: {
-          name: 'answer',
-          schema: { type: 'object' },
-          strict: true,
+      });
+      const result = await provider.execute('question', { timeout: 9 });
+      expect(result.error).toBeUndefined();
+      expect(result).toMatchObject({
+        content: '{"answer":"yes"}',
+        model: 'base',
+        tokenUsage: { input: 11, output: 7 },
+        usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+      });
+      expect(result.citations).toEqual([
+        expect.objectContaining({
+          url: 'https://example.test/source',
+          snippet: 'Evidence.',
+        }),
+      ]);
+      expect(result.providerMeta).toMatchObject({
+        'parallel:interaction_id': 'interaction_1',
+        'parallel:basis_available': true,
+        'parallel:basis': [
+          {
+            field: 'output',
+            reasoning: 'Confirmed by the source.',
+            confidence: 'high',
+            citations: [
+              { url: 'https://example.test/source', excerpts: ['Evidence.'] },
+            ],
+          },
+        ],
+      });
+      const [, request] = (http as unknown as ReturnType<typeof vi.fn>).mock
+        .calls[0] as [string, HttpRequestOptions];
+      expect(request.body).toMatchObject({
+        model: 'base',
+        stream: false,
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'answer', strict: true },
         },
-      },
-    });
-    const result = await provider.execute('question', { timeout: 9 });
-    expect(result.citations).toEqual([
-      expect.objectContaining({
-        url: 'https://example.test/source',
-        snippet: 'Evidence.',
-      }),
-    ]);
-    expect(result.providerMeta).toMatchObject({
-      'parallel:interaction_id': 'interaction_1',
-      'parallel:basis_available': true,
-    });
-    const [, request] = (http as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0] as [string, HttpRequestOptions];
-    expect(request.body).toMatchObject({
-      model: 'base',
-      stream: false,
-      response_format: {
-        type: 'json_schema',
-        json_schema: { name: 'answer', strict: true },
-      },
-    });
-  });
+      });
+    },
+  );
 
   it('does not expose invalid basis URLs in Chat citations or provider metadata', async () => {
     const result = await new ParallelChatProvider({
@@ -317,8 +337,94 @@ describe('Parallel first-party providers', () => {
   );
 
   it.each([
+    [
+      { message: { content: ' Message. ' }, delta: { content: 'Delta.' } },
+      ' Message. ',
+    ],
+    [{ message: { content: 'Same.' }, delta: { content: 'Same.' } }, 'Same.'],
+    [{ message: { content: '' }, delta: { content: ' Delta. ' } }, ' Delta. '],
+    [{ message: { content: ' \n ' }, delta: { content: 'Delta.' } }, 'Delta.'],
+    [
+      { message: { content: 'Message.' }, delta: { content: null } },
+      'Message.',
+    ],
+    [{ message: { content: 'Message.' }, delta: {} }, 'Message.'],
+  ])('selects Chat content deterministically (%o)', async (choice, content) => {
+    const result = await new ParallelChatProvider({
+      apiKey: key,
+      httpClient: client({ choices: [choice] }),
+    }).execute('question', { timeout: 9 });
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe(content);
+    expect(result.providerMeta).toEqual({ 'parallel:basis_available': false });
+  });
+
+  it('selects the first nonblank Chat choice without combining answers', async () => {
+    const result = await new ParallelChatProvider({
+      apiKey: key,
+      httpClient: client({
+        choices: [
+          { delta: { content: null } },
+          { message: { content: ' ' } },
+          { delta: { content: 'First answer.' } },
+          { message: { content: 'Later answer.' } },
+        ],
+      }),
+    }).execute('question', { timeout: 9 });
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe('First answer.');
+  });
+
+  it.each([
     [{ choices: [] }, 'invalid Chat response'],
     [{ choices: [{ message: {} }] }, 'invalid Chat response'],
+    [{ choices: [{ delta: null }] }, 'invalid Chat response'],
+    [{ choices: [{ delta: [] }] }, 'invalid Chat response'],
+    [{ choices: [{ message: 'private-response' }] }, 'invalid Chat response'],
+    [{ choices: [{ delta: 'private-response' }] }, 'invalid Chat response'],
+    ...['message', 'delta'].flatMap((field) =>
+      [42, false, ['private-response'], { text: 'private-response' }].map(
+        (content) => [
+          { choices: [{ [field]: { content } }] },
+          'invalid Chat response',
+        ],
+      ),
+    ),
+    [
+      {
+        choices: [{ message: { content: null }, delta: { content: 'Valid.' } }],
+      },
+      'invalid Chat response',
+    ],
+    [
+      { choices: [{ message: { content: 'Valid.' }, delta: { content: 42 } }] },
+      'invalid Chat response',
+    ],
+    [
+      {
+        choices: [{ delta: { content: 'Valid.' } }],
+        usage: { total_tokens: '18' },
+      },
+      'invalid Chat response',
+    ],
+    [
+      { choices: [{ delta: { content: 'Valid.' } }], basis: {} },
+      'invalid Chat response',
+    ],
+    ...[
+      {},
+      { delta: {} },
+      { delta: { content: null } },
+      { delta: { content: '' } },
+      { delta: { content: ' \n ' } },
+      { message: { content: '' } },
+      { message: { content: ' \n ' } },
+    ].map((choice) => [
+      { choices: [choice], content: 'private-response' },
+      'without message content',
+    ]),
   ])(
     'rejects malformed successful Chat payloads (%o)',
     async (data, message) => {
@@ -334,6 +440,11 @@ describe('Parallel first-party providers', () => {
         error: expect.stringContaining(message),
         failureDiagnostic: { kind: 'provider', httpStatus: 200 },
       });
+      expect(result.failureDiagnostic).toEqual({
+        kind: 'provider',
+        httpStatus: 200,
+      });
+      expect(JSON.stringify(result)).not.toContain('private-response');
     },
   );
 

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -1768,6 +1768,8 @@ describe('frozen paid protocol (injected, zero-network)', () => {
   it.each([
     ['invalid-schema', 'provider_reported_error', 'provider', 'http_200'],
     ['missing-content', 'provider_reported_error', 'provider', 'http_200'],
+    ['empty-text', 'provider_reported_error', 'provider', 'http_200'],
+    ['empty-delta', 'provider_reported_error', 'provider', 'http_200'],
     ['timeout', 'provider_timeout', 'timeout', undefined],
     ['network', 'provider_network_failed', 'network', undefined],
     ['quality-only', undefined, undefined, undefined],
@@ -1797,7 +1799,11 @@ describe('frozen paid protocol (injected, zero-network)', () => {
                   ? []
                   : scenario === 'missing-content'
                     ? [{}]
-                    : [{ message: { content: '' } }],
+                    : scenario === 'empty-text'
+                      ? [{ message: { content: '' } }]
+                      : scenario === 'empty-delta'
+                        ? [{ delta: { content: '' } }]
+                        : [{ delta: { content: 'Answer without citations.' } }],
               error: privateText,
               diagnostics: { secret: privateText },
             },
@@ -1862,7 +1868,8 @@ describe('frozen paid protocol (injected, zero-network)', () => {
         expect(evidence.receipt.lifecycle).toBe('failed');
         expect(evidence.quality).toMatchObject({
           passed: false,
-          content_present: false,
+          content_present: scenario === 'quality-only',
+          citation_requirement_met: false,
         });
         if (expected) expect(evidence.receipt.failure).toEqual(expected);
         else expect(evidence.receipt).not.toHaveProperty('failure');


### PR DESCRIPTION
## Summary
Accept both official Parallel Chat response forms instead of rejecting non-streaming responses that use `choices[].delta.content`.

PlanMode task #3430 (targeted remediation under #2564). Based on exact main `6a7834c58002dad2dcd334b48618ffe83a34dfa1` after PR #166.

## Contract and rationale
- The current [official Chat Completions OpenAPI](https://docs.parallel.ai/api-reference/chat-api-beta/chat-completions) declares non-streaming HTTP 200 `ChatCompletion.choices` using `Choice`, with `delta.content` as string/null.
- The [official Chat quickstart](https://docs.parallel.ai/chat-api/chat-quickstart) instead reads `response.choices[0].message.content`.
- Preserve choice order; within each choice prefer nonblank `message.content`, falling back to nonblank `delta.content`. Conflicting valid strings deterministically select message, without concatenating answers. Preserve the selected string verbatim.
- Null/missing delta content supplies no answer. Empty/whitespace-only content is rejected unless another supported field/choice supplies nonblank text. Existing strict message-field validation remains intact; malformed fields (including a malformed alternate field) fail schema validation. No arbitrary top-level content, arrays, objects, or coercion.
- Invalid schemas and missing usable text preserve the bounded `{kind:"provider",httpStatus:200}` diagnostic. Basis/citations, usage, model, metering, and request behavior are unchanged.

## Tests
All local checks ran with an allowlisted environment (`env -i`, PATH, isolated HOME, CI=true), without provider credentials/calls:
- `npm test -- tests/adapters/parallel.test.ts`: 84 passed; regression tests demonstrated 14 failures before the implementation.
- Focused adapter, execution runtime/authority/plan/phases, and both live-validation regression suites: 262 passed across 7 files.
- `npm test`: 2,292 passed, 7 platform skips, 119 files passed.
- `npm run typecheck`, `npm run lint`, `npm run build`, `git diff --check`: passed.
- Offline live-validation fixture now uses valid delta text without citations to preserve the quality-only versus provider-failure distinction; empty message/delta cases exercise failure projection through the real adapter and persisted canonical run.

## Scope and remaining verification
Self-review completed. No package-lock, public contract, docs, settings, dependency, or release changes. No paid provider verification, certification dispatch, publication, tag, release, or deployment. Full existing Linux/Windows/PTY/macOS/SEA CI must pass on the unchanged PR head before the authorized merge. Live provider behavior remains unverified by this offline remediation.