### PR TITLE
fix(parallel): remove beta chat from v2 shipping support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed beta `parallel/chat` from v2 shipping support after repeated
+  incompatible HTTP-success payloads, including after accepting both documented
+  content shapes. Parallel Search, Turbo, and Research remain supported through
+  their separate Search and Task APIs; this is not a live-validation claim.
+
 ## [2.0.0] - 2026-08-27
 
 Version 2 replaces Librarium's provider, configuration, execution, package,
@@ -109,7 +116,7 @@ and artifact contracts. Review the breaking changes before upgrading from v1.
   Research, Perplexity Agent medium and high, Valyu Research, and You Research.
   Durable work can be resumed across processes using provider-scoped handles.
 - Parallel Search profiles for advanced search and turbo search, plus Parallel
-  Chat and Parallel Research. `parallel/turbo` is included in `quick`.
+  Research. `parallel/turbo` is included in `quick`.
 - Valyu Search and Research, You.com Answer, and expanded You.com Research
   profiles with validated options, lifecycle handling, usage, and citations.
 - Configurable Firecrawl Search for web and news sources, locale and time

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ and diagnostics go to standard error.
 
 ## V2 catalog
 
-The v2 catalog has **33 built-in providers** and **40 implemented public
+The v2 catalog has **33 built-in providers** and **39 implemented public
 profiles**. A profile is the unit of selection and provenance:
 `provider_id/profile_id`. A provider can expose more than one profile, such as
 `exa/search` and the durable `exa/research` profile. Adapter IDs are a Node
@@ -108,7 +108,7 @@ process state remains available. All other profiles are `inline/none`.
 | Kagi | `kagi-fastgpt/grounded` |
 | OpenAI | `openai-research/research` (background/durable), `openai-chat/chat` |
 | OpenRouter | `openrouter/grounded`, `openrouter/chat` |
-| Parallel | `parallel/search`, `parallel/turbo`, `parallel/chat`, `parallel/research` (background/durable) |
+| Parallel | `parallel/search`, `parallel/turbo`, `parallel/research` (background/durable) |
 | Perplexity | `perplexity-search/search` (raw Search, unchanged), `perplexity-sonar-pro/grounded` (Agent low, inline), `perplexity-deep-research/research` (Agent medium, background/durable), `perplexity-sonar-deep/research` (Agent high, background/durable) |
 | SearchAPI | `searchapi/search`, `searchapi-chatgpt/surface`, `searchapi-gemini/surface`, `searchapi-perplexity/surface`, `searchapi-google-ai-mode/surface`, `searchapi-bing-copilot/surface`, `searchapi-google-ai-overview/surface` |
 | SerpAPI | `serpapi/search` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ compatibility: Requires Node.js 22.12 or newer and the Librarium 2.x CLI.
 # Librarium -- Multi-Provider Deep Research
 
 Run research queries through Librarium’s v2 public provider/profile catalog.
-There are 33 built-in providers and 40 implemented profiles. Preserve the
+There are 33 built-in providers and 39 implemented profiles. Preserve the
 profile and collection provenance when reporting results; do not turn source
 counts or agreement into a confidence claim.
 

--- a/benchmark/targets.json
+++ b/benchmark/targets.json
@@ -9,13 +9,6 @@
       "costConfidence": "unknown"
     },
     {
-      "id": "parallel-chat",
-      "tier": "ai-grounded",
-      "envVar": "PARALLEL_API_KEY",
-      "estimatedCostUsd": null,
-      "costConfidence": "unknown"
-    },
-    {
       "id": "parallel-search",
       "tier": "raw-search",
       "envVar": "PARALLEL_API_KEY",
@@ -360,8 +353,7 @@
       "searchapi-perplexity",
       "searchapi-google-ai-mode",
       "searchapi-bing-copilot",
-      "searchapi-google-ai-overview",
-      "parallel-chat"
+      "searchapi-google-ai-overview"
     ],
     "llm": ["claude", "openai-chat", "gemini-chat", "openrouter-chat"],
     "all": [
@@ -396,7 +388,6 @@
       "searchapi-google-ai-mode",
       "searchapi-bing-copilot",
       "searchapi-google-ai-overview",
-      "parallel-chat",
       "parallel-search",
       "parallel-turbo"
     ]

--- a/src/adapters/parallel-options.ts
+++ b/src/adapters/parallel-options.ts
@@ -96,19 +96,6 @@ export const ParallelSearchOptionsSchema = ParallelSearchControlsSchema.extend({
 /** Turbo locks Search API `mode` to `turbo`; callers cannot override it. */
 export const ParallelTurboOptionsSchema = ParallelSearchControlsSchema;
 
-export const ParallelChatOptionsSchema = z
-  .object({
-    responseFormat: z
-      .object({
-        name: z.string().trim().min(1).max(64),
-        schema: z.record(z.string(), z.json()),
-        strict: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict();
-
 export const ParallelResearchOptionsSchema = z
   .object({
     processor: z.enum(['pro', 'pro-fast', 'ultra', 'ultra-fast']).optional(),
@@ -133,7 +120,6 @@ export const ParallelResearchOptionsSchema = z
 
 export type ParallelSearchOptions = z.infer<typeof ParallelSearchOptionsSchema>;
 export type ParallelTurboOptions = z.infer<typeof ParallelTurboOptionsSchema>;
-export type ParallelChatOptions = z.infer<typeof ParallelChatOptionsSchema>;
 export type ParallelResearchOptions = z.infer<
   typeof ParallelResearchOptionsSchema
 >;

--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -1,21 +1,15 @@
 import { z } from 'zod';
 import { OpaqueIdSchema } from '../contracts/common.js';
 import { UnsafeToRetrySubmissionError } from '../core/errors.js';
-import {
-  HttpRequestAbortedError,
-  HttpRequestTimeoutError,
-} from '../core/http-client.js';
 import { normalizeUrl } from '../core/normalizer.js';
 import type {
   AsyncPollResult,
   AsyncTaskHandle,
   AsyncTaskStatus,
   Citation,
-  ProviderFailureDiagnostic,
   ProviderOptions,
   ProviderResult,
   ProviderTier,
-  ProviderUsage,
 } from '../types.js';
 import {
   BackgroundBaseProvider,
@@ -23,7 +17,6 @@ import {
   type BaseProviderOptions,
 } from './base.js';
 import {
-  ParallelChatOptionsSchema,
   ParallelResearchOptionsSchema,
   type ParallelSearchOptions,
   ParallelSearchOptionsSchema,
@@ -32,7 +25,6 @@ import {
 } from './parallel-options.js';
 
 const API = 'https://api.parallel.ai';
-const CHAT_MODELS = new Set(['speed', 'lite', 'base', 'core']);
 const RESEARCH_PROCESSORS = new Set(['pro', 'pro-fast', 'ultra', 'ultra-fast']);
 const STATUS: Record<string, AsyncTaskStatus> = {
   queued: 'pending',
@@ -43,17 +35,6 @@ const STATUS: Record<string, AsyncTaskStatus> = {
   cancelling: 'running',
   cancelled: 'cancelled',
 };
-
-function classifyParallelFailure(
-  status: number,
-): ProviderFailureDiagnostic['kind'] {
-  if (status === 401 || status === 403) return 'authentication';
-  if (status === 402) return 'billing';
-  if (status === 408 || status === 504) return 'timeout';
-  if (status === 429) return 'rate_limit';
-  if (status >= 400 && status < 500) return 'invalid_request';
-  return 'provider';
-}
 
 interface WebResult {
   url?: unknown;
@@ -82,21 +63,6 @@ interface TaskRun {
 interface TaskResult {
   run?: TaskRun;
   output?: { type?: unknown; content?: unknown; basis?: FieldBasis[] };
-}
-interface ChatResponse {
-  id?: string;
-  interaction_id?: string;
-  model?: string;
-  choices?: Array<{
-    message?: { content?: string };
-    delta?: { content?: string | null };
-  }>;
-  basis?: FieldBasis[];
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
 }
 
 const fieldBasisSchema = z
@@ -135,36 +101,6 @@ const searchResponseSchema = z
     ),
     warnings: z.unknown().optional(),
     usage: z.unknown().optional(),
-  })
-  .passthrough();
-
-const chatResponseSchema = z
-  .object({
-    id: z.unknown().optional(),
-    interaction_id: z.unknown().optional(),
-    model: z.unknown().optional(),
-    choices: z
-      .array(
-        z
-          .object({
-            message: z.object({ content: z.string() }).passthrough().optional(),
-            delta: z
-              .object({ content: z.string().nullish() })
-              .passthrough()
-              .optional(),
-          })
-          .passthrough(),
-      )
-      .min(1),
-    basis: z.array(fieldBasisSchema).optional(),
-    usage: z
-      .object({
-        prompt_tokens: z.number().int().nonnegative().optional(),
-        completion_tokens: z.number().int().nonnegative().optional(),
-        total_tokens: z.number().int().nonnegative().optional(),
-      })
-      .passthrough()
-      .optional(),
   })
   .passthrough();
 
@@ -469,143 +405,6 @@ export class ParallelTurboProvider extends ParallelSearchProvider {
   }
 }
 
-export class ParallelChatProvider extends BaseProvider {
-  readonly id = 'parallel-chat';
-  readonly tier: ProviderTier = 'ai-grounded';
-  readonly model: string;
-  constructor(
-    options: BaseProviderOptions & {
-      model?: string;
-      configuredOptions?: unknown;
-    } = {},
-  ) {
-    super(options);
-    this.model = options.model?.trim() || 'base';
-    this.options = options.configuredOptions ?? {};
-  }
-  private readonly options: unknown;
-  async execute(
-    query: string,
-    options: ProviderOptions,
-  ): Promise<ProviderResult> {
-    const start = performance.now();
-    const parsed = ParallelChatOptionsSchema.safeParse(this.options);
-    if (!parsed.success || !CHAT_MODELS.has(this.model))
-      return {
-        provider: this.id,
-        tier: this.tier,
-        content: '',
-        citations: [],
-        durationMs: Math.round(performance.now() - start),
-        error: !parsed.success
-          ? `parallel-chat options: ${parsed.error.message}`
-          : 'parallel-chat model must be one of: speed, lite, base, core',
-      };
-    try {
-      const response = await this.request<ChatResponse>(
-        `${API}/v1beta/chat/completions`,
-        {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${this.getApiKey()}` },
-          body: {
-            model: this.model,
-            messages: [{ role: 'user', content: query }],
-            stream: false,
-            ...(parsed.data.responseFormat && {
-              response_format: {
-                type: 'json_schema',
-                json_schema: parsed.data.responseFormat,
-              },
-            }),
-          },
-          timeout: options.timeout * 1000,
-          signal: options.signal,
-        },
-      );
-      const durationMs = Math.round(performance.now() - start);
-      if (response.status < 200 || response.status >= 300)
-        return this.resultError(
-          durationMs,
-          this.formatError(response.status, response.data),
-          {
-            kind: classifyParallelFailure(response.status),
-            httpStatus: response.status,
-          },
-        );
-      const parsedResponse = chatResponseSchema.safeParse(response.data);
-      if (!parsedResponse.success)
-        return this.resultError(
-          durationMs,
-          'Parallel returned an invalid Chat response',
-          { kind: 'provider', httpStatus: response.status },
-        );
-      const content = parsedResponse.data.choices
-        .flatMap((choice) => [choice.message?.content, choice.delta?.content])
-        .find(
-          (value): value is string =>
-            typeof value === 'string' && value.trim().length > 0,
-        );
-      if (content === undefined)
-        return this.resultError(
-          durationMs,
-          'Parallel returned a Chat response without message content',
-          { kind: 'provider', httpStatus: response.status },
-        );
-      const basis = basisMeta(parsedResponse.data.basis);
-      return {
-        provider: this.id,
-        tier: this.tier,
-        content,
-        citations: citationsFromBasis(parsedResponse.data.basis, this.id),
-        durationMs,
-        model: text(parsedResponse.data.model) ?? this.model,
-        tokenUsage: {
-          input: parsedResponse.data.usage?.prompt_tokens,
-          output: parsedResponse.data.usage?.completion_tokens,
-        },
-        usage: usage(parsedResponse.data.usage),
-        providerMeta: {
-          ...(text(parsedResponse.data.interaction_id) && {
-            'parallel:interaction_id': text(parsedResponse.data.interaction_id),
-          }),
-          ...(basis && { 'parallel:basis': basis }),
-          'parallel:basis_available': parsedResponse.data.basis !== undefined,
-        },
-      };
-    } catch (error) {
-      return this.resultError(
-        Math.round(performance.now() - start),
-        this.formatCatchError(error),
-        {
-          kind:
-            error instanceof HttpRequestTimeoutError ||
-            error instanceof HttpRequestAbortedError ||
-            (error instanceof DOMException && error.name === 'AbortError')
-              ? 'timeout'
-              : error instanceof TypeError
-                ? 'network'
-                : 'provider',
-        },
-      );
-    }
-  }
-  private resultError(
-    durationMs: number,
-    error: string,
-    failureDiagnostic?: ProviderFailureDiagnostic,
-  ): ProviderResult {
-    return {
-      provider: this.id,
-      tier: this.tier,
-      content: '',
-      citations: [],
-      durationMs,
-      error,
-      ...(failureDiagnostic && { failureDiagnostic }),
-    };
-  }
-}
-
 export class ParallelResearchProvider extends BackgroundBaseProvider {
   readonly id = 'parallel-research';
   readonly tier: ProviderTier = 'deep-research';
@@ -845,14 +644,4 @@ export class ParallelResearchProvider extends BackgroundBaseProvider {
       error,
     };
   }
-}
-
-function usage(value: ChatResponse['usage']): ProviderUsage | undefined {
-  return value
-    ? {
-        inputTokens: value.prompt_tokens,
-        outputTokens: value.completion_tokens,
-        totalTokens: value.total_tokens,
-      }
-    : undefined;
 }

--- a/src/adapters/provider-descriptors.ts
+++ b/src/adapters/provider-descriptors.ts
@@ -11,7 +11,6 @@ import {
   openRouterGroundedOptions,
   openRouterOptions as openRouterOptionsSchema,
   type ProviderDescriptorDefinition,
-  parallelChatOptions,
   parallelResearchOptions,
   parallelSearchOptions,
   parallelTurboOptions,
@@ -51,7 +50,6 @@ import type { OpenRouterProviderOptions } from './openrouter.js';
 import { OpenRouterChatProvider } from './openrouter-chat.js';
 import { OpenRouterOnlineProvider } from './openrouter-online.js';
 import {
-  ParallelChatProvider,
   ParallelResearchProvider,
   ParallelSearchProvider,
   ParallelTurboProvider,
@@ -195,7 +193,6 @@ function parallelOptions<
   T extends z.output<
     | typeof parallelSearchOptions
     | typeof parallelTurboOptions
-    | typeof parallelChatOptions
     | typeof parallelResearchOptions
   >,
 >(
@@ -218,14 +215,6 @@ const factories: Record<string, ProviderFactory> = {
       new ParallelResearchProvider({
         model:
           configuredModel(context) ?? context.options.processor ?? undefined,
-        configuredOptions: parallelOptions(context.options),
-      }),
-  ),
-  'parallel-chat': typedFactory(
-    parallelChatOptions,
-    (context) =>
-      new ParallelChatProvider({
-        model: configuredModel(context),
         configuredOptions: parallelOptions(context.options),
       }),
   ),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -389,7 +389,6 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'searchapi-google-ai-mode',
     'searchapi-bing-copilot',
     'searchapi-google-ai-overview',
-    'parallel-chat',
   ],
   // Generic LLMs (tier `llm`). Opt-in only: excluded from every default
   // grounded group above and from `all`. They can use provider web search and
@@ -430,7 +429,6 @@ export const DEFAULT_GROUPS: Record<string, string[]> = {
     'searchapi-google-ai-mode',
     'searchapi-bing-copilot',
     'searchapi-google-ai-overview',
-    'parallel-chat',
     'parallel-search',
     'parallel-turbo',
   ],

--- a/src/core/pricing-snapshot.ts
+++ b/src/core/pricing-snapshot.ts
@@ -107,13 +107,6 @@ const DEFINITIONS: readonly PriceDefinitionInput[] = [
     rates: [rate('processor_requests', '0.1')],
     reference: 'official:docs.parallel.ai/getting-started/pricing',
   }),
-  definition('parallel', 'chat', {
-    target: { kind: 'model', target_id: 'base' },
-    expected: ['requests'],
-    fixed: { requests: '1' },
-    rates: [rate('requests', '0.01')],
-    reference: 'official:docs.parallel.ai/getting-started/pricing',
-  }),
   unavailable(
     'parallel',
     'search',
@@ -439,6 +432,6 @@ export const BUILTIN_PRICING_SNAPSHOT: PricingSnapshotInput =
     reviewed_at: REVIEWED_AT,
     currency: 'USD',
     fingerprint:
-      'sha256:7d0bb6bf5049bb68bdf3c5836fd57eb2f6d73b262911e736f5d36cfb48019d5a',
+      'sha256:87f793e4b1f2fdccb17f36c8fb1fb523ea82949ccae2030cab05f0e244ef986d',
     definitions: DEFINITIONS,
   });

--- a/src/core/profile-bindings.ts
+++ b/src/core/profile-bindings.ts
@@ -74,7 +74,6 @@ const MODEL_OVERRIDE_ALLOWLISTS: Readonly<Record<string, ReadonlySet<string>>> =
   {
     'gemini-grounded': new Set(['gemini-2.5-flash', 'gemini-2.5-pro']),
     'openrouter-online': new Set(['openai/gpt-4o-mini', 'openai/gpt-4o']),
-    'parallel-chat': new Set(['speed', 'lite', 'base', 'core']),
     'parallel-research': new Set(['pro', 'pro-fast', 'ultra', 'ultra-fast']),
   };
 
@@ -408,7 +407,6 @@ export const BUILTIN_PROFILE_BINDING_SPECS: readonly BindingSpec[] = [
     adapter_id: 'parallel-research',
     project: parallelResearchTargetProjection,
   },
-  { provider_id: 'parallel', profile_id: 'chat', adapter_id: 'parallel-chat' },
   {
     provider_id: 'parallel',
     profile_id: 'search',

--- a/src/core/provider-descriptor.ts
+++ b/src/core/provider-descriptor.ts
@@ -5,7 +5,6 @@ import {
   grokXOnlyOptionsSchema,
 } from '../adapters/grok-options.js';
 import {
-  ParallelChatOptionsSchema,
   ParallelResearchOptionsSchema,
   ParallelSearchOptionsSchema,
   ParallelTurboOptionsSchema,
@@ -160,9 +159,6 @@ export const parallelSearchOptions = commonOptions.merge(
 );
 export const parallelTurboOptions = commonOptions.merge(
   ParallelTurboOptionsSchema,
-);
-export const parallelChatOptions = commonOptions.merge(
-  ParallelChatOptionsSchema,
 );
 export const parallelResearchOptions = commonOptions.merge(
   ParallelResearchOptionsSchema,
@@ -389,26 +385,6 @@ export const BUILTIN_PROVIDER_DEFINITIONS = [
     },
     metering: { kind: 'api_unit_priced', unit: 'processor request' },
     capabilities: background(),
-    autoEnable: false,
-  }),
-  define({
-    id: 'parallel-chat',
-    registrationOrder: 20.5,
-    tier: 'ai-grounded',
-    envVar: 'PARALLEL_API_KEY',
-    defaultModel: 'base',
-    optionsSchema: parallelChatOptions,
-    display: {
-      family: 'Parallel',
-      name: 'Parallel Chat',
-      description:
-        'Parallel Chat API answers with model-dependent research basis.',
-      bestFor: 'First-party Parallel chat and structured output.',
-      setupUrl: 'https://docs.parallel.ai/chat-api/chat-quickstart',
-      order: 285,
-    },
-    metering: { kind: 'api_unit_priced', unit: 'request' },
-    capabilities: inline('always'),
     autoEnable: false,
   }),
   define({

--- a/src/core/provider-profiles.ts
+++ b/src/core/provider-profiles.ts
@@ -1150,8 +1150,7 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
     display: {
       family: 'Parallel',
       name: 'Parallel',
-      description:
-        'Parallel search, turbo, chat, and research APIs for agents.',
+      description: 'Parallel search, turbo, and research APIs for agents.',
       best_for: 'First-party Parallel retrieval and task execution.',
       setup_url: 'https://docs.parallel.ai/',
     },
@@ -1181,18 +1180,6 @@ export const BUILTIN_PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
         operator_id: 'parallel',
         status: 'implemented',
         workflows: ['quick'],
-      }),
-      declare({
-        profile_id: 'chat',
-        selection_order: 540,
-        target: configurableTarget('model', 'base'),
-        result_kind: 'grounded_answer',
-        grounding_policy: 'optional',
-        corpora: ['web'],
-        retrieval_method: 'model_search_tool',
-        operator_id: 'parallel',
-        status: 'implemented',
-        features: { json_schema_output: true, web_search: 'always' },
       }),
       declare({
         profile_id: 'research',

--- a/src/node-live-validation-binding.ts
+++ b/src/node-live-validation-binding.ts
@@ -412,7 +412,7 @@ function verifyRcInstalledMatrix(value: unknown): void {
     'RC installed-package matrix',
   );
   if (
-    matrix.target_count !== 40 ||
+    matrix.target_count !== 39 ||
     typeof matrix.catalog_digest !== 'string' ||
     !/^fnv1a64\.1:[0-9a-f]{16}$/.test(matrix.catalog_digest) ||
     typeof matrix.pricing_snapshot_fingerprint !== 'string' ||
@@ -420,7 +420,7 @@ function verifyRcInstalledMatrix(value: unknown): void {
     typeof matrix.matrix_fingerprint !== 'string' ||
     !/^sha256:[0-9a-f]{64}$/.test(matrix.matrix_fingerprint) ||
     !Array.isArray(matrix.targets) ||
-    matrix.targets.length !== 40
+    matrix.targets.length !== 39
   ) {
     throw new CanonicalLiveValidationError(
       'RC installed-package matrix identity is invalid.',
@@ -470,7 +470,7 @@ function verifyRcInstalledMatrix(value: unknown): void {
     return target.key;
   });
   if (
-    new Set(keys).size !== 40 ||
+    new Set(keys).size !== 39 ||
     JSON.stringify(keys) !== JSON.stringify([...keys].sort(rcCompareText)) ||
     sha256Bytes(
       rcCanonicalJson({

--- a/src/node-live-validation-production.ts
+++ b/src/node-live-validation-production.ts
@@ -181,12 +181,12 @@ export function productionValidationMatrix(
     (target) => `${target.key}:${target.binding_id}:${target.adapter_id}`,
   );
   if (
-    matrix.targets.length !== 40 ||
-    new Set(actualInventory).size !== 40 ||
+    matrix.targets.length !== 39 ||
+    new Set(actualInventory).size !== 39 ||
     JSON.stringify(actualInventory) !== JSON.stringify(expectedInventory)
   ) {
     throw new CanonicalLiveValidationError(
-      'Production paid validation requires the exact 40-target canonical binding inventory.',
+      'Production paid validation requires the exact 39-target canonical binding inventory.',
     );
   }
   return matrix;

--- a/src/node-release-candidate.ts
+++ b/src/node-release-candidate.ts
@@ -83,7 +83,7 @@ export interface ReleaseMatrixTarget {
 }
 
 export interface ReleaseMatrixIdentity {
-  readonly target_count: 40;
+  readonly target_count: 39;
   readonly catalog_digest: string;
   readonly pricing_snapshot_fingerprint: string;
   readonly matrix_fingerprint: string;
@@ -749,7 +749,7 @@ function parseMatrixCore(
   if (!Array.isArray(targetsValue)) {
     fail(labels.targetsArray);
   }
-  if (declaredTargetCount !== 40) {
+  if (declaredTargetCount !== 39) {
     fail(labels.count);
   }
   const targets = targetsValue.map((targetValue, index) => {
@@ -814,8 +814,8 @@ function parseMatrixCore(
   });
   const keys = targets.map((target) => target.key);
   if (
-    targets.length !== 40 ||
-    new Set(keys).size !== 40 ||
+    targets.length !== 39 ||
+    new Set(keys).size !== 39 ||
     canonicalJson(keys) !== canonicalJson([...keys].sort(compareText))
   ) {
     fail(labels.ordering);
@@ -846,7 +846,7 @@ function parseMatrixCore(
     fail(labels.fingerprintMismatch);
   }
   return {
-    target_count: 40,
+    target_count: 39,
     catalog_digest: catalog,
     pricing_snapshot_fingerprint: pricing,
     matrix_fingerprint: fingerprint,
@@ -872,7 +872,7 @@ function matrixIdentity(value: unknown): ReleaseMatrixIdentity {
   }
   return parseMatrixCore(
     matrix.targets,
-    40,
+    39,
     matrix.catalog_digest,
     matrix.pricing_snapshot_fingerprint,
     matrix.fingerprint,
@@ -881,16 +881,16 @@ function matrixIdentity(value: unknown): ReleaseMatrixIdentity {
       targetField: (_index, key, field) =>
         key ? `${key} ${field}` : `Canonical matrix target ${_index} ${field}`,
       targetsArray: 'Canonical matrix targets must be an array.',
-      count: 'Release candidate requires the exact sorted 40-profile matrix.',
+      count: 'Release candidate requires the exact sorted 39-profile matrix.',
       ordering:
-        'Release candidate requires the exact sorted 40-profile matrix.',
+        'Release candidate requires the exact sorted 39-profile matrix.',
       catalog: 'Canonical catalog digest',
       pricing: 'Canonical pricing snapshot fingerprint',
       consistency:
         'Canonical target matrix fingerprints differ from their matrix.',
       fingerprint: 'Canonical matrix fingerprint',
       fingerprintMismatch:
-        'Canonical matrix fingerprint does not match its exact 40 targets.',
+        'Canonical matrix fingerprint does not match its exact 39 targets.',
     },
   );
 }
@@ -918,9 +918,9 @@ function parseMatrixIdentity(value: unknown): ReleaseMatrixIdentity {
       targetRecord: (index) => `Frozen installed-package target ${index}`,
       targetField: (index, _key, field) => `Frozen target ${index} ${field}`,
       targetsArray:
-        'Frozen installed-package identity must contain exactly 40 targets.',
+        'Frozen installed-package identity must contain exactly 39 targets.',
       count:
-        'Frozen installed-package identity must contain exactly 40 targets.',
+        'Frozen installed-package identity must contain exactly 39 targets.',
       ordering: 'Frozen installed-package targets must be unique and sorted.',
       catalog: 'Frozen catalog digest',
       pricing: 'Frozen pricing snapshot fingerprint',
@@ -928,7 +928,7 @@ function parseMatrixIdentity(value: unknown): ReleaseMatrixIdentity {
         'Frozen target matrix fingerprints differ from their matrix.',
       fingerprint: 'Frozen matrix fingerprint',
       fingerprintMismatch:
-        'Frozen matrix fingerprint does not match its exact 40 targets.',
+        'Frozen matrix fingerprint does not match its exact 39 targets.',
     },
   );
 }

--- a/tests/adapters/parallel.test.ts
+++ b/tests/adapters/parallel.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  ParallelChatProvider,
   ParallelResearchProvider,
   ParallelSearchProvider,
   ParallelTurboProvider,
@@ -9,7 +8,6 @@ import type {
   HttpClient,
   HttpRequestOptions,
 } from '../../src/core/http-client.js';
-import { normalizeProviderAttemptOutput } from '../../src/core/research-response-projector.js';
 
 const key = 'parallel-fixture-key';
 
@@ -160,97 +158,30 @@ describe('Parallel first-party providers', () => {
     });
   });
 
-  it.each(['message', 'delta'] as const)(
-    'maps chat %s content, basis, usage and JSON schema output',
-    async (field) => {
-      const http = client({
-        id: 'chat_record_1',
-        interaction_id: 'interaction_1',
-        model: 'base',
-        choices: [{ [field]: { content: '{"answer":"yes"}' } }],
-        basis: [
-          {
-            field: 'output',
-            reasoning: 'Confirmed by the source.',
-            confidence: 'high',
-            citations: [
-              { url: 'https://example.test/source', excerpts: ['Evidence.'] },
-            ],
-          },
-        ],
-        usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
-      });
-      const provider = new ParallelChatProvider({
-        apiKey: key,
-        httpClient: http,
-        model: 'base',
-        configuredOptions: {
-          responseFormat: {
-            name: 'answer',
-            schema: { type: 'object' },
-            strict: true,
-          },
-        },
-      });
-      const result = await provider.execute('question', { timeout: 9 });
-      expect(result.error).toBeUndefined();
-      expect(result).toMatchObject({
-        content: '{"answer":"yes"}',
-        model: 'base',
-        tokenUsage: { input: 11, output: 7 },
-        usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
-      });
-      expect(result.citations).toEqual([
-        expect.objectContaining({
-          url: 'https://example.test/source',
-          snippet: 'Evidence.',
-        }),
-      ]);
-      expect(result.providerMeta).toMatchObject({
-        'parallel:interaction_id': 'interaction_1',
-        'parallel:basis_available': true,
-        'parallel:basis': [
-          {
-            field: 'output',
-            reasoning: 'Confirmed by the source.',
-            confidence: 'high',
-            citations: [
-              { url: 'https://example.test/source', excerpts: ['Evidence.'] },
-            ],
-          },
-        ],
-      });
-      const [, request] = (http as unknown as ReturnType<typeof vi.fn>).mock
-        .calls[0] as [string, HttpRequestOptions];
-      expect(request.body).toMatchObject({
-        model: 'base',
-        stream: false,
-        response_format: {
-          type: 'json_schema',
-          json_schema: { name: 'answer', strict: true },
-        },
-      });
-    },
-  );
-
-  it('does not expose invalid basis URLs in Chat citations or provider metadata', async () => {
-    const result = await new ParallelChatProvider({
+  it('keeps unsafe basis URLs out of Task citations and metadata', async () => {
+    const result = await new ParallelResearchProvider({
       apiKey: key,
       httpClient: client({
-        choices: [{ message: { content: 'Response.' } }],
-        basis: [
-          {
-            citations: [
-              { url: 'javascript:alert(1)', excerpts: ['Unsafe.'] },
-              { url: 'https://user:pass@example.test', excerpts: ['Unsafe.'] },
-              { url: 'https://example.test/safe', excerpts: ['Safe.'] },
-            ],
-          },
-        ],
+        run: { run_id: 'trun_1', status: 'completed' },
+        output: {
+          type: 'text',
+          content: 'Research report.',
+          basis: [
+            {
+              citations: [
+                { url: 'javascript:alert(1)', excerpts: ['Unsafe.'] },
+                {
+                  url: 'https://user:pass@example.test',
+                  excerpts: ['Unsafe.'],
+                },
+                { url: 'https://example.test/safe', excerpts: ['Safe.'] },
+              ],
+            },
+          ],
+        },
       }),
-      model: 'base',
-    }).execute('question', { timeout: 9 });
-
+    }).retrieve({ taskId: 'trun_1' } as never);
+    expect(result.error).toBeUndefined();
     expect(result.citations).toEqual([
       expect.objectContaining({ url: 'https://example.test/safe' }),
     ]);
@@ -263,202 +194,6 @@ describe('Parallel first-party providers', () => {
         }),
       ],
     });
-  });
-
-  it('uses a configured model when the documented compatibility field is empty and persists the canonical result', async () => {
-    const provider = new ParallelChatProvider({
-      apiKey: key,
-      httpClient: client({
-        id: 'chat_record_2',
-        interaction_id: 'interaction_2',
-        model: '',
-        choices: [{ message: { content: 'Compatible response.' } }],
-      }),
-      model: 'base',
-    });
-
-    const result = await provider.execute('question', { timeout: 9 });
-    expect(result).toMatchObject({
-      content: 'Compatible response.',
-      model: 'base',
-      providerMeta: { 'parallel:interaction_id': 'interaction_2' },
-    });
-    expect(result.providerMeta).not.toHaveProperty('parallel:id');
-    expect(
-      normalizeProviderAttemptOutput(
-        { binding: { adapter_id: 'parallel-chat' } } as never,
-        'result-1',
-        result,
-        '2026-08-12T00:00:00.000Z',
-      ),
-    ).toMatchObject({ content: 'Compatible response.', model: 'base' });
-  });
-
-  it('does not conflate a chat record id with an interaction id', async () => {
-    const result = await new ParallelChatProvider({
-      apiKey: key,
-      httpClient: client({
-        id: 'chat_record_only',
-        model: 'base',
-        choices: [{ message: { content: 'Response.' } }],
-      }),
-      model: 'base',
-    }).execute('question', { timeout: 9 });
-
-    expect(result.error).toBeUndefined();
-    expect(result.providerMeta).not.toHaveProperty('parallel:interaction_id');
-  });
-
-  it.each([
-    [400, 'invalid_request'],
-    [401, 'authentication'],
-    [403, 'authentication'],
-    [402, 'billing'],
-    [408, 'timeout'],
-    [429, 'rate_limit'],
-    [500, 'provider'],
-    [504, 'timeout'],
-  ] as const)(
-    'records bounded diagnostics for HTTP %i Chat failures',
-    async (status, kind) => {
-      const result = await new ParallelChatProvider({
-        apiKey: key,
-        httpClient: client({ error: { message: 'provider detail' } }, status),
-        model: 'base',
-      }).execute('question', { timeout: 9 });
-
-      expect(result).toMatchObject({
-        content: '',
-        citations: [],
-        failureDiagnostic: { kind, httpStatus: status },
-      });
-      expect(result.failureDiagnostic).not.toHaveProperty('message');
-    },
-  );
-
-  it.each([
-    [
-      { message: { content: ' Message. ' }, delta: { content: 'Delta.' } },
-      ' Message. ',
-    ],
-    [{ message: { content: 'Same.' }, delta: { content: 'Same.' } }, 'Same.'],
-    [{ message: { content: '' }, delta: { content: ' Delta. ' } }, ' Delta. '],
-    [{ message: { content: ' \n ' }, delta: { content: 'Delta.' } }, 'Delta.'],
-    [
-      { message: { content: 'Message.' }, delta: { content: null } },
-      'Message.',
-    ],
-    [{ message: { content: 'Message.' }, delta: {} }, 'Message.'],
-  ])('selects Chat content deterministically (%o)', async (choice, content) => {
-    const result = await new ParallelChatProvider({
-      apiKey: key,
-      httpClient: client({ choices: [choice] }),
-    }).execute('question', { timeout: 9 });
-
-    expect(result.error).toBeUndefined();
-    expect(result.content).toBe(content);
-    expect(result.providerMeta).toEqual({ 'parallel:basis_available': false });
-  });
-
-  it('selects the first nonblank Chat choice without combining answers', async () => {
-    const result = await new ParallelChatProvider({
-      apiKey: key,
-      httpClient: client({
-        choices: [
-          { delta: { content: null } },
-          { message: { content: ' ' } },
-          { delta: { content: 'First answer.' } },
-          { message: { content: 'Later answer.' } },
-        ],
-      }),
-    }).execute('question', { timeout: 9 });
-
-    expect(result.error).toBeUndefined();
-    expect(result.content).toBe('First answer.');
-  });
-
-  it.each([
-    [{ choices: [] }, 'invalid Chat response'],
-    [{ choices: [{ message: {} }] }, 'invalid Chat response'],
-    [{ choices: [{ delta: null }] }, 'invalid Chat response'],
-    [{ choices: [{ delta: [] }] }, 'invalid Chat response'],
-    [{ choices: [{ message: 'private-response' }] }, 'invalid Chat response'],
-    [{ choices: [{ delta: 'private-response' }] }, 'invalid Chat response'],
-    ...['message', 'delta'].flatMap((field) =>
-      [42, false, ['private-response'], { text: 'private-response' }].map(
-        (content) => [
-          { choices: [{ [field]: { content } }] },
-          'invalid Chat response',
-        ],
-      ),
-    ),
-    [
-      {
-        choices: [{ message: { content: null }, delta: { content: 'Valid.' } }],
-      },
-      'invalid Chat response',
-    ],
-    [
-      { choices: [{ message: { content: 'Valid.' }, delta: { content: 42 } }] },
-      'invalid Chat response',
-    ],
-    [
-      {
-        choices: [{ delta: { content: 'Valid.' } }],
-        usage: { total_tokens: '18' },
-      },
-      'invalid Chat response',
-    ],
-    [
-      { choices: [{ delta: { content: 'Valid.' } }], basis: {} },
-      'invalid Chat response',
-    ],
-    ...[
-      {},
-      { delta: {} },
-      { delta: { content: null } },
-      { delta: { content: '' } },
-      { delta: { content: ' \n ' } },
-      { message: { content: '' } },
-      { message: { content: ' \n ' } },
-    ].map((choice) => [
-      { choices: [choice], content: 'private-response' },
-      'without message content',
-    ]),
-  ])(
-    'rejects malformed successful Chat payloads (%o)',
-    async (data, message) => {
-      const result = await new ParallelChatProvider({
-        apiKey: key,
-        httpClient: client(data),
-        model: 'base',
-      }).execute('question', { timeout: 9 });
-
-      expect(result).toMatchObject({
-        content: '',
-        citations: [],
-        error: expect.stringContaining(message),
-        failureDiagnostic: { kind: 'provider', httpStatus: 200 },
-      });
-      expect(result.failureDiagnostic).toEqual({
-        kind: 'provider',
-        httpStatus: 200,
-      });
-      expect(JSON.stringify(result)).not.toContain('private-response');
-    },
-  );
-
-  it('records a bounded network diagnostic for Chat transport failures', async () => {
-    const result = await new ParallelChatProvider({
-      apiKey: key,
-      httpClient: vi.fn(async () => {
-        throw new TypeError('private network detail');
-      }) as unknown as HttpClient,
-      model: 'base',
-    }).execute('question', { timeout: 9 });
-
-    expect(result.failureDiagnostic).toEqual({ kind: 'network' });
-    expect(result.failureDiagnostic).not.toHaveProperty('message');
   });
 
   it('has durable Task create, poll, retrieve and terminal mapping', async () => {

--- a/tests/benchmark.test.ts
+++ b/tests/benchmark.test.ts
@@ -91,7 +91,7 @@ describe('benchmark corpus and target catalog', () => {
     const targets = allTargets(catalog);
     expect(
       targets.filter((target) => target.type === 'individual-provider'),
-    ).toHaveLength(38);
+    ).toHaveLength(37);
     expect(
       targets.filter((target) => target.type === 'built-in-group'),
     ).toHaveLength(8);

--- a/tests/configuration-mapping.test.ts
+++ b/tests/configuration-mapping.test.ts
@@ -703,43 +703,6 @@ describe('configuration mapping', () => {
     });
   });
 
-  it.each([true, false])(
-    'does not inject llmWebSearch=%s into Parallel Chat',
-    (llmWebSearch) => {
-      const mapped = map(
-        config({
-          defaults: { llmWebSearch },
-          providers: { 'parallel-chat': { enabled: true } },
-        }),
-        { requestDeadlineMs: 2_000_000, credentials: credentials() },
-      );
-
-      const parallelChat = mapped.catalog.get('parallel', 'chat');
-      expect(parallelChat?.availability.configuration_valid).toBe(true);
-      expect(parallelChat?.profile.result_kind).toBe('grounded_answer');
-    },
-  );
-
-  it.each([true, false])(
-    'still rejects an explicit unsupported Parallel Chat webSearch=%s option',
-    (webSearch) => {
-      const mapped = map(
-        config({
-          providers: {
-            'parallel-chat': { enabled: true, options: { webSearch } },
-          },
-        }),
-        { requestDeadlineMs: 2_000_000, credentials: credentials() },
-      );
-
-      const parallelChat = mapped.catalog.get('parallel', 'chat');
-      expect(parallelChat?.availability.configuration_valid).toBe(false);
-      expect(parallelChat?.availability.reasons).toContain(
-        'configuration_invalid',
-      );
-    },
-  );
-
   it.each([
     ['claude', 'claude'],
     ['openai-chat', 'openai-chat'],

--- a/tests/default-groups.test.ts
+++ b/tests/default-groups.test.ts
@@ -108,7 +108,7 @@ describe('default groups -- visibility expansion', () => {
 
   it('has eight default groups and all 33 grounded providers', () => {
     expect(Object.keys(DEFAULT_GROUPS)).toHaveLength(8);
-    expect(DEFAULT_GROUPS.all).toHaveLength(34);
+    expect(DEFAULT_GROUPS.all).toHaveLength(33);
   });
 });
 

--- a/tests/fixtures/provider-conformance.ts
+++ b/tests/fixtures/provider-conformance.ts
@@ -189,8 +189,4 @@ export const PROVIDER_CONFORMANCE_EVIDENCE: Readonly<
     evidence: ['tests/adapters/llm-providers.test.ts'],
     lanes: [...base, 'options'],
   },
-  'parallel/chat': {
-    evidence: ['tests/adapters/parallel.test.ts'],
-    lanes: [...grounded, 'options'],
-  },
 };

--- a/tests/init-provider-choices.test.ts
+++ b/tests/init-provider-choices.test.ts
@@ -24,7 +24,6 @@ const NEW_OPT_IN_PROVIDERS = [
 
 const PARALLEL_OPT_IN_PROVIDERS = [
   'parallel-research',
-  'parallel-chat',
   'parallel-search',
   'parallel-turbo',
 ] as const;

--- a/tests/node-live-validation-production.test.ts
+++ b/tests/node-live-validation-production.test.ts
@@ -265,7 +265,6 @@ describe('production live-validation binding (injected, offline)', () => {
       'grok-combined/combined',
       'grok-x-only/x',
       'grok/web',
-      'parallel/chat',
       'parallel/research',
       'perplexity-deep-research/research',
       'perplexity-sonar-deep/research',
@@ -548,11 +547,14 @@ describe('production live-validation binding (injected, offline)', () => {
 });
 
 describe('production paid matrix and candidate attribution', () => {
-  it('requires the exact canonical 40-target binding inventory', () => {
+  it('requires the exact canonical 39-target binding inventory', () => {
     const matrix = productionValidationMatrix(
       loadConfig(join(tmpdir(), 'librarium-missing-matrix-config.json')),
     );
-    expect(matrix.targets).toHaveLength(40);
+    expect(matrix.targets).toHaveLength(39);
+    expect(matrix.targets.map((target) => target.key)).not.toContain(
+      'parallel/chat',
+    );
     expect(matrix.targets.map((target) => target.key)).toStrictEqual(
       buildCanonicalValidationMatrix().targets.map((target) => target.key),
     );
@@ -575,7 +577,7 @@ describe('production paid matrix and candidate attribution', () => {
       (target) => target.key === search.key,
     );
 
-    expect(optionBound.targets).toHaveLength(40);
+    expect(optionBound.targets).toHaveLength(39);
     expect(optionBound.catalog_digest).not.toBe(baseline.catalog_digest);
     expect(boundSearch?.catalog_digest).toBe(optionBound.catalog_digest);
   });

--- a/tests/node-live-validation.test.ts
+++ b/tests/node-live-validation.test.ts
@@ -12,8 +12,7 @@ import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ParallelChatProvider } from '../src/adapters/parallel.js';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createCliProgram } from '../src/cli-program.js';
 import {
   type ApprovalGate,
@@ -35,10 +34,6 @@ import {
 } from '../src/commands/live-validation.js';
 import type { PreparedResearchExecution } from '../src/core/execution-plan.js';
 import { profileIdentityKey } from '../src/core/execution-plan.js';
-import {
-  type HttpClient,
-  HttpRequestTimeoutError,
-} from '../src/core/http-client.js';
 import { BUILTIN_PRICING_SNAPSHOT } from '../src/core/pricing-snapshot.js';
 import { buildProviderCatalog } from '../src/core/profile-catalog.js';
 import {
@@ -87,10 +82,12 @@ afterEach(() => {
 });
 
 describe('canonical v3 live validation matrix', () => {
-  it('derives the exact implemented 40-profile matrix, including durable private adapters', () => {
+  it('derives the exact implemented 39-profile matrix, including durable private adapters', () => {
     const matrix = buildCanonicalValidationMatrix();
-    expect(matrix.targets.length).toBeGreaterThan(0);
-    expect(matrix.targets.length).toBeLessThanOrEqual(40);
+    expect(matrix.targets).toHaveLength(39);
+    expect(matrix.targets.map((target) => target.key)).not.toContain(
+      'parallel/chat',
+    );
     expect(matrix.targets.map((target) => target.key)).toContain(
       'exa/research',
     );
@@ -106,10 +103,10 @@ describe('canonical v3 live validation matrix', () => {
       adapter_id: 'exa-research',
       credential_family: 'EXA_API_KEY',
     });
-    expect(new Set(matrix.targets.map((target) => target.key)).size).toBe(40);
+    expect(new Set(matrix.targets.map((target) => target.key)).size).toBe(39);
     expect(
       new Set(matrix.targets.map((target) => target.adapter_id)).size,
-    ).toBe(40);
+    ).toBe(39);
   });
 
   it('admits only one exact prepared canonical profile and never a legacy selector list', () => {
@@ -211,8 +208,7 @@ describe('canonical v3 live validation matrix', () => {
       catalog_authority: catalog,
     });
     expect(matrix.catalog_digest).toBe(catalog.digest);
-    expect(matrix.targets.length).toBeGreaterThan(0);
-    expect(matrix.targets.length).toBeLessThanOrEqual(40);
+    expect(matrix.targets).toHaveLength(39);
     expect(
       matrix.targets.every(
         (target) => target.catalog_digest === catalog.digest,
@@ -1766,94 +1762,55 @@ describe('frozen paid protocol (injected, zero-network)', () => {
   });
 
   it.each([
-    ['invalid-schema', 'provider_reported_error', 'provider', 'http_200'],
-    ['missing-content', 'provider_reported_error', 'provider', 'http_200'],
-    ['empty-text', 'provider_reported_error', 'provider', 'http_200'],
-    ['empty-delta', 'provider_reported_error', 'provider', 'http_200'],
-    ['timeout', 'provider_timeout', 'timeout', undefined],
-    ['network', 'provider_network_failed', 'network', undefined],
-    ['quality-only', undefined, undefined, undefined],
+    ['provider', 'provider_reported_error', 'http_200'],
+    ['timeout', 'provider_timeout', undefined],
+    ['network', 'provider_network_failed', undefined],
+    [undefined, undefined, undefined],
   ] as const)(
-    'projects %s through the real adapter, bridge and persisted canonical run offline',
-    async (scenario, code, category, providerCode) => {
-      const restoreNetwork = installOfflineNetworkGuard();
+    'preserves canonical receipt diagnostics independently of any removed adapter (%s)',
+    async (kind, code, providerCode) => {
+      const restore = installOfflineNetworkGuard();
       try {
         const { gate: frozen, matrix } = gate();
         const target = matrix.targets.find(
-          (item) => item.key === 'parallel/chat',
+          (item) => item.key === 'brave-answers/grounded',
         )!;
         const protocol = frozen.approval.targets.find(
           (item) => item.key === target.key,
         )!;
         const privateText = 'private-provider-payload-and-secret';
-        const httpClient = vi.fn(async () => {
-          if (scenario === 'timeout') throw new HttpRequestTimeoutError(1000);
-          if (scenario === 'network') throw new TypeError(privateText);
-          return {
-            status: 200,
-            statusText: 'OK',
-            headers: { authorization: privateText },
-            data: {
-              choices:
-                scenario === 'invalid-schema'
-                  ? []
-                  : scenario === 'missing-content'
-                    ? [{}]
-                    : scenario === 'empty-text'
-                      ? [{ message: { content: '' } }]
-                      : scenario === 'empty-delta'
-                        ? [{ delta: { content: '' } }]
-                        : [{ delta: { content: 'Answer without citations.' } }],
-              error: privateText,
-              diagnostics: { secret: privateText },
-            },
-            durationMs: 1,
-          };
-        });
-        const provider = new ParallelChatProvider({
-          apiKey: 'offline-fixture-key',
-          httpClient: httpClient as HttpClient,
-        });
-        const execute = vi.spyOn(provider, 'execute');
         const raw = await canonicalManifest(
           target,
           frozen.approval.raw_root,
-          `receipt-${scenario}`,
+          `receipt-${kind ?? 'quality'}`,
           'succeeded',
           undefined,
-          provider,
+          {
+            id: target.adapter_id,
+            displayName: 'Fixture',
+            envVar: '',
+            tier: 'ai-grounded',
+            execution: 'inline',
+            execute: async () => ({
+              provider: target.adapter_id,
+              tier: 'ai-grounded',
+              content: kind ? '' : 'Answer without citations.',
+              citations: [],
+              durationMs: 1,
+              ...(kind && {
+                error: privateText,
+                failureDiagnostic: {
+                  kind,
+                  ...(providerCode && { httpStatus: 200 }),
+                },
+              }),
+            }),
+          },
         );
         const manifest = CanonicalRunManifestV3Schema.parse(JSON.parse(raw));
-        const state = manifest.coordination_state;
-        const adapterResult = await execute.mock.results[0]!.value;
-        expect(httpClient).toHaveBeenCalledOnce();
-        expect(state.status).toBe(code ? 'unsuccessful' : 'succeeded');
-        const expected = code
-          ? {
-              code,
-              category,
-              retryable: true,
-              fallback_allowed: true,
-              ...(providerCode && { provider_code: providerCode }),
-            }
-          : undefined;
-        for (const record of [state.slots[0]!, state.attempts[0]!]) {
-          expect(record.status).toBe(code ? 'failed' : 'succeeded');
-          if (expected)
-            expect(record.error).toEqual({
-              ...expected,
-              message: 'The provider returned an error.',
-            });
-          else expect(record.error).toBeUndefined();
-        }
-        if (code)
-          expect(adapterResult.failureDiagnostic).toEqual({
-            kind: category,
-            ...(providerCode && { httpStatus: 200 }),
-          });
         const terminal = {
           status: 'terminal' as const,
-          lifecycle: code ? ('failed' as const) : ('succeeded' as const),
+          lifecycle: kind ? ('failed' as const) : ('succeeded' as const),
           request_id: manifest.request.request_id,
           raw_manifest: raw,
           manifest,
@@ -1865,61 +1822,38 @@ describe('frozen paid protocol (injected, zero-network)', () => {
           terminal,
           'failed',
         );
-        expect(evidence.receipt.lifecycle).toBe('failed');
         expect(evidence.quality).toMatchObject({
           passed: false,
-          content_present: scenario === 'quality-only',
+          content_present: !kind,
           citation_requirement_met: false,
         });
-        if (expected) expect(evidence.receipt.failure).toEqual(expected);
-        else expect(evidence.receipt).not.toHaveProperty('failure');
-        const serialized = JSON.stringify(evidence.receipt);
-        for (const forbidden of [
-          privateText,
-          'offline-fixture-key',
-          'message',
-          'payload',
-          'headers',
-          'diagnostics',
-          'secret',
-          'failureDiagnostic',
-          'The provider returned an error.',
-          adapterResult.error,
-        ].filter(Boolean)) {
-          expect(serialized).not.toContain(forbidden);
-        }
-        writeSanitizedCanonicalReceipt(
-          frozen.approval.receipt_root,
-          `${scenario}.json`,
-          evidence.receipt,
-          target,
+        expect(JSON.stringify(evidence.receipt)).not.toContain(privateText);
+        expect(manifest.coordination_state.status).toBe(
+          kind ? 'unsuccessful' : 'succeeded',
         );
-        expect(
-          JSON.parse(
-            readFileSync(
-              join(frozen.approval.receipt_root, `${scenario}.json`),
-              'utf8',
-            ),
-          ),
-        ).toEqual(evidence.receipt);
-
-        // Removing the slot copy still projects only its exact latest attempt.
-        if (expected) {
-          state.slots[0]!.error = undefined;
+        if (kind) {
+          const expected = {
+            code,
+            category: kind,
+            retryable: true,
+            fallback_allowed: true,
+            ...(providerCode && { provider_code: providerCode }),
+          };
+          expect(evidence.receipt.failure).toEqual(expected);
+          manifest.coordination_state.slots[0]!.error = undefined;
           manifest.terminal_response!.errors = [];
           expect(
             rebuildFrozenValidationEvidence(frozen, target, protocol, terminal)
               .receipt.failure,
           ).toEqual(expected);
-          state.slots[0]!.latest_attempt_id = 'another-attempt';
+          manifest.coordination_state.slots[0]!.latest_attempt_id =
+            'another-attempt';
           expect(
             rebuildFrozenValidationEvidence(frozen, target, protocol, terminal)
               .receipt,
           ).not.toHaveProperty('failure');
         } else {
-          // Even a stale error must not turn quality rejection into a
-          // reported provider execution failure after canonical success.
-          state.slots[0]!.error = {
+          manifest.coordination_state.slots[0]!.error = {
             code: 'provider_timeout',
             category: 'timeout',
             retryable: true,
@@ -1936,8 +1870,22 @@ describe('frozen paid protocol (injected, zero-network)', () => {
             ).receipt,
           ).not.toHaveProperty('failure');
         }
+        writeSanitizedCanonicalReceipt(
+          frozen.approval.receipt_root,
+          'diagnostic.json',
+          evidence.receipt,
+          target,
+        );
+        expect(
+          JSON.parse(
+            readFileSync(
+              join(frozen.approval.receipt_root, 'diagnostic.json'),
+              'utf8',
+            ),
+          ),
+        ).toEqual(evidence.receipt);
       } finally {
-        restoreNetwork();
+        restore();
       }
     },
   );

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -105,7 +105,7 @@ describe('pricing snapshot validation', () => {
       .sort();
 
     expect(priced).toEqual(bound);
-    expect(new Set(priced).size).toBe(40);
+    expect(new Set(priced).size).toBe(39);
     expect(
       BUILTIN_PRICING_SNAPSHOT.definitions.every((entry) =>
         ['complete', 'partial', 'unavailable'].includes(entry.completeness),
@@ -377,10 +377,10 @@ describe('pricing snapshot validation', () => {
 
   it('pins and verifies the reviewed built-in fingerprint', async () => {
     expect(BUILTIN_PRICING_SNAPSHOT.fingerprint).toBe(
-      'sha256:7d0bb6bf5049bb68bdf3c5836fd57eb2f6d73b262911e736f5d36cfb48019d5a',
+      'sha256:87f793e4b1f2fdccb17f36c8fb1fb523ea82949ccae2030cab05f0e244ef986d',
     );
     expect(pricingSnapshotFingerprint(BUILTIN_PRICING_SNAPSHOT)).toBe(
-      'sha256:7d0bb6bf5049bb68bdf3c5836fd57eb2f6d73b262911e736f5d36cfb48019d5a',
+      'sha256:87f793e4b1f2fdccb17f36c8fb1fb523ea82949ccae2030cab05f0e244ef986d',
     );
     expect(
       `sha256:${createHash('sha256')

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -137,7 +137,6 @@ const IMPLEMENTED_MATRIX = [
   ['openai-chat', 'chat'],
   ['gemini-chat', 'chat'],
   ['openrouter', 'chat'],
-  ['parallel', 'chat'],
 ] as const;
 
 const PLANNED_MATRIX: readonly (readonly [string, string])[] = [];
@@ -283,8 +282,7 @@ describe('provider catalog -- declarations', () => {
         key === 'valyu/research' ? true : undefined,
       );
       expect(declaration.features?.json_schema_output).toBe(
-        ['exa/research', 'you-research/research'].includes(key) ||
-          key === 'parallel/chat'
+        ['exa/research', 'you-research/research'].includes(key)
           ? true
           : undefined,
       );
@@ -1910,7 +1908,7 @@ describe('provider catalog -- configured target fidelity', () => {
     expect(configurable.filter((key) => existing.includes(key))).toEqual(
       existing,
     );
-    expect(configurable).toHaveLength(14);
+    expect(configurable).toHaveLength(13);
     expect(configurable).toEqual(
       expect.arrayContaining([
         'gemini-grounded/grounded',

--- a/tests/provider-conformance.test.ts
+++ b/tests/provider-conformance.test.ts
@@ -34,7 +34,7 @@ describe('built-in provider conformance inventory', () => {
     expect(Object.keys(PROVIDER_CONFORMANCE_EVIDENCE).sort()).toEqual(
       implemented,
     );
-    expect(implemented).toHaveLength(40);
+    expect(implemented).toHaveLength(39);
   });
 
   it('keeps every implemented profile bound to one executable strategy', () => {

--- a/tests/provider-descriptors.test.ts
+++ b/tests/provider-descriptors.test.ts
@@ -25,7 +25,7 @@ describe('built-in provider descriptors', () => {
 
   it('drives registry, catalog, credentials, aliases, and metering', async () => {
     await initializeProviders();
-    expect(BUILTIN_PROVIDER_DESCRIPTORS).toHaveLength(38);
+    expect(BUILTIN_PROVIDER_DESCRIPTORS).toHaveLength(37);
     expect(getAllProviders()).toHaveLength(BUILTIN_PROVIDER_DESCRIPTORS.length);
 
     for (const descriptor of BUILTIN_PROVIDER_DESCRIPTORS) {
@@ -94,7 +94,6 @@ describe('built-in provider descriptors', () => {
       'searchapi',
       'serpapi',
       'tavily',
-      'parallel-chat',
       'claude',
       'openai-chat',
       'gemini-chat',
@@ -132,7 +131,6 @@ describe('built-in provider descriptors', () => {
         'gemini-chat',
         'openrouter-chat',
         'parallel-research',
-        'parallel-chat',
         'parallel-search',
         'parallel-turbo',
         'you-answer',
@@ -197,7 +195,6 @@ describe('built-in provider descriptors', () => {
       })),
     ).toEqual([
       { id: 'parallel-research', isOptIn: true, enableByDefault: false },
-      { id: 'parallel-chat', isOptIn: true, enableByDefault: false },
       { id: 'parallel-search', isOptIn: true, enableByDefault: false },
       { id: 'parallel-turbo', isOptIn: true, enableByDefault: false },
     ]);

--- a/tests/public-documentation-drift.test.ts
+++ b/tests/public-documentation-drift.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import * as parallelAdapters from '../src/adapters/parallel.js';
 import { createCliProgram } from '../src/cli-program.js';
 import { ARTIFACTS_VERSION } from '../src/contracts/artifacts/versions.js';
 import {
@@ -7,6 +8,9 @@ import {
   QUICK_WORKFLOW_ROSTER,
   VISIBILITY_WORKFLOW_ROSTER,
 } from '../src/core/builtin-workflows.js';
+import { BUILTIN_PRICING_SNAPSHOT } from '../src/core/pricing-snapshot.js';
+import { BUILTIN_PROFILE_BINDING_SPECS } from '../src/core/profile-bindings.js';
+import { BUILTIN_PROVIDER_DEFINITIONS } from '../src/core/provider-descriptor.js';
 import { BUILTIN_PROVIDER_CATALOG } from '../src/core/provider-profiles.js';
 import { SCRIPT_CUSTOM_PROVIDER_PROTOCOL_VERSION } from '../src/node-entry.js';
 
@@ -43,15 +47,57 @@ const mcpTools = [
 describe('public v2 documentation drift', () => {
   it('keeps the generated catalog facts in README aligned with source', () => {
     expect(BUILTIN_PROVIDER_CATALOG).toHaveLength(33);
-    expect(profileKeys).toHaveLength(40);
+    expect(profileKeys).toHaveLength(39);
     expect(README).toMatch(
-      /\*\*33 built-in providers\*\* and \*\*40 implemented public\s+profiles\*\*/,
+      /\*\*33 built-in providers\*\* and \*\*39 implemented public\s+profiles\*\*/,
+    );
+    expect(SKILL).toContain(
+      '33 built-in providers and 39 implemented profiles',
     );
 
     for (const provider of BUILTIN_PROVIDER_CATALOG) {
       expect(README).toContain(`${provider.provider_id}/`);
     }
     for (const key of profileKeys) expect(README).toContain(`\`${key}\``);
+  });
+
+  it('excludes beta Parallel Chat from every shipping authority and public claim', () => {
+    const retained = ['parallel/research', 'parallel/search', 'parallel/turbo'];
+    expect(
+      profileKeys.filter((key) => key.startsWith('parallel/')).sort(),
+    ).toEqual(retained);
+    for (const definitions of [
+      BUILTIN_PROFILE_BINDING_SPECS,
+      BUILTIN_PRICING_SNAPSHOT.definitions,
+    ]) {
+      expect(
+        definitions
+          .filter(({ provider_id }) => provider_id === 'parallel')
+          .map(({ provider_id, profile_id }) => `${provider_id}/${profile_id}`)
+          .sort(),
+      ).toEqual(retained);
+    }
+    expect(
+      BUILTIN_PROVIDER_DEFINITIONS.filter(({ id }) =>
+        id.startsWith('parallel-'),
+      )
+        .map(({ id }) => id)
+        .sort(),
+    ).toEqual(retained.map((key) => key.replace('/', '-')));
+    expect(Object.keys(parallelAdapters).sort()).toEqual([
+      'ParallelResearchProvider',
+      'ParallelSearchProvider',
+      'ParallelTurboProvider',
+    ]);
+    for (const document of [
+      README,
+      SKILL,
+      PROVIDER_GUIDE,
+      CONTRACTS_GUIDE,
+      read('benchmark/targets.json'),
+    ]) {
+      expect(document).not.toMatch(/parallel[\s/-]+chat|ParallelChatProvider/i);
+    }
   });
 
   it('keeps workflow names and curated rosters aligned with source', () => {

--- a/tests/rc-artifacts.test.ts
+++ b/tests/rc-artifacts.test.ts
@@ -114,7 +114,7 @@ function matrix(overrides: Record<string, unknown> = {}) {
     schema_version: 1,
     catalog_digest: catalogDigest,
     pricing_snapshot_fingerprint: pricingFingerprint,
-    targets: Array.from({ length: 40 }, (_, index) => {
+    targets: Array.from({ length: 39 }, (_, index) => {
       const id = String(index).padStart(2, '0');
       return {
         key: `provider-${id}/profile`,
@@ -376,7 +376,7 @@ describe('release candidate artifact contract', () => {
     }
   });
 
-  it('accepts the real 40-profile matrix and its versioned catalog digest', () => {
+  it('accepts the real 39-profile matrix and its versioned catalog digest', () => {
     const actual = buildCanonicalValidationMatrix();
     expect(actual.catalog_digest).toMatch(/^fnv1a64\.1:[0-9a-f]{16}$/);
     expect(() => assertReleaseMatrixParity(actual, actual)).not.toThrow();
@@ -386,17 +386,17 @@ describe('release candidate artifact contract', () => {
     [
       'duplicate targets',
       (value: any) => (value.targets[1] = value.targets[0]),
-      'exact sorted 40-profile matrix',
+      'exact sorted 39-profile matrix',
     ],
     [
       'unsorted targets',
       (value: any) => value.targets.reverse(),
-      'exact sorted 40-profile matrix',
+      'exact sorted 39-profile matrix',
     ],
     [
       'wrong target count',
       (value: any) => value.targets.pop(),
-      'exact sorted 40-profile matrix',
+      'exact sorted 39-profile matrix',
     ],
     [
       'per-target digest drift',
@@ -433,8 +433,8 @@ describe('release candidate artifact contract', () => {
     ],
     [
       'wrong target count',
-      (value: any) => (value.installed_package.target_count = 39),
-      'must contain exactly 40 targets',
+      (value: any) => (value.installed_package.target_count = 40),
+      'must contain exactly 39 targets',
     ],
     [
       'per-target digest drift',
@@ -533,7 +533,7 @@ describe('release candidate artifact contract', () => {
       },
     });
     expect(commands.map((args) => args[0])).toEqual(['run', 'pack']);
-    expect(frozen.installed_package.target_count).toBe(40);
+    expect(frozen.installed_package.target_count).toBe(39);
     expect(frozen.npm.inventory).toContainEqual(
       expect.objectContaining({ path: 'dist/release-matrix.json' }),
     );
@@ -550,7 +550,7 @@ describe('release candidate artifact contract', () => {
       dependencies: fixtureDependencies,
     });
     expect(verified.candidate).toEqual(fixture.candidate.candidate);
-    expect(verified.installed_package.target_count).toBe(40);
+    expect(verified.installed_package.target_count).toBe(39);
     expect(verified.sea.rows).toHaveLength(5);
     expect(verified.live_validation.record_names).toEqual(
       RELEASE_CANDIDATE_RECORD_NAMES,

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -172,7 +172,7 @@ describe('registry', () => {
   it('initializeProviders registers all active providers', async () => {
     await initializeProviders();
     const all = getAllProviders();
-    expect(all).toHaveLength(38);
+    expect(all).toHaveLength(37);
 
     const ids = all.map((p) => p.id);
     expect(ids).toContain('perplexity-sonar-deep');
@@ -210,7 +210,7 @@ describe('registry', () => {
     expect(ids).toContain('searchapi-bing-copilot');
     expect(ids).toContain('searchapi-google-ai-overview');
     expect(ids).toContain('parallel-research');
-    expect(ids).toContain('parallel-chat');
+    expect(ids).not.toContain('parallel-chat');
     expect(ids).toContain('parallel-search');
     expect(ids).toContain('valyu-search');
     expect(ids).toContain('valyu-research');
@@ -234,7 +234,7 @@ describe('registry', () => {
     ]);
     expect(
       getAllProviders().filter((provider) => provider.execution === 'inline'),
-    ).toHaveLength(32);
+    ).toHaveLength(31);
   });
 
   it('injects credentials into every background built-in', async () => {

--- a/tests/request-deadline-migration.test.ts
+++ b/tests/request-deadline-migration.test.ts
@@ -600,7 +600,6 @@ describe('v1 total request-deadline migration', () => {
   it('matches v2 invocation to the v1 tier deadline class for every built-in adapter', () => {
     const expectedAdapterIds = [
       'parallel-research',
-      'parallel-chat',
       'parallel-search',
       'parallel-turbo',
       'perplexity-sonar-deep',
@@ -643,7 +642,7 @@ describe('v1 total request-deadline migration', () => {
     expect(
       BUILTIN_PROFILE_BINDING_SPECS.map((spec) => spec.adapter_id),
     ).toEqual(expectedAdapterIds);
-    expect(new Set(expectedAdapterIds).size).toBe(40);
+    expect(new Set(expectedAdapterIds).size).toBe(39);
     const declarations = new Map(
       catalogProfileRefs(BUILTIN_PROVIDER_CATALOG).map(
         ({ entry, declaration }) => [

--- a/tests/workers/provider-catalog.test.ts
+++ b/tests/workers/provider-catalog.test.ts
@@ -34,9 +34,9 @@ describe('provider catalog in workerd', () => {
   it('builds the full catalog without Node APIs', () => {
     const catalog = workerCatalog();
     expect(catalog.entries).toHaveLength(33);
-    expect(catalog.resolved).toHaveLength(40);
-    expect(catalog.profiles).toHaveLength(40);
-    expect(catalog.workflow('all').members).toHaveLength(40);
+    expect(catalog.resolved).toHaveLength(39);
+    expect(catalog.profiles).toHaveLength(39);
+    expect(catalog.workflow('all').members).toHaveLength(39);
     expect(catalog.workflow('quick').members).toHaveLength(6);
     expect(catalog.workflow('visibility').members).toHaveLength(9);
     expect(catalog.workflow('deep').members).toHaveLength(8);


### PR DESCRIPTION
## Summary
Remove only `parallel/chat` from Librarium v2 shipping support. Repeated exact-candidate beta Chat calls returned HTTP 200 with incompatible payloads even after the dual-shape parser in #167. No separate supported library-level Chat contract exists, so its constructor, compatibility parser, options, and Chat-only tests are removed rather than left as unsupported API.

PlanMode: #3444 (under #2564).

## Retained unchanged
- `parallel/search`: POST `https://api.parallel.ai/v1/search` with existing configurable Search controls.
- `parallel/turbo`: the same Search endpoint with mode fixed to `turbo`.
- `parallel/research`: POST `/v1/tasks/runs`, GET `/v1/tasks/runs/{run_id}`, and GET `/v1/tasks/runs/{run_id}/result`, all under `https://api.parallel.ai`.

All retained class bodies are byte-identical to the base. Every other profile, pricing definition, and matrix target identity is unchanged. This is offline compatibility evidence, not a live-validation claim.

## Changes and implications
- Remove Chat from catalogs, bindings, descriptors/defaults, model override allowlist, pricing/budget authority, benchmark targets/groups, README/package skill, and changelog shipping claims.
- 33 public providers remain; public profiles, pricing definitions, and canonical release targets change 40 → 39. Legacy registered adapters/benchmark individuals change 38 → 37; executable bindings change 40 → 39.
- Fixed release/installed-package validation gates now require 39 targets. Prior 40-target frozen candidates/approvals do not certify this changed source.
- Add explicit absence/drift assertions across public docs, catalog, bindings, prices, adapter exports, and release matrices. Preserve shared unsafe-citation and canonical receipt/quality-projection coverage using Research and injected fixtures.
- No dependency or package-lock changes.

## Deterministic identity changes
- Catalog: `fnv1a64.1:0b163288dbc76811` → `fnv1a64.1:a5964123b863e933`
- Pricing: `sha256:7d0bb6bf5049bb68bdf3c5836fd57eb2f6d73b262911e736f5d36cfb48019d5a` → `sha256:87f793e4b1f2fdccb17f36c8fb1fb523ea82949ccae2030cab05f0e244ef986d`
- Matrix: `sha256:12a30626994075cd1c1fc2c80eb3bf82f270aa4888c86c85bbbe443cfd150447` → `sha256:ccaa04fd60cc48ccad793a35126e624fc072238323a88d99cc7b0ca2c1f373bc`

## Verification
Commands ran in a secret-free environment (empty environment with explicit PATH, isolated HOME, TMPDIR, CI):
- `npm test`: 119 files, 2239 passed, 7 platform skips.
- `npm run test:integration`: 12 passed.
- `npm run test:workers`: 29 passed.
- `npm run test:packed`, `npm run test:declarations`, `npm run typecheck`, `npm run lint`, `npm run build`: passed.
- `npm run benchmark:ci`: 4 offline cases passed.
- `npm run contracts:generate` plus contract diff: no drift; `git diff --check` passed.
- Offline exact-base comparison and built-package matrix determinism assertions passed.
- Source/package stale-reference sweep: only explicit removal/absence/history mentions remain; no Chat implementation in dist.

Full Linux/Windows/macOS PTY/SEA CI must pass at the unchanged head before the user-authorized merge. No provider calls, certification dispatch, package publication, tag/release/deployment, or settings changes were made.